### PR TITLE
Overhauling and expanding quick start guide

### DIFF
--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -28,15 +28,10 @@ Enable SSH for remote management:
 
   set service ssh port '22'
 
-Configure Source NAT for our "Inside" network.
 
-.. code-block:: sh
 
-  set nat source rule 100 outbound-interface 'eth0'
-  set nat source rule 100 source address '192.168.0.0/24'
-  set nat source rule 100 translation address masquerade
-
-Configure a DHCP Server:
+Configure DHCP Server and DNS
+^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: sh
 
@@ -49,17 +44,27 @@ Configure a DHCP Server:
 
 And a DNS forwarder:
 
-Please note that the `listen-on` statement is deprecated. Please use
-`listen-address` instead!
-
 .. code-block:: sh
 
   set service dns forwarding cache-size '0'
-  set service dns forwarding listen-on 'eth1'
+  set service dns forwarding listen-address '192.168.0.1'
   set service dns forwarding name-server '8.8.8.8'
   set service dns forwarding name-server '8.8.4.4'
 
-Add a set of firewall policies for our "Outside" interface:
+NAT and Firewall
+^^^^^^^^^^^^^^^^
+
+Configure Source NAT for our "Inside" network.
+
+.. code-block:: sh
+
+  set nat source rule 100 outbound-interface 'eth0'
+  set nat source rule 100 source address '192.168.0.0/24'
+  set nat source rule 100 translation address masquerade
+
+Add a set of firewall policies for our "Outside" interface.  
+
+This configuration creates a proper stateful firewall that blocks all traffic:
 
 .. code-block:: sh
 
@@ -75,6 +80,13 @@ Add a set of firewall policies for our "Outside" interface:
   set firewall name OUTSIDE-LOCAL rule 20 icmp type-name 'echo-request'
   set firewall name OUTSIDE-LOCAL rule 20 protocol 'icmp'
   set firewall name OUTSIDE-LOCAL rule 20 state new 'enable'
+
+If you wanted to enable SSH access to your firewall from the the Internet, you could create some additional rules to allow the traffic.
+
+These rules allow SSH traffic and rate limit it to 4 requests per minute. This blocks brute-forcing attempts:
+
+.. code-block:: sh
+
   set firewall name OUTSIDE-LOCAL rule 30 action 'drop'
   set firewall name OUTSIDE-LOCAL rule 30 destination port '22'
   set firewall name OUTSIDE-LOCAL rule 30 protocol 'tcp'
@@ -105,7 +117,7 @@ Commit changes, save the configuration, and exit configuration mode:
   vyos@vyos$
 
 Basic QoS
----------
+^^^^^^^^^
 
 The traffic policy subsystem provides an interface to Linux traffic control
 (tc_).
@@ -162,5 +174,39 @@ interface-level traffic-policy directive:
 VyOS 1.2 (Crux) also supports HFSC (:code:`set traffic-policy shaper-hfsc`)
 
 See further information in the :ref:`qos` chapter.
+
+Security Hardening
+^^^^^^^^^^^^^^^^^^
+
+Especially if you are allowing SSH access from the Internet, there are a few additional configuration steps that should be taken.
+
+Create a user to replace the default `vyos` user:
+
+.. code-block:: sh
+
+  set system login user myvyosuser level admin
+  set system login user myvyosuser authentication plaintext-password mysecurepassword
+
+Set up SSH key based authentication.  For example, on Linux you'd want to run `ssh-keygen -t rsa`.  Then the contents of `id_rsa.pub` would be used below:
+
+.. code-block:: sh
+
+  set system login user myvyosuser authentication public-keys myusername@mydesktop type ssh-rsa
+  set system login user myvyosuser authentication public-keys myusername@mydesktop key contents_of_id_rsa.pub
+
+Or you can use the `loadkey` command. Commit and save.
+
+Finally, try and ssh into the VyOS install as your new user.  
+
+Once you have confirmed that your new user can access your server, without a password, delete the original `vyos` user and disable password authentication into SSH:
+
+.. code-block:: sh
+
+  delete system login user vyos
+  set service ssh disable-password-authentication
+
+Commit and save.
+
+
 
 .. _tc: http://en.wikipedia.org/wiki/Tc_(Linux)


### PR DESCRIPTION
Lots of rewriting here.  

* Enhancing navigation
* Changing the DNS example to use `listen-address` instead of `listen-on`.  Seems a bit redundant to say something is deprecated, then use it in the example. 
* Making the SSH firewall rules a separate section.  Suggesting that everyone should enable SSH on their WAN by default makes things less secure for the kind of person using this guide.
* Adding a new section for security hardening.  Changing the default vyos user, adding SSH key authentication, forcing key-only SSH logins.