### PR TITLE
Add sphinx-autobuild to docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ Required Debian Packages:
 * `texlive-fonts-recommended`
 * `texlive-latex-extra`
 
+### sphinx-autobuild
+Required extra setup procedure on Debian:
+```bash
+sudo apt-get install python-pip
+sudo pip install sphinx-autobuild
+```
+
+To build and run a webeserver, inside the `docs` folder:
+* `make livehtml` and browse to http://localhost:8000
+
+
 ## Docker
 
 Using our [Dockerfile](docker/Dockerfile) you create your own Docker container
@@ -34,4 +45,16 @@ $ docker build -t vyos-docu docker
 Linux
 ```bash
 $ docker run --rm -it -v "$(pwd)":/vyos -w /vyos/docs -e GOSU_UID=$(id -u) -e GOSU_GID=$(id -g) vyos-docu make html
+
+# sphinx autobuild
+$ docker run --rm -it -p 8000:8000 -v "$(pwd)":/vyos -w /vyos/docs -e GOSU_UID=$(id -u) -e GOSU_GID=$(id -g) vyos-docu make livehtml
 ```
+
+Windows
+```powershell
+docker run --rm -it -v "$(pwd):/vyos" -w /vyos/docs vyos-docu make html
+
+# sphinx autobuild
+docker run --rm -it -p 8000:8000 -v "$(pwd):/vyos" -w /vyos/docs vyos-docu vyos-docu make livehtml
+```
+

--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ Windows
 docker run --rm -it -v "$(pwd):/vyos" -w /vyos/docs vyos-docu make html
 
 # sphinx autobuild
-docker run --rm -it -p 8000:8000 -v "$(pwd):/vyos" -w /vyos/docs vyos-docu vyos-docu make livehtml
+docker run --rm -it -p 8000:8000 -v "$(pwd):/vyos" -w /vyos/docs vyos-docu make livehtml
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     mc \
     make \
     python3-sphinx \
+    python3-pip \
     python-sphinx-rtd-theme \
     latexmk \
     texlive-latex-recommended \
@@ -24,8 +25,12 @@ RUN apt-get update && apt-get install -y \
     sudo \
     gosu
 
+RUN pip3 install sphinx-autobuild
+
 # Cleanup
 RUN rm -rf /var/lib/apt/lists/*
+
+EXPOSE 8000
 
 # Allow password-less 'sudo' for all users in group 'sudo'
 RUN sed "s/^%sudo.*/%sudo\tALL=(ALL) NOPASSWD:ALL/g" -i /etc/sudoers && \

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,6 +8,10 @@ SPHINXPROJ    = VyOS
 SOURCEDIR     = .
 BUILDDIR      = _build
 
+AUTOHOST      =0.0.0.0
+AUTOPORT      =8000
+AUTOOPTS      =--poll
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
@@ -18,3 +22,7 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+livehtml:
+	sphinx-autobuild --host $(AUTOHOST) --port $(AUTOPORT) $(AUTOOPTS) \
+		"$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
This makes it possible to view the documentation in a web browser as it should be presented.
