### PR TITLE
edit traffic policy on ifb interface

### DIFF
--- a/docs/qos.rst
+++ b/docs/qos.rst
@@ -1181,9 +1181,9 @@ Steps to do:
 
   :code:`set interfaces input ifb0 description "WAN Input"`
 
-* Apply the `WAN-OUT` traffic-policy to ifb0 input.
+* Apply the `WAN-IN` traffic-policy to ifb0 input.
 
-  :code:`set interfaces input ifb0 traffic-policy in WAN-IN`
+  :code:`set interfaces input ifb0 traffic-policy out WAN-IN`
 
 * Redirect traffic from eth0 to ifb0
 


### PR DESCRIPTION
"QoS policy inbound is type shaper and is only valid for out" redirected incoming traffic from physical port eth0 to interface ifb0 is represented as outbound traffic from ifb0 interface.

Setup was tested on VyOS 1.2.1