### PR TITLE
Remove 'dhcp-server disabled' from quick start

### DIFF
--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -40,7 +40,6 @@ Configure a DHCP Server:
 
 .. code-block:: sh
 
-  set service dhcp-server disabled 'false'
   set service dhcp-server shared-network-name LAN subnet 192.168.0.0/24 default-router '192.168.0.1'
   set service dhcp-server shared-network-name LAN subnet 192.168.0.0/24 dns-server '192.168.0.1'
   set service dhcp-server shared-network-name LAN subnet 192.168.0.0/24 domain-name 'internal-network'


### PR DESCRIPTION
Set up my first VyOS router today and fell into this trap, dhcp-server is now enabled by default when configured and has to be disabled using 'dhcp-server disable' instead.