### PR TITLE
Making these indexes display their TOC

### DIFF
--- a/docs/routing/index.rst
+++ b/docs/routing/index.rst
@@ -8,8 +8,7 @@ policy routing, and dynamic routing using standard protocols (RIP, OSPF, and
 BGP).
 
 .. toctree::
-   :maxdepth: 2
-   :hidden:
+   :maxdepth: 1
 
    arp
    bgp

--- a/docs/services/index.rst
+++ b/docs/services/index.rst
@@ -8,7 +8,7 @@ Services
 This chapter descriptes the available system/network services provided by VyOS.
 
 .. toctree::
-   :hidden:
+   :maxdepth: 1
 
    conntrack
    dhcp


### PR DESCRIPTION
This indexes are short and contain almost no other data.  I think it makes sense to display the table of contents on them, so especially on mobile, they don't feel like such dead ends.

