### PR TITLE
Remove duplicate udp-broadcast-relay from index

### DIFF
--- a/docs/services/index.rst
+++ b/docs/services/index.rst
@@ -23,5 +23,4 @@ This chapter descriptes the available system/network services provided by VyOS.
    snmp
    ssh
    tftp
-   udp-broadcast-relay
    webproxy


### PR DESCRIPTION
Fix duplicate udp-broadcast-relay reference in service index.

This screenshot shows the duplicate entry in the sidebar.

![afbeelding](https://user-images.githubusercontent.com/15987676/58548352-72920700-8209-11e9-91ed-02dde70e7caa.png)
