### PR TITLE
T1521 Add sudo to the build instructions

### DIFF
--- a/docs/build-vyos.rst
+++ b/docs/build-vyos.rst
@@ -46,8 +46,8 @@ Running the container and building the ISO
 .. code-block:: sh
 
   user@build:~$ docker run --rm -it --privileged -v $(pwd):/vyos -w /vyos vyos-builder bash
-  root@d4220bb519a0:/vyos# ./configure --architecture amd64 --build-by "your@email.tld" --build-type release --version 1.2.0
-  root@d4220bb519a0:/vyos# make iso
+  vyos_bld@d4220bb519a0:/vyos# ./configure --architecture amd64 --build-by "your@email.tld" --build-type release --version 1.2.0
+  vyos_bld@d4220bb519a0:/vyos# sudo make iso
   
   
 You may use these options to customize you ISO


### PR DESCRIPTION
live-build fails without root and the current docker image automatically
drops to vyos_bld so 'make iso' will fail

https://phabricator.vyos.net/T1521