### PR TITLE
add build-vyos.rst to toctree

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ as a router and firewall platform for cloud deployments.
     :caption: Contributing:
     :includehidden:
 
+    build-vyos.rst
     contributing/index.rst
 
 


### PR DESCRIPTION
fix: add build-vyos in contributing section. That place made the most sense to me.