### PR TITLE
Azure fixes

### DIFF
--- a/docs/appendix/examples/azure-vpn-bgp.rst
+++ b/docs/appendix/examples/azure-vpn-bgp.rst
@@ -6,6 +6,8 @@ Route-Based Site-to-Site VPN to Azure (BGP over IKEv2/IPsec)
 This guide shows an example of a route-based IKEv2 site-to-site VPN to
 Azure using VTI and BGP for dynamic routing updates.
 
+For redundant / active-active configurations see `Route-Based Redundant Site-to-Site VPN to Azure (BGP over IKEv2/IPsec) <https://docs.vyos.io/en/crux/appendix/examples/azure-vpn-dual-bgp.html>`_
+
 Prerequisites
 ^^^^^^^^^^^^^
 

--- a/docs/appendix/examples/azure-vpn-dual-bgp.rst
+++ b/docs/appendix/examples/azure-vpn-dual-bgp.rst
@@ -10,7 +10,7 @@ and BGP for dynamic routing updates.
 Prerequisites
 ^^^^^^^^^^^^^
 
-- A pair of Azure VNet Gateways deployed in active-passive
+- A pair of Azure VNet Gateways deployed in active-active
   configuration with BGP enabled.
 
 - A local network gateway deployed in Azure representing


### PR DESCRIPTION
This PR contains two small fixes for Azure docs.

1) Linked dual VPN guide from the single VPN guide. I've got reports of users missing the latter (maybe when arriving from search engines?), so hopefully this will help.

2) On the dual VPN guide I mentioned that you need an active-passive gateway pair when what you actually need is an active-active gateway pair.