### PR TITLE
Replaced missing diagram on Zone Policy Example with new SVG

### DIFF
--- a/docs/appendix/examples/zone-policy-diagram.svg
+++ b/docs/appendix/examples/zone-policy-diagram.svg
@@ -1,0 +1,3824 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="zone-policy-diagram.svg"
+   inkscape:version="1.0beta2 (2b71d25, 2019-12-03)"
+   id="svg2498"
+   version="1.1"
+   viewBox="0 0 251.23923 289.35104"
+   height="289.35104mm"
+   width="251.23923mm">
+  <defs
+     id="defs2492">
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient43331"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1748918,0,0,0.1064449,4.4038533,46.098002)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient43333"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1748918,0,0,0.1064449,4.4382717,46.098002)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient43335"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.1748918,0,0,0.1064449,130.79122,46.098002)" />
+    <linearGradient
+       id="linearGradient5123">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop5125" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop5127" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4386">
+      <stop
+         offset="0"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         id="stop4388" />
+      <stop
+         offset="1"
+         style="stop-color:#dfdfdf;stop-opacity:1"
+         id="stop4390" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient25151"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient25153"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient25155"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,28.084322,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="linearGradient25284"
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447" />
+    <linearGradient
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,22.410835,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="linearGradient25287"
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447" />
+    <linearGradient
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,16.737631,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="linearGradient25290"
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447" />
+    <linearGradient
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,11.06438,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="linearGradient25293"
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447" />
+    <linearGradient
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,5.3911289,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="linearGradient25296"
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447" />
+    <linearGradient
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,-0.2821563,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="linearGradient25299"
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447" />
+    <linearGradient
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,30.92086,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5123"
+       id="linearGradient25302"
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447" />
+    <linearGradient
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,25.247609,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5123"
+       id="linearGradient25305"
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447" />
+    <linearGradient
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,19.574225,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5123"
+       id="linearGradient25308"
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447" />
+    <linearGradient
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,13.900977,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5123"
+       id="linearGradient25311"
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447" />
+    <linearGradient
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,8.2277282,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5123"
+       id="linearGradient25314"
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447" />
+    <linearGradient
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,2.5545053,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5123"
+       id="linearGradient25317"
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447" />
+    <linearGradient
+       gradientTransform="matrix(2.7372324,0,0,2.2504624,-5.011313,14.556065)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5123"
+       id="linearGradient25327"
+       y2="26.7868"
+       x2="22.311644"
+       y1="26.887815"
+       x1="27.324621" />
+    <linearGradient
+       gradientTransform="matrix(2.8415131,0,0,2.83799,-5.3545917,0.4858861)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4386"
+       id="linearGradient25335"
+       y2="10.018264"
+       x2="23.233509"
+       y1="34.463955"
+       x1="24.349752" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5048"
+       id="linearGradient460"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient462"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient464"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4386"
+       id="linearGradient466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8415131,0,0,2.83799,-5.3545917,0.4858861)"
+       x1="24.349752"
+       y1="34.463955"
+       x2="23.233509"
+       y2="10.018264" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5123"
+       id="linearGradient468"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7372324,0,0,2.2504624,-5.011313,14.556065)"
+       x1="27.324621"
+       y1="26.887815"
+       x2="22.311644"
+       y2="26.7868" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5123"
+       id="linearGradient470"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7372324,0,0,2.2504624,-5.011313,14.556065)"
+       x1="27.324621"
+       y1="26.887815"
+       x2="22.311644"
+       y2="26.7868" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5123"
+       id="linearGradient472"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,2.5545053,0.8636252)"
+       x1="16.36447"
+       y1="39.918777"
+       x2="16.36447"
+       y2="30.928421" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5123"
+       id="linearGradient474"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,8.2277282,0.8636252)"
+       x1="16.36447"
+       y1="39.918777"
+       x2="16.36447"
+       y2="30.928421" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5123"
+       id="linearGradient476"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,13.900977,0.8636252)"
+       x1="16.36447"
+       y1="39.918777"
+       x2="16.36447"
+       y2="30.928421" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5123"
+       id="linearGradient478"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,19.574225,0.8636252)"
+       x1="16.36447"
+       y1="39.918777"
+       x2="16.36447"
+       y2="30.928421" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5123"
+       id="linearGradient480"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,25.247609,0.8636252)"
+       x1="16.36447"
+       y1="39.918777"
+       x2="16.36447"
+       y2="30.928421" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5123"
+       id="linearGradient482"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,30.92086,0.8636252)"
+       x1="16.36447"
+       y1="39.918777"
+       x2="16.36447"
+       y2="30.928421" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="linearGradient484"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,-0.2821563,0.8636252)"
+       x1="16.36447"
+       y1="39.918777"
+       x2="16.36447"
+       y2="30.928421" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="linearGradient486"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,5.3911289,0.8636252)"
+       x1="16.36447"
+       y1="39.918777"
+       x2="16.36447"
+       y2="30.928421" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="linearGradient488"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,11.06438,0.8636252)"
+       x1="16.36447"
+       y1="39.918777"
+       x2="16.36447"
+       y2="30.928421" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="linearGradient490"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,16.737631,0.8636252)"
+       x1="16.36447"
+       y1="39.918777"
+       x2="16.36447"
+       y2="30.928421" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="linearGradient492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,22.410835,0.8636252)"
+       x1="16.36447"
+       y1="39.918777"
+       x2="16.36447"
+       y2="30.928421" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="linearGradient494"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,28.084322,0.8636252)"
+       x1="16.36447"
+       y1="39.918777"
+       x2="16.36447"
+       y2="30.928421" />
+    <linearGradient
+       id="linearGradient2245">
+      <stop
+         offset="0"
+         style="stop-color:#dde1d9;stop-opacity:1"
+         id="stop2247" />
+      <stop
+         offset="1"
+         style="stop-color:#cacdc6;stop-opacity:1"
+         id="stop2249" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2253">
+      <stop
+         offset="0"
+         style="stop-color:#8f8f8f;stop-opacity:1"
+         id="stop2255" />
+      <stop
+         offset="1"
+         style="stop-color:#494949;stop-opacity:1"
+         id="stop2257" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2667">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop2669" />
+      <stop
+         offset="1"
+         style="stop-color:#fcfcff;stop-opacity:0"
+         id="stop2671" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2701">
+      <stop
+         offset="0"
+         style="stop-color:#585956;stop-opacity:1"
+         id="stop2703" />
+      <stop
+         offset="1"
+         style="stop-color:#bbbeb8;stop-opacity:1"
+         id="stop2705" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2711">
+      <stop
+         offset="0"
+         style="stop-color:#909090;stop-opacity:1"
+         id="stop2713" />
+      <stop
+         offset="1"
+         style="stop-color:#bebebe;stop-opacity:0"
+         id="stop2715" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2635">
+      <stop
+         offset="0"
+         style="stop-color:#f9fff5;stop-opacity:1"
+         id="stop2637" />
+      <stop
+         offset="1"
+         style="stop-color:#f9fff5;stop-opacity:0"
+         id="stop2639" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2752">
+      <stop
+         offset="0"
+         style="stop-color:#9d9d9d;stop-opacity:1"
+         id="stop2754" />
+      <stop
+         offset="1"
+         style="stop-color:#b9b9b9;stop-opacity:1"
+         id="stop2756" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2985">
+      <stop
+         offset="0"
+         style="stop-color:#d8dfd6;stop-opacity:1"
+         id="stop2987" />
+      <stop
+         offset="1"
+         style="stop-color:#d8dfd6;stop-opacity:0"
+         id="stop2989" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3400">
+      <stop
+         offset="0"
+         style="stop-color:#416db4;stop-opacity:1"
+         id="stop3402" />
+      <stop
+         offset="1"
+         style="stop-color:#385e9b;stop-opacity:1"
+         id="stop3404" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="scale(1.925808,0.519262)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient30928"
+       fy="67.501709"
+       fx="12.57571"
+       r="8.7662792"
+       cy="67.501709"
+       cx="12.57571" />
+    <linearGradient
+       gradientTransform="scale(1.492875,0.669848)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2985"
+       id="linearGradient30930"
+       y2="44.878883"
+       x2="-23.8857"
+       y1="49.953003"
+       x1="-23.8857" />
+    <radialGradient
+       gradientTransform="scale(1.925808,0.519262)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient30932"
+       fy="67.501709"
+       fx="12.57571"
+       r="8.7662792"
+       cy="67.501709"
+       cx="12.57571" />
+    <linearGradient
+       gradientTransform="scale(1.816345,0.550556)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2701"
+       id="linearGradient30934"
+       y2="64.892525"
+       x2="12.127711"
+       y1="53.535141"
+       x1="12.206709" />
+    <linearGradient
+       gradientTransform="matrix(1.129863,0,0,0.885063,-1.625,-1.304372)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2245"
+       id="linearGradient30936"
+       y2="33.339787"
+       x2="34.784473"
+       y1="7.2293582"
+       x1="8.6116238" />
+    <linearGradient
+       gradientTransform="scale(1.104397,0.905471)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2253"
+       id="linearGradient30938"
+       y2="31.246054"
+       x2="32.536823"
+       y1="5.3817744"
+       x1="10.390738" />
+    <linearGradient
+       gradientTransform="matrix(0.77934,0,0,0.77934,73.6389,-5.946102)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3400"
+       id="linearGradient30940"
+       y2="15.323487"
+       x2="-57.495499"
+       y1="38.652531"
+       x1="-57.547276" />
+    <linearGradient
+       gradientTransform="matrix(5.705159,0,0,0.17528,1,-0.679373)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="linearGradient30942"
+       y2="162.45061"
+       x2="3.7069974"
+       y1="171.29134"
+       x1="3.7069976" />
+    <linearGradient
+       gradientTransform="matrix(1.108069,0,0,0.902471,1,1)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5123"
+       id="linearGradient30944"
+       y2="55.200756"
+       x2="34.974548"
+       y1="13.004725"
+       x1="17.698339" />
+    <linearGradient
+       gradientTransform="matrix(1.238977,0,0,0.895955,0.590553,-1.331524)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2667"
+       id="linearGradient30946"
+       y2="26.729263"
+       x2="17.199417"
+       y1="1.6537577"
+       x1="11.492236" />
+    <radialGradient
+       gradientTransform="scale(1.925808,0.519262)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient30948"
+       fy="67.501709"
+       fx="12.57571"
+       r="8.7662792"
+       cy="67.501709"
+       cx="12.57571" />
+    <linearGradient
+       gradientTransform="scale(1.129863,0.885063)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2245"
+       id="linearGradient30950"
+       y2="52.536461"
+       x2="18.176752"
+       y1="48.643234"
+       x1="18.316999" />
+    <linearGradient
+       gradientTransform="scale(2.309851,0.432928)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2752"
+       id="linearGradient30954"
+       y2="100.20015"
+       x2="8.1134233"
+       y1="88.509071"
+       x1="8.1134243" />
+    <linearGradient
+       gradientTransform="matrix(2.143634,0,0,0.466498,1,-0.508826)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2635"
+       id="linearGradient30960"
+       y2="74.098007"
+       x2="8.6485014"
+       y1="101.2846"
+       x1="13.62871" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2711"
+       id="linearGradient30962"
+       y2="3.8451097"
+       x2="35.520542"
+       y1="3.9384086"
+       x1="34.300991" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2253"
+       id="linearGradient666"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.104397,0.905471)"
+       x1="10.390738"
+       y1="5.3817744"
+       x2="32.536823"
+       y2="31.246054" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2752"
+       id="linearGradient668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(2.309851,0.432928)"
+       x1="8.1134243"
+       y1="88.509071"
+       x2="8.1134233"
+       y2="100.20015" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2752"
+       id="linearGradient670"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(2.309851,0.432928)"
+       x1="8.1134243"
+       y1="88.509071"
+       x2="8.1134233"
+       y2="100.20015" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2711"
+       id="linearGradient672"
+       gradientUnits="userSpaceOnUse"
+       x1="34.300991"
+       y1="3.9384086"
+       x2="35.520542"
+       y2="3.8451097" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2711"
+       id="linearGradient674"
+       gradientUnits="userSpaceOnUse"
+       x1="34.300991"
+       y1="3.9384086"
+       x2="35.520542"
+       y2="3.8451097" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2711"
+       id="linearGradient676"
+       gradientUnits="userSpaceOnUse"
+       x1="34.300991"
+       y1="3.9384086"
+       x2="35.520542"
+       y2="3.8451097" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2711"
+       id="linearGradient678"
+       gradientUnits="userSpaceOnUse"
+       x1="34.300991"
+       y1="3.9384086"
+       x2="35.520542"
+       y2="3.8451097" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient744"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.925808,0.519262)"
+       cx="12.57571"
+       cy="67.501709"
+       fx="12.57571"
+       fy="67.501709"
+       r="8.7662792" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2985"
+       id="linearGradient746"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.492875,0.669848)"
+       x1="-23.8857"
+       y1="49.953003"
+       x2="-23.8857"
+       y2="44.878883" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient748"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.925808,0.519262)"
+       cx="12.57571"
+       cy="67.501709"
+       fx="12.57571"
+       fy="67.501709"
+       r="8.7662792" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2701"
+       id="linearGradient750"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.816345,0.550556)"
+       x1="12.206709"
+       y1="53.535141"
+       x2="12.127711"
+       y2="64.892525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2245"
+       id="linearGradient752"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.129863,0,0,0.885063,-1.625,-1.304372)"
+       x1="8.6116238"
+       y1="7.2293582"
+       x2="34.784473"
+       y2="33.339787" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2253"
+       id="linearGradient754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.104397,0.905471)"
+       x1="10.390738"
+       y1="5.3817744"
+       x2="32.536823"
+       y2="31.246054" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3400"
+       id="linearGradient756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.77934,0,0,0.77934,73.6389,-5.946102)"
+       x1="-57.547276"
+       y1="38.652531"
+       x2="-57.495499"
+       y2="15.323487" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="linearGradient758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.705159,0,0,0.17528,1,-0.679373)"
+       x1="3.7069976"
+       y1="171.29134"
+       x2="3.7069974"
+       y2="162.45061" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5123"
+       id="linearGradient760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.108069,0,0,0.902471,1,1)"
+       x1="17.698339"
+       y1="13.004725"
+       x2="34.974548"
+       y2="55.200756" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2667"
+       id="linearGradient762"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.238977,0,0,0.895955,0.590553,-1.331524)"
+       x1="11.492236"
+       y1="1.6537577"
+       x2="17.199417"
+       y2="26.729263" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.925808,0.519262)"
+       cx="12.57571"
+       cy="67.501709"
+       fx="12.57571"
+       fy="67.501709"
+       r="8.7662792" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2245"
+       id="linearGradient766"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.129863,0.885063)"
+       x1="18.316999"
+       y1="48.643234"
+       x2="18.176752"
+       y2="52.536461" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2253"
+       id="linearGradient768"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.104397,0.905471)"
+       x1="10.390738"
+       y1="5.3817744"
+       x2="32.536823"
+       y2="31.246054" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2752"
+       id="linearGradient770"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(2.309851,0.432928)"
+       x1="8.1134243"
+       y1="88.509071"
+       x2="8.1134233"
+       y2="100.20015" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2752"
+       id="linearGradient772"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(2.309851,0.432928)"
+       x1="8.1134243"
+       y1="88.509071"
+       x2="8.1134233"
+       y2="100.20015" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2752"
+       id="linearGradient774"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(2.309851,0.432928)"
+       x1="8.1134243"
+       y1="88.509071"
+       x2="8.1134233"
+       y2="100.20015" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2635"
+       id="linearGradient776"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.143634,0,0,0.466498,1,-0.508826)"
+       x1="13.62871"
+       y1="101.2846"
+       x2="8.6485014"
+       y2="74.098007" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2711"
+       id="linearGradient778"
+       gradientUnits="userSpaceOnUse"
+       x1="34.300991"
+       y1="3.9384086"
+       x2="35.520542"
+       y2="3.8451097" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2711"
+       id="linearGradient780"
+       gradientUnits="userSpaceOnUse"
+       x1="34.300991"
+       y1="3.9384086"
+       x2="35.520542"
+       y2="3.8451097" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2711"
+       id="linearGradient782"
+       gradientUnits="userSpaceOnUse"
+       x1="34.300991"
+       y1="3.9384086"
+       x2="35.520542"
+       y2="3.8451097" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2711"
+       id="linearGradient784"
+       gradientUnits="userSpaceOnUse"
+       x1="34.300991"
+       y1="3.9384086"
+       x2="35.520542"
+       y2="3.8451097" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2711"
+       id="linearGradient786"
+       gradientUnits="userSpaceOnUse"
+       x1="34.300991"
+       y1="3.9384086"
+       x2="35.520542"
+       y2="3.8451097" />
+    <radialGradient
+       cx="12.57571"
+       cy="67.501709"
+       r="8.7662792"
+       fx="12.57571"
+       fy="67.501709"
+       id="radialGradient30928-2"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.925808,0.519262)" />
+    <radialGradient
+       cx="12.57571"
+       cy="67.501709"
+       r="8.7662792"
+       fx="12.57571"
+       fy="67.501709"
+       id="radialGradient30932-5"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.925808,0.519262)" />
+    <radialGradient
+       cx="12.57571"
+       cy="67.501709"
+       r="8.7662792"
+       fx="12.57571"
+       fy="67.501709"
+       id="radialGradient30948-1"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.925808,0.519262)" />
+    <linearGradient
+       x1="7.6046205"
+       y1="28.481176"
+       x2="36.183067"
+       y2="40.943935"
+       id="linearGradient19003"
+       xlink:href="#linearGradient4228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.5551094,0,0,2.0216842,3.2352686,19.024775)" />
+    <linearGradient
+       id="linearGradient4228">
+      <stop
+         id="stop4230"
+         style="stop-color:#bbbbbb;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4232"
+         style="stop-color:#9f9f9f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient6717"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient6719"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)" />
+    <radialGradient
+       cx="15.571491"
+       cy="2.958519"
+       r="20.935818"
+       fx="15.571491"
+       fy="2.958519"
+       id="radialGradient19000"
+       xlink:href="#linearGradient4244"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.1758355,1.2018439,-1.7549782,1.798161,-0.646306,22.849447)" />
+    <linearGradient
+       id="linearGradient4244">
+      <stop
+         id="stop4246"
+         style="stop-color:#e4e4e4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4248"
+         style="stop-color:#d3d3d3;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.378357"
+       y1="4.433136"
+       x2="44.0961"
+       y2="47.620636"
+       id="linearGradient18985"
+       xlink:href="#linearGradient4254"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.5646484,0,0,1.8284958,3.0046676,26.372688)" />
+    <linearGradient
+       id="linearGradient4254">
+      <stop
+         id="stop4256"
+         style="stop-color:#616161;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4258"
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient43333-0"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1748918,0,0,0.1064449,4.4382717,46.098002)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient43335-0"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.1748918,0,0,0.1064449,130.79122,46.098002)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient6717-5"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient6719-5"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)" />
+    <radialGradient
+       cx="15.571491"
+       cy="2.958519"
+       r="20.935818"
+       fx="15.571491"
+       fy="2.958519"
+       id="radialGradient19000-8"
+       xlink:href="#linearGradient4244"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.1758355,1.2018439,-1.7549782,1.798161,-0.646306,22.849447)" />
+    <radialGradient
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient25153-1"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient25155-4"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8261"
+       xlink:href="#linearGradient5048"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="10.018264"
+       x2="23.233509"
+       y1="34.463955"
+       x1="24.349752"
+       gradientTransform="matrix(2.8415131,0,0,2.83799,-5.3545917,0.4858861)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8263"
+       xlink:href="#linearGradient4386"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="26.7868"
+       x2="22.311644"
+       y1="26.887815"
+       x1="27.324621"
+       gradientTransform="matrix(2.7372324,0,0,2.2504624,-5.011313,14.556065)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8265"
+       xlink:href="#linearGradient5123"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="26.7868"
+       x2="22.311644"
+       y1="26.887815"
+       x1="27.324621"
+       gradientTransform="matrix(2.7372324,0,0,2.2504624,-5.011313,14.556065)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8267"
+       xlink:href="#linearGradient5123"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,2.5545053,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8269"
+       xlink:href="#linearGradient5123"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,8.2277282,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8271"
+       xlink:href="#linearGradient5123"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,13.900977,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8273"
+       xlink:href="#linearGradient5123"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,19.574225,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8275"
+       xlink:href="#linearGradient5123"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,25.247609,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8277"
+       xlink:href="#linearGradient5123"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,30.92086,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8279"
+       xlink:href="#linearGradient5123"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,-0.2821563,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8281"
+       xlink:href="#linearGradient5060"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,5.3911289,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8283"
+       xlink:href="#linearGradient5060"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,11.06438,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8285"
+       xlink:href="#linearGradient5060"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,16.737631,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8287"
+       xlink:href="#linearGradient5060"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,22.410835,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8289"
+       xlink:href="#linearGradient5060"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="30.928421"
+       x2="16.36447"
+       y1="39.918777"
+       x1="16.36447"
+       gradientTransform="matrix(2.8081147,0,0,2.8081175,28.084322,0.8636252)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8291"
+       xlink:href="#linearGradient5060"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.943935"
+       x2="36.183067"
+       y1="28.481176"
+       x1="7.6046205"
+       gradientTransform="matrix(2.5551094,0,0,2.0216842,3.2352686,19.024775)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8293"
+       xlink:href="#linearGradient4228"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8295"
+       xlink:href="#linearGradient5048"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="47.620636"
+       x2="44.0961"
+       y1="4.433136"
+       x1="12.378357"
+       gradientTransform="matrix(2.5646484,0,0,1.8284958,3.0046676,26.372688)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8297"
+       xlink:href="#linearGradient4254"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.1748918,0,0,0.1064449,4.4038533,46.098002)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8299"
+       xlink:href="#linearGradient5048"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8301"
+       xlink:href="#linearGradient5048"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="44.878883"
+       x2="-23.8857"
+       y1="49.953003"
+       x1="-23.8857"
+       gradientTransform="scale(1.492875,0.669848)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8303"
+       xlink:href="#linearGradient2985"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="64.892525"
+       x2="12.127711"
+       y1="53.535141"
+       x1="12.206709"
+       gradientTransform="scale(1.816345,0.550556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8305"
+       xlink:href="#linearGradient2701"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="33.339787"
+       x2="34.784473"
+       y1="7.2293582"
+       x1="8.6116238"
+       gradientTransform="matrix(1.129863,0,0,0.885063,-1.625,-1.304372)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8307"
+       xlink:href="#linearGradient2245"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="31.246054"
+       x2="32.536823"
+       y1="5.3817744"
+       x1="10.390738"
+       gradientTransform="scale(1.104397,0.905471)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8309"
+       xlink:href="#linearGradient2253"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="15.323487"
+       x2="-57.495499"
+       y1="38.652531"
+       x1="-57.547276"
+       gradientTransform="matrix(0.77934,0,0,0.77934,73.6389,-5.946102)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8311"
+       xlink:href="#linearGradient3400"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="162.45061"
+       x2="3.7069974"
+       y1="171.29134"
+       x1="3.7069976"
+       gradientTransform="matrix(5.705159,0,0,0.17528,1,-0.679373)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8313"
+       xlink:href="#linearGradient5060"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="55.200756"
+       x2="34.974548"
+       y1="13.004725"
+       x1="17.698339"
+       gradientTransform="matrix(1.108069,0,0,0.902471,1,1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8315"
+       xlink:href="#linearGradient5123"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="26.729263"
+       x2="17.199417"
+       y1="1.6537577"
+       x1="11.492236"
+       gradientTransform="matrix(1.238977,0,0,0.895955,0.590553,-1.331524)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8317"
+       xlink:href="#linearGradient2667"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="52.536461"
+       x2="18.176752"
+       y1="48.643234"
+       x1="18.316999"
+       gradientTransform="scale(1.129863,0.885063)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8319"
+       xlink:href="#linearGradient2245"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="31.246054"
+       x2="32.536823"
+       y1="5.3817744"
+       x1="10.390738"
+       gradientTransform="scale(1.104397,0.905471)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8321"
+       xlink:href="#linearGradient2253"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="100.20015"
+       x2="8.1134233"
+       y1="88.509071"
+       x1="8.1134243"
+       gradientTransform="scale(2.309851,0.432928)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8323"
+       xlink:href="#linearGradient2752"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="100.20015"
+       x2="8.1134233"
+       y1="88.509071"
+       x1="8.1134243"
+       gradientTransform="scale(2.309851,0.432928)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8325"
+       xlink:href="#linearGradient2752"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="100.20015"
+       x2="8.1134233"
+       y1="88.509071"
+       x1="8.1134243"
+       gradientTransform="scale(2.309851,0.432928)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8327"
+       xlink:href="#linearGradient2752"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="74.098007"
+       x2="8.6485014"
+       y1="101.2846"
+       x1="13.62871"
+       gradientTransform="matrix(2.143634,0,0,0.466498,1,-0.508826)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8329"
+       xlink:href="#linearGradient2635"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="3.8451097"
+       x2="35.520542"
+       y1="3.9384086"
+       x1="34.300991"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8331"
+       xlink:href="#linearGradient2711"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="3.8451097"
+       x2="35.520542"
+       y1="3.9384086"
+       x1="34.300991"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8333"
+       xlink:href="#linearGradient2711"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="3.8451097"
+       x2="35.520542"
+       y1="3.9384086"
+       x1="34.300991"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8335"
+       xlink:href="#linearGradient2711"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="3.8451097"
+       x2="35.520542"
+       y1="3.9384086"
+       x1="34.300991"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8337"
+       xlink:href="#linearGradient2711"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="3.8451097"
+       x2="35.520542"
+       y1="3.9384086"
+       x1="34.300991"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8339"
+       xlink:href="#linearGradient2711"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="0"
+     inkscape:window-y="23"
+     inkscape:window-x="0"
+     inkscape:window-height="691"
+     inkscape:window-width="1280"
+     showgrid="false"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="481.57572"
+     inkscape:cx="446.53669"
+     inkscape:zoom="0.48517716"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     fit-margin-top="10"
+     fit-margin-left="10"
+     fit-margin-right="10"
+     fit-margin-bottom="10" />
+  <metadata
+     id="metadata2495">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1"
+     transform="translate(-23.397505,2.8368025)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 147.4165,80.535681 147.3426,38.313153"
+       id="path4039"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 95.013066,81.566889 139.06237,77.36068"
+       id="path1928"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 52.568648,124.40574 61.43329,89.728486"
+       id="path1930"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 88.684022,124.04237 78.017527,91.787855"
+       id="path1932"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 220.14289,90.045166 209.48575,128.51191"
+       id="path1969"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 248.253,130.66277 237.09945,92.091649"
+       id="path1971"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 156.26498,77.360679 41.95133,1.867376"
+       id="path1973"
+       inkscape:connector-curvature="0" />
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,130.57932,64.526019)"
+       id="g2597">
+      <g
+         id="layer1-8"
+         style="display:inline" />
+      <g
+         id="layer2"
+         style="display:inline">
+        <g
+           id="g43337">
+          <g
+             transform="translate(-4)"
+             id="g43326">
+            <rect
+               width="84.447739"
+               height="25.850916"
+               x="25.390865"
+               y="85.125816"
+               id="rect35646"
+               style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#linearGradient43331);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 109.8386,85.126705 c 0,0 0,25.849485 0,25.849485 9.00649,0.0487 21.77332,-5.79156 21.77331,-12.926404 0,-7.13485 -10.05056,-12.92308 -21.77331,-12.923081 z"
+               id="path35648"
+               style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient43333);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 25.390865,85.126705 c 0,0 0,25.849485 0,25.849485 -9.006495,0.0487 -21.7733159,-5.79156 -21.7733159,-12.926404 0,-7.13485 10.0505669,-12.92308 21.7733159,-12.923081 z"
+               id="path35650"
+               style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient43335);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+          </g>
+          <rect
+             width="101.91125"
+             height="74.962074"
+             x="13.40662"
+             y="21.487539"
+             id="rect36307"
+             style="fill:#fd3301;fill-opacity:1;fill-rule:nonzero;stroke:#790009;stroke-width:3.86854;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="M 15.693772,73.333616 113.26837,73.023855"
+             id="path39222"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="M 15.693772,85.712947 113.26837,85.403186"
+             id="path39224"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="M 32.335638,85.446081 32.29634,73.06694"
+             id="path39226"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="M 63.91032,85.446078 63.871021,73.06694"
+             id="path41166"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="M 97.353375,85.446078 97.314076,73.06694"
+             id="path41168"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <g
+             transform="matrix(0.7737082,0,0,0.7737082,74.155761,0.354917)"
+             id="g41177"
+             style="display:inline;stroke-width:1.25;stroke-miterlimit:4;stroke-dasharray:none">
+            <path
+               inkscape:connector-curvature="0"
+               d="M -75.91453,62.092636 50.198384,61.692277"
+               id="path41179"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M -75.91453,78.092636 50.198383,77.692277"
+               id="path41181"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m -54.405301,77.747717 -0.05079,-15.999753"
+               id="path41183"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m -13.595754,77.747714 -0.05079,-15.99975"
+               id="path41185"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 29.628623,77.747714 29.57783,61.747964"
+               id="path41187"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          </g>
+          <g
+             transform="matrix(0.7737082,0,0,0.7737082,74.155762,-24.423161)"
+             id="g41189"
+             style="display:inline;stroke-width:1.25;stroke-miterlimit:4;stroke-dasharray:none">
+            <path
+               inkscape:connector-curvature="0"
+               d="M -75.91453,62.092636 50.198384,61.692277"
+               id="path41191"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M -75.91453,78.092636 50.198383,77.692277"
+               id="path41193"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m -54.405301,77.747717 -0.05079,-15.999753"
+               id="path41195"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m -13.595754,77.747714 -0.05079,-15.99975"
+               id="path41197"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 29.628623,77.747714 29.57783,61.747964"
+               id="path41199"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          </g>
+          <path
+             inkscape:connector-curvature="0"
+             d="m 48.119461,73.521681 -0.0393,-12.379137"
+             id="path41206"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m 81.883371,72.902161 -0.0393,-12.379138"
+             id="path41208"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m 81.883371,48.121307 -0.0393,-12.379138"
+             id="path41210"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m 48.738983,48.740834 -0.0393,-12.379137"
+             id="path41212"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m 48.113809,94.508525 -0.02799,-8.81801"
+             id="path41214"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m 81.877718,94.663407 -0.02799,-8.818014"
+             id="path41216"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+      </g>
+    </g>
+    <g
+       id="g398"
+       transform="matrix(0.26458333,0,0,0.26458333,30.352728,113.65672)">
+      <g
+         style="display:inline"
+         id="layer1-83" />
+      <g
+         style="display:inline"
+         id="layer2-90">
+        <g
+           style="display:inline"
+           id="g6707"
+           transform="matrix(0.04030136,0,0,0.05919351,98.269348,107.74796)">
+          <rect
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#linearGradient25151);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+             id="rect6709"
+             y="-150.69685"
+             x="-1559.2523"
+             height="478.35718"
+             width="1339.6335" />
+          <path
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient25153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+             id="path6711"
+             d="m -219.61876,-150.68038 c 0,0 0,478.33079 0,478.33079 142.874166,0.90045 345.40022,-107.16966 345.40014,-239.196175 0,-132.026537 -159.436816,-239.134595 -345.40014,-239.134615 z"
+             inkscape:connector-curvature="0" />
+          <path
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient25155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+             id="path6713"
+             d="m -1559.2523,-150.68038 c 0,0 0,478.33079 0,478.33079 -142.8742,0.90045 -345.4002,-107.16966 -345.4002,-239.196175 0,-132.026537 159.4368,-239.134595 345.4002,-239.134615 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           style="fill:url(#linearGradient25335);fill-opacity:1;fill-rule:evenodd;stroke:#5e5e5e;stroke-width:2.83663px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           id="path3626"
+           d="m 30.069752,22.03729 v 95.17786 H 92.475495 V 21.46393 L 80.994049,9.423358 H 40.977128 Z"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:#ffffff;fill-opacity:0.655367;fill-rule:evenodd;stroke:none"
+           id="path5791"
+           d="M 41.556086,10.841671 31.488067,25.024802 h 59.56912 l -10.90702,-13.76598 z"
+           inkscape:connector-curvature="0" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.348571;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="rect4553"
+           y="30.698046"
+           x="39.997936"
+           height="11.346502"
+           width="45.386024" />
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path4394"
+           d="M 32.906375,23.771924 V 114.3785 H 89.638911 V 23.248654 L 79.132886,12.260001 H 42.887099 Z"
+           inkscape:connector-curvature="0" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.525714;fill:url(#linearGradient25327);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient25327);stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="rect4408"
+           y="67.574181"
+           x="54.181065"
+           height="11.346499"
+           width="31.202894" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#acacac;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="rect4398"
+           y="66.155869"
+           x="52.762733"
+           height="11.346502"
+           width="31.202871" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.348571;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="rect4551"
+           y="47.7178"
+           x="39.997952"
+           height="11.346502"
+           width="45.386024" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#acacac;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="rect4430"
+           y="46.299488"
+           x="38.579624"
+           height="11.346502"
+           width="45.386032" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#acacac;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="rect4436"
+           y="29.279736"
+           x="38.579647"
+           height="11.346502"
+           width="45.386032" />
+        <path
+           style="display:inline;overflow:visible;visibility:visible;fill:#d40000;fill-opacity:1;fill-rule:evenodd;stroke:#979797;stroke-width:1.44773;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="path4396"
+           transform="matrix(1.9593699,0,0,1.9593562,-86.509754,21.850696)"
+           d="m 68.185294,26.231213 a 2.171828,2.171828 0 1 1 -4.343656,0 2.171828,2.171828 0 1 1 4.343656,0 z"
+           inkscape:connector-curvature="0" />
+        <path
+           style="display:inline;overflow:visible;visibility:visible;fill:#f44800;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="path4445"
+           transform="matrix(2.5342538,0,0,2.5342343,0.4673221,7.5389146)"
+           d="m 16.667518,25.574614 a 0.5050765,0.5050765 0 1 1 -1.010153,0 0.5050765,0.5050765 0 1 1 1.010153,0 z"
+           inkscape:connector-curvature="0" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient25317);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4457"
+           y="84.593979"
+           x="48.507816"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient25314);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4461"
+           y="84.593979"
+           x="54.181038"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient25311);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4465"
+           y="84.593979"
+           x="59.854286"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient25308);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4469"
+           y="84.593979"
+           x="65.527534"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient25305);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4473"
+           y="84.593979"
+           x="71.200821"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.542857;fill:url(#linearGradient25302);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4477"
+           y="84.593979"
+           x="76.874069"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.16;fill:url(#linearGradient25299);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4481"
+           y="84.593979"
+           x="45.671154"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.291429;fill:url(#linearGradient25296);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4483"
+           y="84.593979"
+           x="51.34444"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.291429;fill:url(#linearGradient25293);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4485"
+           y="84.593979"
+           x="57.017693"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.291429;fill:url(#linearGradient25290);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4487"
+           y="84.593979"
+           x="62.690945"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.291429;fill:url(#linearGradient25287);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4489"
+           y="84.593979"
+           x="68.364159"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.228571;fill:url(#linearGradient25284);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4491"
+           y="84.593979"
+           x="74.037407"
+           height="28.36627"
+           width="2.8366244" />
+      </g>
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,195.15035,113.65672)"
+       id="g458">
+      <g
+         id="g400"
+         style="display:inline" />
+      <g
+         id="g456"
+         style="display:inline">
+        <g
+           transform="matrix(0.04030136,0,0,0.05919351,98.269348,107.74796)"
+           id="g408"
+           style="display:inline">
+          <rect
+             width="1339.6335"
+             height="478.35718"
+             x="-1559.2523"
+             y="-150.69685"
+             id="rect402"
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#linearGradient460);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m -219.61876,-150.68038 c 0,0 0,478.33079 0,478.33079 142.874166,0.90045 345.40022,-107.16966 345.40014,-239.196175 0,-132.026537 -159.436816,-239.134595 -345.40014,-239.134615 z"
+             id="path404"
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient462);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m -1559.2523,-150.68038 c 0,0 0,478.33079 0,478.33079 -142.8742,0.90045 -345.4002,-107.16966 -345.4002,-239.196175 0,-132.026537 159.4368,-239.134595 345.4002,-239.134615 z"
+             id="path406"
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient464);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+        </g>
+        <path
+           inkscape:connector-curvature="0"
+           d="m 30.069752,22.03729 v 95.17786 H 92.475495 V 21.46393 L 80.994049,9.423358 H 40.977128 Z"
+           id="path410"
+           style="fill:url(#linearGradient466);fill-opacity:1;fill-rule:evenodd;stroke:#5e5e5e;stroke-width:2.83663px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 41.556086,10.841671 31.488067,25.024802 h 59.56912 l -10.90702,-13.76598 z"
+           id="path412"
+           style="fill:#ffffff;fill-opacity:0.655367;fill-rule:evenodd;stroke:none" />
+        <rect
+           width="45.386024"
+           height="11.346502"
+           x="39.997936"
+           y="30.698046"
+           id="rect414"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.348571;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 32.906375,23.771924 V 114.3785 H 89.638911 V 23.248654 L 79.132886,12.260001 H 42.887099 Z"
+           id="path416"
+           style="fill:none;stroke:#ffffff;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           width="31.202894"
+           height="11.346499"
+           x="54.181065"
+           y="67.574181"
+           id="rect418"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.525714;fill:url(#linearGradient468);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient470);stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+        <rect
+           width="31.202871"
+           height="11.346502"
+           x="52.762733"
+           y="66.155869"
+           id="rect420"
+           style="display:inline;overflow:visible;visibility:visible;fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#acacac;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+        <rect
+           width="45.386024"
+           height="11.346502"
+           x="39.997952"
+           y="47.7178"
+           id="rect422"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.348571;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+        <rect
+           width="45.386032"
+           height="11.346502"
+           x="38.579624"
+           y="46.299488"
+           id="rect424"
+           style="display:inline;overflow:visible;visibility:visible;fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#acacac;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+        <rect
+           width="45.386032"
+           height="11.346502"
+           x="38.579647"
+           y="29.279736"
+           id="rect426"
+           style="display:inline;overflow:visible;visibility:visible;fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#acacac;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 68.185294,26.231213 a 2.171828,2.171828 0 1 1 -4.343656,0 2.171828,2.171828 0 1 1 4.343656,0 z"
+           transform="matrix(1.9593699,0,0,1.9593562,-86.509754,21.850696)"
+           id="path428"
+           style="display:inline;overflow:visible;visibility:visible;fill:#d40000;fill-opacity:1;fill-rule:evenodd;stroke:#979797;stroke-width:1.44773;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 16.667518,25.574614 a 0.5050765,0.5050765 0 1 1 -1.010153,0 0.5050765,0.5050765 0 1 1 1.010153,0 z"
+           transform="matrix(2.5342538,0,0,2.5342343,0.4673221,7.5389146)"
+           id="path430"
+           style="display:inline;overflow:visible;visibility:visible;fill:#f44800;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           width="2.8366244"
+           height="28.36627"
+           x="48.507816"
+           y="84.593979"
+           id="rect432"
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient472);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           width="2.8366244"
+           height="28.36627"
+           x="54.181038"
+           y="84.593979"
+           id="rect434"
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient474);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           width="2.8366244"
+           height="28.36627"
+           x="59.854286"
+           y="84.593979"
+           id="rect436"
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient476);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           width="2.8366244"
+           height="28.36627"
+           x="65.527534"
+           y="84.593979"
+           id="rect438"
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient478);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           width="2.8366244"
+           height="28.36627"
+           x="71.200821"
+           y="84.593979"
+           id="rect440"
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient480);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           width="2.8366244"
+           height="28.36627"
+           x="76.874069"
+           y="84.593979"
+           id="rect442"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.542857;fill:url(#linearGradient482);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           width="2.8366244"
+           height="28.36627"
+           x="45.671154"
+           y="84.593979"
+           id="rect444"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.16;fill:url(#linearGradient484);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           width="2.8366244"
+           height="28.36627"
+           x="51.34444"
+           y="84.593979"
+           id="rect446"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.291429;fill:url(#linearGradient486);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           width="2.8366244"
+           height="28.36627"
+           x="57.017693"
+           y="84.593979"
+           id="rect448"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.291429;fill:url(#linearGradient488);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           width="2.8366244"
+           height="28.36627"
+           x="62.690945"
+           y="84.593979"
+           id="rect450"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.291429;fill:url(#linearGradient490);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           width="2.8366244"
+           height="28.36627"
+           x="68.364159"
+           y="84.593979"
+           id="rect452"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.291429;fill:url(#linearGradient492);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           width="2.8366244"
+           height="28.36627"
+           x="74.037407"
+           y="84.593979"
+           id="rect454"
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.228571;fill:url(#linearGradient494);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+      </g>
+    </g>
+    <g
+       id="g664"
+       transform="matrix(0.26458333,0,0,0.26458333,74.830932,114.69494)">
+      <g
+         style="display:inline"
+         id="layer1-5" />
+      <g
+         style="display:inline"
+         id="layer2-2">
+        <g
+           id="g2860"
+           transform="matrix(2.523753,0,0,2.523753,-14.365049,36.911359)">
+          <g
+             id="g3880"
+             transform="translate(7.165836,-12.94079)">
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient30928);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+               id="path2862"
+               transform="matrix(1,0,0,1.368932,-1.978553,-13.61713)"
+               d="m 41.10058,35.051105 c 0.0024,2.514454 -7.556723,4.553162 -16.882173,4.553162 -9.325451,0 -16.8845543,-2.038708 -16.8821739,-4.553162 -0.00238,-2.514454 7.5567229,-4.553162 16.8821739,-4.553162 9.32545,0 16.884553,2.038708 16.882173,4.553162 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:#adb0aa;fill-opacity:1;fill-rule:evenodd;stroke:#4b4d4a;stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+               id="path2864"
+               transform="translate(57.53339,3.203427)"
+               d="m -26.263968,29.716238 c 0.0011,2.176096 -4.205267,3.940408 -9.394418,3.940408 -5.189152,0 -9.39549,-1.764312 -9.394419,-3.940408 -0.0011,-2.176096 4.205267,-3.940408 9.394419,-3.940408 5.189151,0 9.395489,1.764312 9.394418,3.940408 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#7b7f7a;stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+               id="path2866"
+               transform="matrix(0.940273,0,0,0.940273,55.40361,4.271194)"
+               d="m -26.263968,29.716238 c 0.0011,2.176096 -4.205267,3.940408 -9.394418,3.940408 -5.189152,0 -9.39549,-1.764312 -9.394419,-3.940408 -0.0011,-2.176096 4.205267,-3.940408 9.394419,-3.940408 5.189151,0 9.395489,1.764312 9.394418,3.940408 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient30930);stroke-width:0.873372;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+               id="path2868"
+               transform="matrix(0.940273,0,0,0.940273,55.40361,3.521194)"
+               d="m -26.263968,29.716238 c 0.0011,2.176096 -4.205267,3.940408 -9.394418,3.940408 -5.189152,0 -9.39549,-1.764312 -9.394419,-3.940408 -0.0011,-2.176096 4.205267,-3.940408 9.394419,-3.940408 5.189151,0 9.395489,1.764312 9.394418,3.940408 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="fill:#d0d0d0;fill-opacity:1;fill-rule:evenodd;stroke:#979797;stroke-width:0.513255;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+               id="path2870"
+               d="m 25.6875,28.766243 -0.0625,1 c 0,0 4.324108,3.599166 9,4.202507 2.337946,0.30167 4.753675,0.702412 6.75,1.1875 1.996325,0.485088 3.588356,1.119606 4.125,1.65625 0.310411,0.310411 0.451063,0.573639 0.5,0.78125 0.04894,0.207611 0.03822,0.354815 -0.09375,0.5625 -0.263933,0.41537 -1.079857,0.967652 -2.46875,1.40625 C 40.659715,40.439695 35.717076,41 28.875,41 v 1 c 6.895998,0 11.863665,-0.527671 14.84375,-1.46875 1.490042,-0.47054 2.524942,-1.015687 3.03125,-1.8125 C 47.003154,38.320344 47.107321,37.830301 47,37.375 46.892679,36.919699 46.615445,36.490445 46.21875,36.09375 45.34118,35.21618 43.681912,34.68731 41.625,34.1875 39.568088,33.68769 37.109264,33.273171 34.75,32.96875 30.031473,32.359908 25.6875,28.766243 25.6875,28.766243 Z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient30932);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+               id="path2872"
+               transform="matrix(1,0,0,1.368932,-1.978553,-19.02126)"
+               d="m 41.10058,35.051105 c 0.0024,2.514454 -7.556723,4.553162 -16.882173,4.553162 -9.325451,0 -16.8845543,-2.038708 -16.8821739,-4.553162 -0.00238,-2.514454 7.5567229,-4.553162 16.8821739,-4.553162 9.32545,0 16.884553,2.038708 16.882173,4.553162 z"
+               inkscape:connector-curvature="0" />
+            <rect
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient30934);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.608729;marker:none"
+               id="rect2874"
+               y="30.703611"
+               x="17.472397"
+               height="2.7400389"
+               width="9.0396729" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient30936);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient666);stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+               id="path2876"
+               d="M 7.0809024,1.6956221 H 36.669097 c 0.911342,0 1.624147,0.5834818 1.666752,1.401587 l 1.332044,25.5781139 c 0.05821,1.117735 -0.901056,2.020305 -2.020305,2.020305 H 6.102412 c -1.1192491,0 -2.078514,-0.90257 -2.0203052,-2.020305 L 5.4141506,3.0972091 c 0.040284,-0.7735346 0.5475027,-1.401587 1.6667518,-1.401587 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient30940);fill-opacity:1;fill-rule:evenodd;stroke:#4263a8;stroke-width:0.641569;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+               id="path2878"
+               d="M 8.4105348,4.3058272 7.1683398,26.351144 H 34.818729 L 33.483712,4.3992558 Z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="fill:none;stroke:url(#linearGradient30942);stroke-width:1.27824;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.248408"
+               id="path2880"
+               d="M 6.1774331,28.735789 H 37.60591"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient30944);stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:0.700637;marker:none"
+               id="path2882"
+               d="M 6.9145985,2.7063396 36.760101,2.6685383 c 0.283697,-3.593e-4 0.559302,0.2372498 0.582105,0.6525438 L 38.704098,28.12433 c 0.05804,1.057031 -0.539749,1.785871 -1.598371,1.785871 H 6.5817583 c -1.0586228,0 -1.5930144,-0.728791 -1.5358714,-1.785871 L 6.3699773,3.6301633 C 6.4086732,2.9143326 6.5363627,2.7068187 6.9145985,2.7063396 Z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="opacity:0.531429;fill:url(#linearGradient30946);fill-opacity:1;fill-rule:evenodd;stroke:none"
+               id="path2884"
+               d="M 8.7115364,4.7463626 7.9090069,22.616693 C 18.953645,20.216063 19.33047,12.124494 33.063039,9.4699426 L 32.901567,4.8124267 Z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient30948);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+               id="path2886"
+               transform="matrix(1.264398,0,0,1.291262,-6.216332,-4.000423)"
+               d="m 41.10058,35.051105 c 0.0024,2.514454 -7.556723,4.553162 -16.882173,4.553162 -9.325451,0 -16.8845543,-2.038708 -16.8821739,-4.553162 -0.00238,-2.514454 7.5567229,-4.553162 16.8821739,-4.553162 9.32545,0 16.884553,2.038708 16.882173,4.553162 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient30950);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient30938);stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+               id="path2888"
+               d="M 6.4621839,36.817452 H 37.46459 c 1.119249,0 0.977355,0.271438 1.092227,0.612846 l 2.834646,8.42481 c 0.114872,0.341409 0.02702,0.612846 -1.092227,0.612846 H 3.6275382 c -1.1192491,0 -1.2070995,-0.271437 -1.0922275,-0.612846 l 2.8346457,-8.42481 c 0.114872,-0.341409 -0.027022,-0.612846 1.0922275,-0.612846 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="fill:#7a7d77;fill-opacity:1;fill-rule:evenodd;stroke:none"
+               id="path2890"
+               d="M 6.3916892,38.829113 4.6239223,43.955638 H 10.104 l 0.53033,-2.032932 h 14.849242 l 0.549679,2.075114 h 6.167835 l -1.679378,-5.168707 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="fill:#777874;fill-opacity:1;fill-rule:evenodd;stroke:none"
+               id="path2892"
+               d="m 11.076272,42.27626 -0.441942,1.679379 h 14.760854 l -0.441942,-1.767767 -13.87697,0.08839 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:#777a75;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.25pt;marker:none"
+               id="path2894"
+               d="m 37.592776,38.829114 1.679379,5.038136 -5.480078,-0.08839 -1.502602,-4.861359 5.303301,-0.08839 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient668);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.25pt;marker:none"
+               id="path2896"
+               d="m 37.592776,38.298786 1.679379,5.038136 -5.480078,-0.08839 -1.502602,-4.861359 5.303301,-0.08839 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="fill:url(#linearGradient670);fill-opacity:1;fill-rule:evenodd;stroke:none"
+               id="path2898"
+               d="M 6.3916892,38.210397 4.6239223,43.336922 H 10.104 l 0.53033,-2.032932 h 14.849242 l 0.549679,2.075114 h 6.167835 l -1.679378,-5.168707 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient30954);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.25pt;marker:none"
+               id="path2900"
+               d="m 11.076272,41.745932 -0.441942,1.679379 h 14.760854 l -0.441942,-1.767767 -13.87697,0.08839 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient30960);stroke-width:0.641569;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+               id="path2902"
+               d="M 6.1278189,37.578116 H 37.953634 l 2.637179,8.092563 H 3.3297429 Z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient672);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none"
+               id="path2904"
+               transform="matrix(1.331237,0,0,0.658449,-10.41933,2.853866)"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient674);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none"
+               id="path2906"
+               transform="matrix(1.331237,0,0,0.658449,-10.30573,4.959651)"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient676);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none"
+               id="path2908"
+               transform="matrix(1.331237,0,0,0.658449,-10.19213,6.959651)"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient678);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none"
+               id="path2910"
+               transform="matrix(1.331237,0,0,0.658449,-10.07853,8.959651)"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient30962);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none"
+               id="path2912"
+               transform="matrix(1.331237,0,0,0.658449,-9.96493,10.95965)"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:0.902903px;font-family:'Bitstream Vera Sans';writing-mode:lr-tb;text-anchor:start;fill:#4a4a4a;fill-opacity:1;stroke:none"
+               id="path2914"
+               d="m 20,27.317666 h 0.281716 c 0.08376,1e-6 0.147985,0.01866 0.19266,0.05599 0.04497,0.03703 0.06745,0.08994 0.06745,0.158714 -1e-6,0.06907 -0.02248,0.122268 -0.06745,0.159595 -0.04467,0.03703 -0.108895,0.05555 -0.19266,0.05555 h -0.111981 v 0.22837 H 20 v -0.658219 m 0.169735,0.123003 v 0.183843 h 0.0939 c 0.03292,0 0.05834,-0.0079 0.07627,-0.02381 0.01793,-0.01617 0.02689,-0.03894 0.02689,-0.06834 0,-0.02939 -0.009,-0.05202 -0.02689,-0.06789 -0.01793,-0.01587 -0.04335,-0.02381 -0.07627,-0.02381 h -0.0939 m 0.792244,-0.0119 c -0.05173,1e-6 -0.09185,0.01911 -0.120358,0.05731 -0.02851,0.03821 -0.04276,0.092 -0.04276,0.161359 0,0.06907 0.01425,0.122709 0.04276,0.160918 0.02851,0.03821 0.06863,0.05731 0.120358,0.05731 0.05202,0 0.09229,-0.0191 0.120799,-0.05731 0.02851,-0.03821 0.04276,-0.09185 0.04276,-0.160918 -10e-7,-0.06936 -0.01425,-0.123149 -0.04276,-0.161359 -0.02851,-0.03821 -0.06878,-0.05731 -0.120799,-0.05731 m 0,-0.123003 c 0.105808,1e-6 0.188692,0.03027 0.248651,0.09082 0.05996,0.06055 0.08994,0.144165 0.08994,0.250855 -1e-6,0.106397 -0.02998,0.189868 -0.08994,0.250414 -0.05996,0.06055 -0.142843,0.09082 -0.248651,0.09082 -0.105515,0 -0.188399,-0.03027 -0.248651,-0.09082 -0.05996,-0.06055 -0.08994,-0.144017 -0.08994,-0.250414 0,-0.10669 0.02998,-0.190309 0.08994,-0.250855 0.06025,-0.06055 0.143136,-0.09082 0.248651,-0.09082 m 0.466441,0.0119 h 0.189574 l 0.239393,0.451451 v -0.451451 h 0.160918 v 0.658219 H 21.82873 l -0.239392,-0.451451 v 0.451451 H 21.42842 v -0.658219 m 0.663069,0 h 0.185606 l 0.149896,0.234543 0.149896,-0.234543 h 0.186048 l -0.250856,0.380912 v 0.277307 h -0.169735 v -0.277307 l -0.250855,-0.380912"
+               inkscape:connector-curvature="0" />
+          </g>
+        </g>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,232.06903,114.69494)"
+       id="g742">
+      <g
+         id="g680"
+         style="display:inline" />
+      <g
+         id="g740"
+         style="display:inline">
+        <g
+           transform="matrix(2.523753,0,0,2.523753,-14.365049,36.911359)"
+           id="g738">
+          <g
+             transform="translate(7.165836,-12.94079)"
+             id="g736">
+            <path
+               inkscape:connector-curvature="0"
+               d="m 41.10058,35.051105 c 0.0024,2.514454 -7.556723,4.553162 -16.882173,4.553162 -9.325451,0 -16.8845543,-2.038708 -16.8821739,-4.553162 -0.00238,-2.514454 7.5567229,-4.553162 16.8821739,-4.553162 9.32545,0 16.884553,2.038708 16.882173,4.553162 z"
+               transform="matrix(1,0,0,1.368932,-1.978553,-13.61713)"
+               id="path682"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient744);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m -26.263968,29.716238 c 0.0011,2.176096 -4.205267,3.940408 -9.394418,3.940408 -5.189152,0 -9.39549,-1.764312 -9.394419,-3.940408 -0.0011,-2.176096 4.205267,-3.940408 9.394419,-3.940408 5.189151,0 9.395489,1.764312 9.394418,3.940408 z"
+               transform="translate(57.53339,3.203427)"
+               id="path684"
+               style="display:inline;overflow:visible;visibility:visible;fill:#adb0aa;fill-opacity:1;fill-rule:evenodd;stroke:#4b4d4a;stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m -26.263968,29.716238 c 0.0011,2.176096 -4.205267,3.940408 -9.394418,3.940408 -5.189152,0 -9.39549,-1.764312 -9.394419,-3.940408 -0.0011,-2.176096 4.205267,-3.940408 9.394419,-3.940408 5.189151,0 9.395489,1.764312 9.394418,3.940408 z"
+               transform="matrix(0.940273,0,0,0.940273,55.40361,4.271194)"
+               id="path686"
+               style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#7b7f7a;stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m -26.263968,29.716238 c 0.0011,2.176096 -4.205267,3.940408 -9.394418,3.940408 -5.189152,0 -9.39549,-1.764312 -9.394419,-3.940408 -0.0011,-2.176096 4.205267,-3.940408 9.394419,-3.940408 5.189151,0 9.395489,1.764312 9.394418,3.940408 z"
+               transform="matrix(0.940273,0,0,0.940273,55.40361,3.521194)"
+               id="path688"
+               style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient746);stroke-width:0.873372;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 25.6875,28.766243 -0.0625,1 c 0,0 4.324108,3.599166 9,4.202507 2.337946,0.30167 4.753675,0.702412 6.75,1.1875 1.996325,0.485088 3.588356,1.119606 4.125,1.65625 0.310411,0.310411 0.451063,0.573639 0.5,0.78125 0.04894,0.207611 0.03822,0.354815 -0.09375,0.5625 -0.263933,0.41537 -1.079857,0.967652 -2.46875,1.40625 C 40.659715,40.439695 35.717076,41 28.875,41 v 1 c 6.895998,0 11.863665,-0.527671 14.84375,-1.46875 1.490042,-0.47054 2.524942,-1.015687 3.03125,-1.8125 C 47.003154,38.320344 47.107321,37.830301 47,37.375 46.892679,36.919699 46.615445,36.490445 46.21875,36.09375 45.34118,35.21618 43.681912,34.68731 41.625,34.1875 39.568088,33.68769 37.109264,33.273171 34.75,32.96875 30.031473,32.359908 25.6875,28.766243 25.6875,28.766243 Z"
+               id="path690"
+               style="fill:#d0d0d0;fill-opacity:1;fill-rule:evenodd;stroke:#979797;stroke-width:0.513255;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 41.10058,35.051105 c 0.0024,2.514454 -7.556723,4.553162 -16.882173,4.553162 -9.325451,0 -16.8845543,-2.038708 -16.8821739,-4.553162 -0.00238,-2.514454 7.5567229,-4.553162 16.8821739,-4.553162 9.32545,0 16.884553,2.038708 16.882173,4.553162 z"
+               transform="matrix(1,0,0,1.368932,-1.978553,-19.02126)"
+               id="path692"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient748);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+            <rect
+               width="9.0396729"
+               height="2.7400389"
+               x="17.472397"
+               y="30.703611"
+               id="rect694"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient750);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.608729;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 7.0809024,1.6956221 H 36.669097 c 0.911342,0 1.624147,0.5834818 1.666752,1.401587 l 1.332044,25.5781139 c 0.05821,1.117735 -0.901056,2.020305 -2.020305,2.020305 H 6.102412 c -1.1192491,0 -2.078514,-0.90257 -2.0203052,-2.020305 L 5.4141506,3.0972091 c 0.040284,-0.7735346 0.5475027,-1.401587 1.6667518,-1.401587 z"
+               id="path696"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient752);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient754);stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 8.4105348,4.3058272 7.1683398,26.351144 H 34.818729 L 33.483712,4.3992558 Z"
+               id="path698"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient756);fill-opacity:1;fill-rule:evenodd;stroke:#4263a8;stroke-width:0.641569;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 6.1774331,28.735789 H 37.60591"
+               id="path700"
+               style="fill:none;stroke:url(#linearGradient758);stroke-width:1.27824;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.248408" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 6.9145985,2.7063396 36.760101,2.6685383 c 0.283697,-3.593e-4 0.559302,0.2372498 0.582105,0.6525438 L 38.704098,28.12433 c 0.05804,1.057031 -0.539749,1.785871 -1.598371,1.785871 H 6.5817583 c -1.0586228,0 -1.5930144,-0.728791 -1.5358714,-1.785871 L 6.3699773,3.6301633 C 6.4086732,2.9143326 6.5363627,2.7068187 6.9145985,2.7063396 Z"
+               id="path702"
+               style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient760);stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:0.700637;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 8.7115364,4.7463626 7.9090069,22.616693 C 18.953645,20.216063 19.33047,12.124494 33.063039,9.4699426 L 32.901567,4.8124267 Z"
+               id="path704"
+               style="opacity:0.531429;fill:url(#linearGradient762);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 41.10058,35.051105 c 0.0024,2.514454 -7.556723,4.553162 -16.882173,4.553162 -9.325451,0 -16.8845543,-2.038708 -16.8821739,-4.553162 -0.00238,-2.514454 7.5567229,-4.553162 16.8821739,-4.553162 9.32545,0 16.884553,2.038708 16.882173,4.553162 z"
+               transform="matrix(1.264398,0,0,1.291262,-6.216332,-4.000423)"
+               id="path706"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient764);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 6.4621839,36.817452 H 37.46459 c 1.119249,0 0.977355,0.271438 1.092227,0.612846 l 2.834646,8.42481 c 0.114872,0.341409 0.02702,0.612846 -1.092227,0.612846 H 3.6275382 c -1.1192491,0 -1.2070995,-0.271437 -1.0922275,-0.612846 l 2.8346457,-8.42481 c 0.114872,-0.341409 -0.027022,-0.612846 1.0922275,-0.612846 z"
+               id="path708"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient766);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient768);stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 6.3916892,38.829113 4.6239223,43.955638 H 10.104 l 0.53033,-2.032932 h 14.849242 l 0.549679,2.075114 h 6.167835 l -1.679378,-5.168707 z"
+               id="path710"
+               style="fill:#7a7d77;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 11.076272,42.27626 -0.441942,1.679379 h 14.760854 l -0.441942,-1.767767 -13.87697,0.08839 z"
+               id="path712"
+               style="fill:#777874;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 37.592776,38.829114 1.679379,5.038136 -5.480078,-0.08839 -1.502602,-4.861359 5.303301,-0.08839 z"
+               id="path714"
+               style="display:inline;overflow:visible;visibility:visible;fill:#777a75;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.25pt;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 37.592776,38.298786 1.679379,5.038136 -5.480078,-0.08839 -1.502602,-4.861359 5.303301,-0.08839 z"
+               id="path716"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient770);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.25pt;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 6.3916892,38.210397 4.6239223,43.336922 H 10.104 l 0.53033,-2.032932 h 14.849242 l 0.549679,2.075114 h 6.167835 l -1.679378,-5.168707 z"
+               id="path718"
+               style="fill:url(#linearGradient772);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 11.076272,41.745932 -0.441942,1.679379 h 14.760854 l -0.441942,-1.767767 -13.87697,0.08839 z"
+               id="path720"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient774);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.25pt;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 6.1278189,37.578116 H 37.953634 l 2.637179,8.092563 H 3.3297429 Z"
+               id="path722"
+               style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient776);stroke-width:0.641569;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               transform="matrix(1.331237,0,0,0.658449,-10.41933,2.853866)"
+               id="path724"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient778);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               transform="matrix(1.331237,0,0,0.658449,-10.30573,4.959651)"
+               id="path726"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient780);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               transform="matrix(1.331237,0,0,0.658449,-10.19213,6.959651)"
+               id="path728"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient782);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               transform="matrix(1.331237,0,0,0.658449,-10.07853,8.959651)"
+               id="path730"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient784);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               transform="matrix(1.331237,0,0,0.658449,-9.96493,10.95965)"
+               id="path732"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient786);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 20,27.317666 h 0.281716 c 0.08376,1e-6 0.147985,0.01866 0.19266,0.05599 0.04497,0.03703 0.06745,0.08994 0.06745,0.158714 -1e-6,0.06907 -0.02248,0.122268 -0.06745,0.159595 -0.04467,0.03703 -0.108895,0.05555 -0.19266,0.05555 h -0.111981 v 0.22837 H 20 v -0.658219 m 0.169735,0.123003 v 0.183843 h 0.0939 c 0.03292,0 0.05834,-0.0079 0.07627,-0.02381 0.01793,-0.01617 0.02689,-0.03894 0.02689,-0.06834 0,-0.02939 -0.009,-0.05202 -0.02689,-0.06789 -0.01793,-0.01587 -0.04335,-0.02381 -0.07627,-0.02381 h -0.0939 m 0.792244,-0.0119 c -0.05173,1e-6 -0.09185,0.01911 -0.120358,0.05731 -0.02851,0.03821 -0.04276,0.092 -0.04276,0.161359 0,0.06907 0.01425,0.122709 0.04276,0.160918 0.02851,0.03821 0.06863,0.05731 0.120358,0.05731 0.05202,0 0.09229,-0.0191 0.120799,-0.05731 0.02851,-0.03821 0.04276,-0.09185 0.04276,-0.160918 -10e-7,-0.06936 -0.01425,-0.123149 -0.04276,-0.161359 -0.02851,-0.03821 -0.06878,-0.05731 -0.120799,-0.05731 m 0,-0.123003 c 0.105808,1e-6 0.188692,0.03027 0.248651,0.09082 0.05996,0.06055 0.08994,0.144165 0.08994,0.250855 -1e-6,0.106397 -0.02998,0.189868 -0.08994,0.250414 -0.05996,0.06055 -0.142843,0.09082 -0.248651,0.09082 -0.105515,0 -0.188399,-0.03027 -0.248651,-0.09082 -0.05996,-0.06055 -0.08994,-0.144017 -0.08994,-0.250414 0,-0.10669 0.02998,-0.190309 0.08994,-0.250855 0.06025,-0.06055 0.143136,-0.09082 0.248651,-0.09082 m 0.466441,0.0119 h 0.189574 l 0.239393,0.451451 v -0.451451 h 0.160918 v 0.658219 H 21.82873 l -0.239392,-0.451451 v 0.451451 H 21.42842 v -0.658219 m 0.663069,0 h 0.185606 l 0.149896,0.234543 0.149896,-0.234543 h 0.186048 l -0.250856,0.380912 v 0.277307 h -0.169735 v -0.277307 l -0.250855,-0.380912"
+               id="path734"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:0.902903px;font-family:'Bitstream Vera Sans';writing-mode:lr-tb;text-anchor:start;fill:#4a4a4a;fill-opacity:1;stroke:none" />
+          </g>
+        </g>
+      </g>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="138.83449"
+       y="99.613564"
+       id="text2368"><tspan
+         style="stroke-width:0.264583"
+         id="tspan2370"
+         sodipodi:role="line"
+         x="138.83449"
+         y="99.613564">VyOS</tspan></text>
+    <path
+       d="m 73.71633,58.990419 a 11.508754,10.950199 0 0 0 -10.52596,6.596272 7.2444316,6.026363 0 0 0 -4.925996,-1.60749 7.2444316,6.026363 0 0 0 -7.069057,4.709678 10.406181,10.690376 0 0 0 -7.216381,-2.988188 10.406181,10.690376 0 0 0 -10.405985,10.690593 10.406181,10.690376 0 0 0 10.405985,10.690291 10.406181,10.690376 0 0 0 1.600241,-0.127307 10.551072,9.4659486 0 0 0 -0.0029,0.22044 10.551072,9.4659486 0 0 0 10.551247,9.465923 10.551072,9.4659486 0 0 0 6.608277,-2.087073 16.20221,15.066759 0 0 0 12.343214,5.306885 16.20221,15.066759 0 0 0 14.706524,-8.744121 10.551072,9.4659486 0 0 0 4.277901,0.813125 10.551072,9.4659486 0 0 0 10.55125,-9.46593 10.551072,9.4659486 0 0 0 -9.184191,-9.386093 8.1498027,6.9966314 0 0 0 1.336473,-3.838805 8.1498027,6.9966314 0 0 0 -8.150002,-6.996632 8.1498027,6.9966314 0 0 0 -5.267681,1.657989 11.508754,10.950199 0 0 0 -9.599105,-4.909557 11.508754,10.950199 0 0 0 -0.0338,0 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.350893;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path16"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="66.210678"
+       y="69.917747"
+       id="text1908"><tspan
+         sodipodi:role="line"
+         id="tspan1906"
+         x="66.210678"
+         y="69.917747"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">DMZ</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="51.303028"
+       y="77.535042"
+       id="text1912"><tspan
+         sodipodi:role="line"
+         x="51.303028"
+         y="77.535042"
+         id="tspan1916">192.168.200.0/24</tspan></text>
+    <text
+       id="text1922"
+       y="84.080986"
+       x="42.721645"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         id="tspan1920"
+         y="84.080986"
+         x="42.721645"
+         sodipodi:role="line">2001:0DB8:0:BBBB::0/64</tspan></text>
+    <path
+       d="m 230.45846,62.905328 a 11.222812,10.482479 0 0 0 -10.26443,6.314524 7.0644385,5.7689571 0 0 0 -4.80361,-1.538829 7.0644385,5.7689571 0 0 0 -6.89342,4.508513 10.147633,10.233754 0 0 0 -7.03708,-2.860554 10.147633,10.233754 0 0 0 -10.14745,10.233963 10.147633,10.233754 0 0 0 10.14745,10.233673 10.147633,10.233754 0 0 0 1.56048,-0.121867 10.288924,9.0616268 0 0 0 -0.003,0.211025 10.288924,9.0616268 0 0 0 10.2891,9.061607 10.288924,9.0616268 0 0 0 6.44409,-1.997933 15.799654,14.423207 0 0 0 12.03654,5.08024 15.799654,14.423207 0 0 0 14.34113,-8.370659 10.288924,9.0616268 0 0 0 4.17161,0.778388 10.288924,9.0616268 0 0 0 10.2891,-9.061603 10.288924,9.0616268 0 0 0 -8.95601,-8.985186 7.9473151,6.6977823 0 0 0 1.30326,-3.674836 7.9473151,6.6977823 0 0 0 -7.94748,-6.697784 7.9473151,6.6977823 0 0 0 -5.1368,1.587171 11.222812,10.482479 0 0 0 -9.36061,-4.699853 11.222812,10.482479 0 0 0 -0.033,0 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.339026;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path16-5"
+       inkscape:connector-curvature="0" />
+    <text
+       id="text1908-3"
+       y="72.643913"
+       x="223.95766"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         y="72.643913"
+         x="223.95766"
+         id="tspan1906-0"
+         sodipodi:role="line">LAN</tspan></text>
+    <text
+       id="text1912-6"
+       y="80.261208"
+       x="209.03348"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         id="tspan1916-2"
+         y="80.261208"
+         x="209.03348"
+         sodipodi:role="line"
+         style="stroke-width:0.264583">192.168.100.0/24</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="200.46863"
+       y="86.807152"
+       id="text1922-2"><tspan
+         sodipodi:role="line"
+         x="200.46863"
+         y="86.807152"
+         id="tspan1920-5"
+         style="stroke-width:0.264583">2001:0DB8:0:AAAA::0/64</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path16-0"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.350893;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 151.96915,7.3386558 a 11.508754,10.950199 0 0 0 -10.52596,6.5962722 7.2444316,6.026363 0 0 0 -4.92599,-1.60749 7.2444316,6.026363 0 0 0 -7.06906,4.709678 10.406181,10.690376 0 0 0 -7.21638,-2.988188 10.406181,10.690376 0 0 0 -10.40599,10.690593 10.406181,10.690376 0 0 0 10.40599,10.690292 10.406181,10.690376 0 0 0 1.60024,-0.127307 10.551072,9.4659487 0 0 0 -0.003,0.22044 10.551072,9.4659487 0 0 0 10.55125,9.465927 10.551072,9.4659487 0 0 0 6.60827,-2.087079 16.20221,15.066759 0 0 0 12.34322,5.306907 16.20221,15.066759 0 0 0 14.70652,-8.74414 10.551072,9.4659487 0 0 0 4.2779,0.813122 10.551072,9.4659487 0 0 0 10.55125,-9.465929 10.551072,9.4659487 0 0 0 -9.18419,-9.386092 8.1498027,6.9966313 0 0 0 1.33647,-3.838806 8.1498027,6.9966313 0 0 0 -8.15,-6.996632 8.1498027,6.9966313 0 0 0 -5.26768,1.657989 11.508754,10.950199 0 0 0 -9.5991,-4.9095572 11.508754,10.950199 0 0 0 -0.0338,0 z" />
+    <text
+       id="text1908-9"
+       y="18.265985"
+       x="144.4635"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         sodipodi:role="line"
+         id="tspan1993"
+         x="144.4635"
+         y="18.265985">WAN</tspan></text>
+    <text
+       id="text1912-62"
+       y="25.88328"
+       x="131.83788"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         sodipodi:role="line"
+         id="tspan1995"
+         x="131.83788"
+         y="25.88328">172.16.10.0/24</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="120.97447"
+       y="32.429222"
+       id="text1922-5"><tspan
+         sodipodi:role="line"
+         id="tspan1997"
+         x="120.97447"
+         y="32.429222">2001:0DB8:0:9999::0/64</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8.46667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="33.810677"
+       y="13.633336"
+       id="text4043"><tspan
+         sodipodi:role="line"
+         id="tspan4041"
+         x="33.810677"
+         y="13.633336"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8.46667px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">Logical</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path2386"
+       d="m 85.994414,240.3896 57.367916,3.80591"
+       style="fill:none;stroke:#000000;stroke-width:0.799999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path2388"
+       d="m 143.36233,244.19551 1.5119,-66.52381"
+       style="fill:none;stroke:#000000;stroke-width:0.799999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path2390"
+       d="m 217.68661,191.47586 -74.0411,53.00282"
+       style="fill:none;stroke:#000000;stroke-width:0.799999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path2392"
+       d="m 214.25173,254.37844 -72.0519,-9.89976"
+       style="fill:none;stroke:#000000;stroke-width:0.799999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,198.67242,235.01226)"
+       id="g975">
+      <g
+         id="layer1-7"
+         style="display:inline" />
+      <g
+         id="layer2-9"
+         style="display:inline">
+        <g
+           transform="matrix(2.523753,0,0,2.523753,-14.365049,36.911359)"
+           id="g2860-6">
+          <g
+             transform="translate(7.165836,-12.94079)"
+             id="g3880-2">
+            <path
+               inkscape:connector-curvature="0"
+               d="m 41.10058,35.051105 c 0.0024,2.514454 -7.556723,4.553162 -16.882173,4.553162 -9.325451,0 -16.8845543,-2.038708 -16.8821739,-4.553162 -0.00238,-2.514454 7.5567229,-4.553162 16.8821739,-4.553162 9.32545,0 16.884553,2.038708 16.882173,4.553162 z"
+               transform="matrix(1,0,0,1.368932,-1.978553,-13.61713)"
+               id="path2862-8"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient30928-2);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m -26.263968,29.716238 c 0.0011,2.176096 -4.205267,3.940408 -9.394418,3.940408 -5.189152,0 -9.39549,-1.764312 -9.394419,-3.940408 -0.0011,-2.176096 4.205267,-3.940408 9.394419,-3.940408 5.189151,0 9.395489,1.764312 9.394418,3.940408 z"
+               transform="translate(57.53339,3.203427)"
+               id="path2864-5"
+               style="display:inline;overflow:visible;visibility:visible;fill:#adb0aa;fill-opacity:1;fill-rule:evenodd;stroke:#4b4d4a;stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m -26.263968,29.716238 c 0.0011,2.176096 -4.205267,3.940408 -9.394418,3.940408 -5.189152,0 -9.39549,-1.764312 -9.394419,-3.940408 -0.0011,-2.176096 4.205267,-3.940408 9.394419,-3.940408 5.189151,0 9.395489,1.764312 9.394418,3.940408 z"
+               transform="matrix(0.940273,0,0,0.940273,55.40361,4.271194)"
+               id="path2866-9"
+               style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#7b7f7a;stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m -26.263968,29.716238 c 0.0011,2.176096 -4.205267,3.940408 -9.394418,3.940408 -5.189152,0 -9.39549,-1.764312 -9.394419,-3.940408 -0.0011,-2.176096 4.205267,-3.940408 9.394419,-3.940408 5.189151,0 9.395489,1.764312 9.394418,3.940408 z"
+               transform="matrix(0.940273,0,0,0.940273,55.40361,3.521194)"
+               id="path2868-4"
+               style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient8303);stroke-width:0.873372;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 25.6875,28.766243 -0.0625,1 c 0,0 4.324108,3.599166 9,4.202507 2.337946,0.30167 4.753675,0.702412 6.75,1.1875 1.996325,0.485088 3.588356,1.119606 4.125,1.65625 0.310411,0.310411 0.451063,0.573639 0.5,0.78125 0.04894,0.207611 0.03822,0.354815 -0.09375,0.5625 -0.263933,0.41537 -1.079857,0.967652 -2.46875,1.40625 C 40.659715,40.439695 35.717076,41 28.875,41 v 1 c 6.895998,0 11.863665,-0.527671 14.84375,-1.46875 1.490042,-0.47054 2.524942,-1.015687 3.03125,-1.8125 C 47.003154,38.320344 47.107321,37.830301 47,37.375 46.892679,36.919699 46.615445,36.490445 46.21875,36.09375 45.34118,35.21618 43.681912,34.68731 41.625,34.1875 39.568088,33.68769 37.109264,33.273171 34.75,32.96875 30.031473,32.359908 25.6875,28.766243 25.6875,28.766243 Z"
+               id="path2870-3"
+               style="fill:#d0d0d0;fill-opacity:1;fill-rule:evenodd;stroke:#979797;stroke-width:0.513255;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 41.10058,35.051105 c 0.0024,2.514454 -7.556723,4.553162 -16.882173,4.553162 -9.325451,0 -16.8845543,-2.038708 -16.8821739,-4.553162 -0.00238,-2.514454 7.5567229,-4.553162 16.8821739,-4.553162 9.32545,0 16.884553,2.038708 16.882173,4.553162 z"
+               transform="matrix(1,0,0,1.368932,-1.978553,-19.02126)"
+               id="path2872-9"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient30932-5);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+            <rect
+               width="9.0396729"
+               height="2.7400389"
+               x="17.472397"
+               y="30.703611"
+               id="rect2874-0"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8305);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.608729;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 7.0809024,1.6956221 H 36.669097 c 0.911342,0 1.624147,0.5834818 1.666752,1.401587 l 1.332044,25.5781139 c 0.05821,1.117735 -0.901056,2.020305 -2.020305,2.020305 H 6.102412 c -1.1192491,0 -2.078514,-0.90257 -2.0203052,-2.020305 L 5.4141506,3.0972091 c 0.040284,-0.7735346 0.5475027,-1.401587 1.6667518,-1.401587 z"
+               id="path2876-5"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8307);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient8309);stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 8.4105348,4.3058272 7.1683398,26.351144 H 34.818729 L 33.483712,4.3992558 Z"
+               id="path2878-6"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8311);fill-opacity:1;fill-rule:evenodd;stroke:#4263a8;stroke-width:0.641569;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 6.1774331,28.735789 H 37.60591"
+               id="path2880-3"
+               style="fill:none;stroke:url(#linearGradient8313);stroke-width:1.27824;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.248408" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 6.9145985,2.7063396 36.760101,2.6685383 c 0.283697,-3.593e-4 0.559302,0.2372498 0.582105,0.6525438 L 38.704098,28.12433 c 0.05804,1.057031 -0.539749,1.785871 -1.598371,1.785871 H 6.5817583 c -1.0586228,0 -1.5930144,-0.728791 -1.5358714,-1.785871 L 6.3699773,3.6301633 C 6.4086732,2.9143326 6.5363627,2.7068187 6.9145985,2.7063396 Z"
+               id="path2882-6"
+               style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient8315);stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:0.700637;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 8.7115364,4.7463626 7.9090069,22.616693 C 18.953645,20.216063 19.33047,12.124494 33.063039,9.4699426 L 32.901567,4.8124267 Z"
+               id="path2884-3"
+               style="opacity:0.531429;fill:url(#linearGradient8317);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 41.10058,35.051105 c 0.0024,2.514454 -7.556723,4.553162 -16.882173,4.553162 -9.325451,0 -16.8845543,-2.038708 -16.8821739,-4.553162 -0.00238,-2.514454 7.5567229,-4.553162 16.8821739,-4.553162 9.32545,0 16.884553,2.038708 16.882173,4.553162 z"
+               transform="matrix(1.264398,0,0,1.291262,-6.216332,-4.000423)"
+               id="path2886-0"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient30948-1);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 6.4621839,36.817452 H 37.46459 c 1.119249,0 0.977355,0.271438 1.092227,0.612846 l 2.834646,8.42481 c 0.114872,0.341409 0.02702,0.612846 -1.092227,0.612846 H 3.6275382 c -1.1192491,0 -1.2070995,-0.271437 -1.0922275,-0.612846 l 2.8346457,-8.42481 c 0.114872,-0.341409 -0.027022,-0.612846 1.0922275,-0.612846 z"
+               id="path2888-8"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8319);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient8321);stroke-width:1.28314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 6.3916892,38.829113 4.6239223,43.955638 H 10.104 l 0.53033,-2.032932 h 14.849242 l 0.549679,2.075114 h 6.167835 l -1.679378,-5.168707 z"
+               id="path2890-4"
+               style="fill:#7a7d77;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 11.076272,42.27626 -0.441942,1.679379 h 14.760854 l -0.441942,-1.767767 -13.87697,0.08839 z"
+               id="path2892-0"
+               style="fill:#777874;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 37.592776,38.829114 1.679379,5.038136 -5.480078,-0.08839 -1.502602,-4.861359 5.303301,-0.08839 z"
+               id="path2894-4"
+               style="display:inline;overflow:visible;visibility:visible;fill:#777a75;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.25pt;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 37.592776,38.298786 1.679379,5.038136 -5.480078,-0.08839 -1.502602,-4.861359 5.303301,-0.08839 z"
+               id="path2896-6"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8323);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.25pt;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 6.3916892,38.210397 4.6239223,43.336922 H 10.104 l 0.53033,-2.032932 h 14.849242 l 0.549679,2.075114 h 6.167835 l -1.679378,-5.168707 z"
+               id="path2898-4"
+               style="fill:url(#linearGradient8325);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 11.076272,41.745932 -0.441942,1.679379 h 14.760854 l -0.441942,-1.767767 -13.87697,0.08839 z"
+               id="path2900-6"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8327);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.25pt;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 6.1278189,37.578116 H 37.953634 l 2.637179,8.092563 H 3.3297429 Z"
+               id="path2902-4"
+               style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient8329);stroke-width:0.641569;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               transform="matrix(1.331237,0,0,0.658449,-10.41933,2.853866)"
+               id="path2904-3"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8331);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               transform="matrix(1.331237,0,0,0.658449,-10.30573,4.959651)"
+               id="path2906-8"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8333);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               transform="matrix(1.331237,0,0,0.658449,-10.19213,6.959651)"
+               id="path2908-4"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8335);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               transform="matrix(1.331237,0,0,0.658449,-10.07853,8.959651)"
+               id="path2910-0"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8337);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 35.620504,3.9384086 c 3.99e-4,0.4640292 -0.37566,0.8404108 -0.839689,0.8404108 -0.464029,0 -0.840088,-0.3763816 -0.839689,-0.8404108 -3.99e-4,-0.4640292 0.37566,-0.8404108 0.839689,-0.8404108 0.464029,0 0.840088,0.3763816 0.839689,0.8404108 z"
+               transform="matrix(1.331237,0,0,0.658449,-9.96493,10.95965)"
+               id="path2912-0"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8339);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 20,27.317666 h 0.281716 c 0.08376,1e-6 0.147985,0.01866 0.19266,0.05599 0.04497,0.03703 0.06745,0.08994 0.06745,0.158714 -1e-6,0.06907 -0.02248,0.122268 -0.06745,0.159595 -0.04467,0.03703 -0.108895,0.05555 -0.19266,0.05555 h -0.111981 v 0.22837 H 20 v -0.658219 m 0.169735,0.123003 v 0.183843 h 0.0939 c 0.03292,0 0.05834,-0.0079 0.07627,-0.02381 0.01793,-0.01617 0.02689,-0.03894 0.02689,-0.06834 0,-0.02939 -0.009,-0.05202 -0.02689,-0.06789 -0.01793,-0.01587 -0.04335,-0.02381 -0.07627,-0.02381 h -0.0939 m 0.792244,-0.0119 c -0.05173,1e-6 -0.09185,0.01911 -0.120358,0.05731 -0.02851,0.03821 -0.04276,0.092 -0.04276,0.161359 0,0.06907 0.01425,0.122709 0.04276,0.160918 0.02851,0.03821 0.06863,0.05731 0.120358,0.05731 0.05202,0 0.09229,-0.0191 0.120799,-0.05731 0.02851,-0.03821 0.04276,-0.09185 0.04276,-0.160918 -10e-7,-0.06936 -0.01425,-0.123149 -0.04276,-0.161359 -0.02851,-0.03821 -0.06878,-0.05731 -0.120799,-0.05731 m 0,-0.123003 c 0.105808,1e-6 0.188692,0.03027 0.248651,0.09082 0.05996,0.06055 0.08994,0.144165 0.08994,0.250855 -1e-6,0.106397 -0.02998,0.189868 -0.08994,0.250414 -0.05996,0.06055 -0.142843,0.09082 -0.248651,0.09082 -0.105515,0 -0.188399,-0.03027 -0.248651,-0.09082 -0.05996,-0.06055 -0.08994,-0.144017 -0.08994,-0.250414 0,-0.10669 0.02998,-0.190309 0.08994,-0.250855 0.06025,-0.06055 0.143136,-0.09082 0.248651,-0.09082 m 0.466441,0.0119 h 0.189574 l 0.239393,0.451451 v -0.451451 h 0.160918 v 0.658219 H 21.82873 l -0.239392,-0.451451 v 0.451451 H 21.42842 v -0.658219 m 0.663069,0 h 0.185606 l 0.149896,0.234543 0.149896,-0.234543 h 0.186048 l -0.250856,0.380912 v 0.277307 h -0.169735 v -0.277307 l -0.250855,-0.380912"
+               id="path2914-9"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:0.902903px;font-family:'Bitstream Vera Sans';writing-mode:lr-tb;text-anchor:start;fill:#4a4a4a;fill-opacity:1;stroke:none" />
+          </g>
+        </g>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,128.33346,167.36814)"
+       id="g1209">
+      <g
+         id="layer1-3"
+         style="display:inline" />
+      <g
+         id="layer2-98"
+         style="display:inline">
+        <path
+           inkscape:connector-curvature="0"
+           d="m 11.599653,73.603805 1.953642,-1.39944 96.096875,0.126356 8.84682,0.641477 v 21.103415 c 0,2.275545 -1.55099,3.726634 -4.0674,3.726634 H 15.845836 c -2.551187,0 -4.246183,-1.095855 -4.246183,-3.284558 z"
+           id="path4170"
+           style="fill:url(#linearGradient19003);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 31.848533,40.136783 c -1.607726,0 -2.652747,0.5431 -3.295834,1.579165 -2e-6,0 -16.639968,32.01098 -16.639968,32.01098 0,0 -0.643091,1.256888 -0.643091,3.333784 0,0 0,18.060858 0,18.060858 0,2.026216 1.692063,3.04135 4.260475,3.041347 h 99.196705 c 2.53341,0 4.0997,-1.344146 4.0997,-3.450759 V 76.6513 c 0,0 0.27258,-1.441922 -0.24116,-2.456472 L 101.30231,42.008387 c -0.47467,-0.958083 -1.638354,-1.849321 -2.893911,-1.871604 z"
+           id="path4196"
+           style="fill:none;stroke:#535353;stroke-width:4.38836;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <g
+           transform="matrix(0.06267019,0,0,0.05331895,119.9796,90.615598)"
+           id="g6707-6">
+          <rect
+             width="1339.6335"
+             height="478.35718"
+             x="-1559.2523"
+             y="-150.69685"
+             id="rect6709-5"
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#linearGradient8301);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m -219.61876,-150.68038 c 0,0 0,478.33079 0,478.33079 142.874166,0.90045 345.40022,-107.16966 345.40014,-239.196175 0,-132.026537 -159.436816,-239.134595 -345.40014,-239.134615 z"
+             id="path6711-7"
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient6717);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m -1559.2523,-150.68038 c 0,0 0,478.33079 0,478.33079 -142.8742,0.90045 -345.4002,-107.16966 -345.4002,-239.196175 0,-132.026537 159.4368,-239.134595 345.4002,-239.134615 z"
+             id="path6713-6"
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient6719);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+        </g>
+        <path
+           inkscape:connector-curvature="0"
+           d="m 13.929746,70.190357 c -1.763629,2.251306 -0.0015,3.678965 2.557261,3.678965 0,0 96.294153,0 96.294153,0 2.76301,-0.03661 4.55603,-1.555781 3.52725,-3.294598 L 99.73029,44.113647 c -0.4556,-0.787045 -1.616653,-1.519181 -2.8218,-1.537485 H 33.065119 c -1.543177,0 -2.557263,0.466738 -3.174531,1.317844 0,0 -15.960842,26.296351 -15.960842,26.296351 z"
+           id="path3093"
+           style="fill:url(#radialGradient19000);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 8.5736699,25.593554 a 1.3700195,1.016466 0 1 1 -2.7400389,0 1.3700195,1.016466 0 1 1 2.7400389,0 z"
+           transform="matrix(2.5551094,0,0,2.5551094,7.4611107,-1.3091229)"
+           id="path4224"
+           style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.457627;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 8.5736699,25.593554 a 1.3700195,1.016466 0 1 1 -2.7400389,0 1.3700195,1.016466 0 1 1 2.7400389,0 z"
+           transform="matrix(2.5551094,0,0,2.5551094,86.024797,-1.5349638)"
+           id="path4226"
+           style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.457627;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 32.863624,41.760801 c -1.543128,0 -2.54616,0.510806 -3.163406,1.485264 -3e-6,0 -16.452257,30.336065 -16.452257,30.336065 0,0 -0.617252,1.182149 -0.617252,3.135546 0,0 0,16.986901 0,16.986901 0,2.477136 1.138848,2.974778 4.089291,2.974778 h 96.65365 c 3.39336,0 3.93499,-0.578531 3.93499,-3.359846 V 76.332608 c 0,0 0.26161,-1.356179 -0.23147,-2.310402 L 100.16795,43.292552 c -0.455592,-0.901113 -1.412229,-1.510794 -2.61734,-1.531751 z"
+           id="path4252"
+           style="fill:none;stroke:url(#linearGradient18985);stroke-width:2.16551;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 106.7172,76.544153 V 89.373191"
+           id="path4282"
+           style="fill:none;stroke:#ffffff;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:0.423729" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 101.60698,76.696889 V 89.525928"
+           id="path4284"
+           style="fill:none;stroke:#ffffff;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:0.423729" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 96.496762,76.696889 V 89.525928"
+           id="path4286"
+           style="fill:none;stroke:#ffffff;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:0.423729" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 91.386543,76.696889 V 89.525928"
+           id="path4288"
+           style="fill:none;stroke:#ffffff;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:0.423729" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 86.276324,76.696889 V 89.525928"
+           id="path4290"
+           style="fill:none;stroke:#ffffff;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:0.423729" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 81.166105,76.696889 V 89.525928"
+           id="path4292"
+           style="fill:none;stroke:#ffffff;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:0.423729" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 104.16209,76.67165 V 89.500688"
+           id="path4294"
+           style="opacity:0.0971428;fill:none;stroke:#000000;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 99.051871,76.824387 V 89.653425"
+           id="path4296"
+           style="opacity:0.0971428;fill:none;stroke:#000000;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 93.941652,76.824387 V 89.653425"
+           id="path4298"
+           style="opacity:0.0971428;fill:none;stroke:#000000;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 88.831434,76.824387 V 89.653425"
+           id="path4300"
+           style="opacity:0.0971428;fill:none;stroke:#000000;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 83.721215,76.824387 V 89.653425"
+           id="path4302"
+           style="opacity:0.0971428;fill:none;stroke:#000000;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+        <g
+           transform="translate(67.840656,8.0673369)"
+           id="g22031"
+           style="display:inline">
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224236"
+             y="69.945557"
+             id="rect22033"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224236"
+             y="69.945557"
+             id="rect22035"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="7.1828671"
+             height="5.6819677"
+             x="-5.6926928"
+             y="68.87529"
+             id="rect22037"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.421451;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224232"
+             y="78.200493"
+             id="rect22039"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224232"
+             y="78.200493"
+             id="rect22041"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="7.1828671"
+             height="5.6819677"
+             x="-5.6926923"
+             y="77.130234"
+             id="rect22043"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.421451;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <path
+           inkscape:connector-curvature="0"
+           d="m -25.215112,86.725266 a 2.2513492,2.2513492 0 1 1 -4.502698,0 2.2513492,2.2513492 0 1 1 4.502698,0 z"
+           transform="translate(102.88665,-8.405037)"
+           id="path22045"
+           style="fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.4;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m -25.215112,86.725266 a 2.2513492,2.2513492 0 1 1 -4.502698,0 2.2513492,2.2513492 0 1 1 4.502698,0 z"
+           transform="translate(102.88665,-3.4520692)"
+           id="path22049"
+           style="display:inline;fill:#a40000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.4;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m -25.215112,86.725266 a 2.2513492,2.2513492 0 1 1 -4.502698,0 2.2513492,2.2513492 0 1 1 4.502698,0 z"
+           transform="translate(102.88665,1.6509881)"
+           id="path22051"
+           style="display:inline;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.4;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,64.339837,224.37622)"
+       id="g223">
+      <g
+         id="layer1-4"
+         style="display:inline" />
+      <g
+         id="layer2-37"
+         style="display:inline">
+        <g
+           id="g43337-5">
+          <g
+             transform="translate(-4)"
+             id="g43326-7">
+            <rect
+               width="84.447739"
+               height="25.850916"
+               x="25.390865"
+               y="85.125816"
+               id="rect35646-2"
+               style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#linearGradient8299);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 109.8386,85.126705 c 0,0 0,25.849485 0,25.849485 9.00649,0.0487 21.77332,-5.79156 21.77331,-12.926404 0,-7.13485 -10.05056,-12.92308 -21.77331,-12.923081 z"
+               id="path35648-9"
+               style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient43333-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 25.390865,85.126705 c 0,0 0,25.849485 0,25.849485 -9.006495,0.0487 -21.7733159,-5.79156 -21.7733159,-12.926404 0,-7.13485 10.0505669,-12.92308 21.7733159,-12.923081 z"
+               id="path35650-7"
+               style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient43335-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+          </g>
+          <rect
+             width="101.91125"
+             height="74.962074"
+             x="13.40662"
+             y="21.487539"
+             id="rect36307-5"
+             style="fill:#fd3301;fill-opacity:1;fill-rule:nonzero;stroke:#790009;stroke-width:3.86854;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="M 15.693772,73.333616 113.26837,73.023855"
+             id="path39222-6"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="M 15.693772,85.712947 113.26837,85.403186"
+             id="path39224-5"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="M 32.335638,85.446081 32.29634,73.06694"
+             id="path39226-3"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="M 63.91032,85.446078 63.871021,73.06694"
+             id="path41166-0"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="M 97.353375,85.446078 97.314076,73.06694"
+             id="path41168-4"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <g
+             transform="matrix(0.7737082,0,0,0.7737082,74.155761,0.354917)"
+             id="g41177-8"
+             style="display:inline;stroke-width:1.25;stroke-miterlimit:4;stroke-dasharray:none">
+            <path
+               inkscape:connector-curvature="0"
+               d="M -75.91453,62.092636 50.198384,61.692277"
+               id="path41179-5"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M -75.91453,78.092636 50.198383,77.692277"
+               id="path41181-5"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m -54.405301,77.747717 -0.05079,-15.999753"
+               id="path41183-5"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m -13.595754,77.747714 -0.05079,-15.99975"
+               id="path41185-4"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 29.628623,77.747714 29.57783,61.747964"
+               id="path41187-2"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          </g>
+          <g
+             transform="matrix(0.7737082,0,0,0.7737082,74.155762,-24.423161)"
+             id="g41189-1"
+             style="display:inline;stroke-width:1.25;stroke-miterlimit:4;stroke-dasharray:none">
+            <path
+               inkscape:connector-curvature="0"
+               d="M -75.91453,62.092636 50.198384,61.692277"
+               id="path41191-9"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M -75.91453,78.092636 50.198383,77.692277"
+               id="path41193-2"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m -54.405301,77.747717 -0.05079,-15.999753"
+               id="path41195-4"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m -13.595754,77.747714 -0.05079,-15.99975"
+               id="path41197-5"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               d="M 29.628623,77.747714 29.57783,61.747964"
+               id="path41199-8"
+               style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          </g>
+          <path
+             inkscape:connector-curvature="0"
+             d="m 48.119461,73.521681 -0.0393,-12.379137"
+             id="path41206-6"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m 81.883371,72.902161 -0.0393,-12.379138"
+             id="path41208-2"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m 81.883371,48.121307 -0.0393,-12.379138"
+             id="path41210-5"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m 48.738983,48.740834 -0.0393,-12.379137"
+             id="path41212-1"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m 48.113809,94.508525 -0.02799,-8.81801"
+             id="path41214-3"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m 81.877718,94.663407 -0.02799,-8.818014"
+             id="path41216-9"
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.967135;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,127.01941,223.83777)"
+       id="g1505">
+      <g
+         id="layer1-1"
+         style="display:inline" />
+      <g
+         id="layer2-4"
+         style="display:inline">
+        <path
+           inkscape:connector-curvature="0"
+           d="m 11.599653,73.603805 1.953642,-1.39944 96.096875,0.126356 8.84682,0.641477 v 21.103415 c 0,2.275545 -1.55099,3.726634 -4.0674,3.726634 H 15.845836 c -2.551187,0 -4.246183,-1.095855 -4.246183,-3.284558 z"
+           id="path4170-7"
+           style="fill:url(#linearGradient8293);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 31.848533,40.136783 c -1.607726,0 -2.652747,0.5431 -3.295834,1.579165 -2e-6,0 -16.639968,32.01098 -16.639968,32.01098 0,0 -0.643091,1.256888 -0.643091,3.333784 0,0 0,18.060858 0,18.060858 0,2.026216 1.692063,3.04135 4.260475,3.041347 h 99.196705 c 2.53341,0 4.0997,-1.344146 4.0997,-3.450759 V 76.6513 c 0,0 0.27258,-1.441922 -0.24116,-2.456472 L 101.30231,42.008387 c -0.47467,-0.958083 -1.638354,-1.849321 -2.893911,-1.871604 z"
+           id="path4196-1"
+           style="fill:none;stroke:#535353;stroke-width:4.38836;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <g
+           transform="matrix(0.06267019,0,0,0.05331895,119.9796,90.615598)"
+           id="g6707-3">
+          <rect
+             width="1339.6335"
+             height="478.35718"
+             x="-1559.2523"
+             y="-150.69685"
+             id="rect6709-8"
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#linearGradient8295);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m -219.61876,-150.68038 c 0,0 0,478.33079 0,478.33079 142.874166,0.90045 345.40022,-107.16966 345.40014,-239.196175 0,-132.026537 -159.436816,-239.134595 -345.40014,-239.134615 z"
+             id="path6711-4"
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient6717-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m -1559.2523,-150.68038 c 0,0 0,478.33079 0,478.33079 -142.8742,0.90045 -345.4002,-107.16966 -345.4002,-239.196175 0,-132.026537 159.4368,-239.134595 345.4002,-239.134615 z"
+             id="path6713-8"
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient6719-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+        </g>
+        <path
+           inkscape:connector-curvature="0"
+           d="m 13.929746,70.190357 c -1.763629,2.251306 -0.0015,3.678965 2.557261,3.678965 0,0 96.294153,0 96.294153,0 2.76301,-0.03661 4.55603,-1.555781 3.52725,-3.294598 L 99.73029,44.113647 c -0.4556,-0.787045 -1.616653,-1.519181 -2.8218,-1.537485 H 33.065119 c -1.543177,0 -2.557263,0.466738 -3.174531,1.317844 0,0 -15.960842,26.296351 -15.960842,26.296351 z"
+           id="path3093-0"
+           style="fill:url(#radialGradient19000-8);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 8.5736699,25.593554 a 1.3700195,1.016466 0 1 1 -2.7400389,0 1.3700195,1.016466 0 1 1 2.7400389,0 z"
+           transform="matrix(2.5551094,0,0,2.5551094,7.4611107,-1.3091229)"
+           id="path4224-4"
+           style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.457627;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 8.5736699,25.593554 a 1.3700195,1.016466 0 1 1 -2.7400389,0 1.3700195,1.016466 0 1 1 2.7400389,0 z"
+           transform="matrix(2.5551094,0,0,2.5551094,86.024797,-1.5349638)"
+           id="path4226-6"
+           style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.457627;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 32.863624,41.760801 c -1.543128,0 -2.54616,0.510806 -3.163406,1.485264 -3e-6,0 -16.452257,30.336065 -16.452257,30.336065 0,0 -0.617252,1.182149 -0.617252,3.135546 0,0 0,16.986901 0,16.986901 0,2.477136 1.138848,2.974778 4.089291,2.974778 h 96.65365 c 3.39336,0 3.93499,-0.578531 3.93499,-3.359846 V 76.332608 c 0,0 0.26161,-1.356179 -0.23147,-2.310402 L 100.16795,43.292552 c -0.455592,-0.901113 -1.412229,-1.510794 -2.61734,-1.531751 z"
+           id="path4252-0"
+           style="fill:none;stroke:url(#linearGradient8297);stroke-width:2.16551;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 106.7172,76.544153 V 89.373191"
+           id="path4282-3"
+           style="fill:none;stroke:#ffffff;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:0.423729" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 101.60698,76.696889 V 89.525928"
+           id="path4284-2"
+           style="fill:none;stroke:#ffffff;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:0.423729" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 96.496762,76.696889 V 89.525928"
+           id="path4286-6"
+           style="fill:none;stroke:#ffffff;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:0.423729" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 91.386543,76.696889 V 89.525928"
+           id="path4288-9"
+           style="fill:none;stroke:#ffffff;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:0.423729" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 86.276324,76.696889 V 89.525928"
+           id="path4290-4"
+           style="fill:none;stroke:#ffffff;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:0.423729" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 81.166105,76.696889 V 89.525928"
+           id="path4292-1"
+           style="fill:none;stroke:#ffffff;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:0.423729" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 104.16209,76.67165 V 89.500688"
+           id="path4294-3"
+           style="opacity:0.0971428;fill:none;stroke:#000000;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 99.051871,76.824387 V 89.653425"
+           id="path4296-7"
+           style="opacity:0.0971428;fill:none;stroke:#000000;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 93.941652,76.824387 V 89.653425"
+           id="path4298-8"
+           style="opacity:0.0971428;fill:none;stroke:#000000;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 88.831434,76.824387 V 89.653425"
+           id="path4300-8"
+           style="opacity:0.0971428;fill:none;stroke:#000000;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="M 83.721215,76.824387 V 89.653425"
+           id="path4302-3"
+           style="opacity:0.0971428;fill:none;stroke:#000000;stroke-width:2.55511px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+        <g
+           transform="translate(25.215111,8.0673369)"
+           id="g21981">
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224236"
+             y="69.945557"
+             id="rect19010"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224236"
+             y="69.945557"
+             id="rect19981"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="7.1828671"
+             height="5.6819677"
+             x="-5.6926928"
+             y="68.87529"
+             id="rect20028"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.421451;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224232"
+             y="78.200493"
+             id="rect21975"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224232"
+             y="78.200493"
+             id="rect21977"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="7.1828671"
+             height="5.6819677"
+             x="-5.6926923"
+             y="77.130234"
+             id="rect21979"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.421451;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <g
+           transform="translate(36.021588,8.0673369)"
+           id="g21989"
+           style="display:inline">
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224236"
+             y="69.945557"
+             id="rect21991"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224236"
+             y="69.945557"
+             id="rect21993"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="7.1828671"
+             height="5.6819677"
+             x="-5.6926928"
+             y="68.87529"
+             id="rect21995"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.421451;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224232"
+             y="78.200493"
+             id="rect21997"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224232"
+             y="78.200493"
+             id="rect21999"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="7.1828671"
+             height="5.6819677"
+             x="-5.6926923"
+             y="77.130234"
+             id="rect22001"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.421451;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <g
+           transform="translate(46.828063,8.0673369)"
+           id="g22003"
+           style="display:inline">
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224236"
+             y="69.945557"
+             id="rect22005"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224236"
+             y="69.945557"
+             id="rect22007"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="7.1828671"
+             height="5.6819677"
+             x="-5.6926928"
+             y="68.87529"
+             id="rect22009"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.421451;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224232"
+             y="78.200493"
+             id="rect22011"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224232"
+             y="78.200493"
+             id="rect22013"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="7.1828671"
+             height="5.6819677"
+             x="-5.6926923"
+             y="77.130234"
+             id="rect22015"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.421451;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <g
+           transform="translate(57.33436,8.0673369)"
+           id="g22017"
+           style="display:inline">
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224236"
+             y="69.945557"
+             id="rect22019"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224236"
+             y="69.945557"
+             id="rect22021"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="7.1828671"
+             height="5.6819677"
+             x="-5.6926928"
+             y="68.87529"
+             id="rect22023"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.421451;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224232"
+             y="78.200493"
+             id="rect22025"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224232"
+             y="78.200493"
+             id="rect22027"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="7.1828671"
+             height="5.6819677"
+             x="-5.6926923"
+             y="77.130234"
+             id="rect22029"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.421451;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <g
+           transform="translate(67.840656,8.0673369)"
+           id="g22031-8"
+           style="display:inline">
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224236"
+             y="69.945557"
+             id="rect22033-1"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224236"
+             y="69.945557"
+             id="rect22035-5"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="7.1828671"
+             height="5.6819677"
+             x="-5.6926928"
+             y="68.87529"
+             id="rect22037-3"
+             style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.421451;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224232"
+             y="78.200493"
+             id="rect22039-5"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="5.0423279"
+             height="3.5414283"
+             x="-4.6224232"
+             y="78.200493"
+             id="rect22041-4"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#363333;stroke-width:3.76235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             width="7.1828671"
+             height="5.6819677"
+             x="-5.6926923"
+             y="77.130234"
+             id="rect22043-3"
+             style="display:inline;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.421451;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <path
+           inkscape:connector-curvature="0"
+           d="m -25.215112,86.725266 a 2.2513492,2.2513492 0 1 1 -4.502698,0 2.2513492,2.2513492 0 1 1 4.502698,0 z"
+           transform="translate(102.88665,-8.405037)"
+           id="path22045-6"
+           style="fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.4;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m -25.215112,86.725266 a 2.2513492,2.2513492 0 1 1 -4.502698,0 2.2513492,2.2513492 0 1 1 4.502698,0 z"
+           transform="translate(102.88665,-3.4520692)"
+           id="path22049-5"
+           style="display:inline;fill:#a40000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.4;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m -25.215112,86.725266 a 2.2513492,2.2513492 0 1 1 -4.502698,0 2.2513492,2.2513492 0 1 1 4.502698,0 z"
+           transform="translate(102.88665,1.6509881)"
+           id="path22051-9"
+           style="display:inline;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.4;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
+    <text
+       id="text1513"
+       y="261.08029"
+       x="117.94748"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="261.08029"
+         x="117.94748"
+         id="tspan2364"
+         sodipodi:role="line">Managed Switch</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="127.2843"
+       y="173.07938"
+       id="text2354"><tspan
+         sodipodi:role="line"
+         id="tspan2352"
+         x="127.2843"
+         y="173.07938"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">ISP Modem</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="72.595024"
+       y="261.45023"
+       id="text2368-7"><tspan
+         style="stroke-width:0.264583"
+         id="tspan2370-3"
+         sodipodi:role="line"
+         x="72.595024"
+         y="261.45023">VyOS</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="199.57973"
+       y="276.41812"
+       id="text2376"><tspan
+         style="stroke-width:0.264583"
+         y="276.41812"
+         x="199.57973"
+         id="tspan2378"
+         sodipodi:role="line">LAN Hosts</tspan></text>
+    <text
+       id="text2382"
+       y="214.58119"
+       x="197.32222"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="214.58119"
+         x="197.32222"
+         id="tspan2384"
+         sodipodi:role="line">DMZ Hosts</tspan></text>
+    <rect
+       y="201.13562"
+       x="133.91182"
+       height="5.9303169"
+       width="22.352728"
+       id="rect2398"
+       style="fill:#ffff06;fill-opacity:0.94;stroke-width:0.448082;stroke-miterlimit:4;stroke-dasharray:none" />
+    <text
+       id="text2396"
+       y="205.89499"
+       x="134.61108"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.9389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.9389px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
+         y="205.89499"
+         x="134.61108"
+         id="tspan2394"
+         sodipodi:role="line">VLAN 10</tspan></text>
+    <rect
+       style="fill:#ffff06;fill-opacity:0.94;stroke-width:0.448082;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2398-3"
+       width="22.352728"
+       height="5.9303174"
+       x="168.35295"
+       y="215.50523" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.9389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="169.05225"
+       y="220.26581"
+       id="text2396-2"><tspan
+         sodipodi:role="line"
+         id="tspan2394-6"
+         x="169.05225"
+         y="220.26581"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.9389px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">VLAN 20</tspan></text>
+    <rect
+       style="fill:#ffff06;fill-opacity:0.94;stroke-width:0.448082;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2398-8"
+       width="22.352728"
+       height="5.9303174"
+       x="172.2305"
+       y="247.20961" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.9389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="172.92978"
+       y="251.97018"
+       id="text2396-8"><tspan
+         sodipodi:role="line"
+         id="tspan2394-7"
+         x="172.92978"
+         y="251.97018"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.9389px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">VLAN 30</tspan></text>
+    <rect
+       style="fill:#ffff06;fill-opacity:0.94;stroke-width:0.375984;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2398-4"
+       width="15.738144"
+       height="5.9303174"
+       x="104.85342"
+       y="238.9984" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.9389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="105.57092"
+       y="243.80238"
+       id="text2396-9"><tspan
+         style="stroke-width:0.264583"
+         sodipodi:role="line"
+         id="tspan2452"
+         x="105.57092"
+         y="243.80238">Trunk</tspan></text>
+    <g
+       id="g1452"
+       transform="matrix(0.26458333,0,0,0.26458333,198.28604,173.06769)">
+      <g
+         style="display:inline"
+         id="layer1-41" />
+      <g
+         style="display:inline"
+         id="layer2-3">
+        <g
+           style="display:inline"
+           id="g6707-7"
+           transform="matrix(0.04030136,0,0,0.05919351,98.269348,107.74796)">
+          <rect
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#linearGradient8261);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+             id="rect6709-50"
+             y="-150.69685"
+             x="-1559.2523"
+             height="478.35718"
+             width="1339.6335" />
+          <path
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient25153-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+             id="path6711-2"
+             d="m -219.61876,-150.68038 c 0,0 0,478.33079 0,478.33079 142.874166,0.90045 345.40022,-107.16966 345.40014,-239.196175 0,-132.026537 -159.436816,-239.134595 -345.40014,-239.134615 z"
+             inkscape:connector-curvature="0" />
+          <path
+             style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient25155-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+             id="path6713-1"
+             d="m -1559.2523,-150.68038 c 0,0 0,478.33079 0,478.33079 -142.8742,0.90045 -345.4002,-107.16966 -345.4002,-239.196175 0,-132.026537 159.4368,-239.134595 345.4002,-239.134615 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           style="fill:url(#linearGradient8263);fill-opacity:1;fill-rule:evenodd;stroke:#5e5e5e;stroke-width:2.83663px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           id="path3626-8"
+           d="m 30.069752,22.03729 v 95.17786 H 92.475495 V 21.46393 L 80.994049,9.423358 H 40.977128 Z"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:#ffffff;fill-opacity:0.655367;fill-rule:evenodd;stroke:none"
+           id="path5791-7"
+           d="M 41.556086,10.841671 31.488067,25.024802 h 59.56912 l -10.90702,-13.76598 z"
+           inkscape:connector-curvature="0" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.348571;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="rect4553-1"
+           y="30.698046"
+           x="39.997936"
+           height="11.346502"
+           width="45.386024" />
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path4394-5"
+           d="M 32.906375,23.771924 V 114.3785 H 89.638911 V 23.248654 L 79.132886,12.260001 H 42.887099 Z"
+           inkscape:connector-curvature="0" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.525714;fill:url(#linearGradient8265);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient8267);stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="rect4408-5"
+           y="67.574181"
+           x="54.181065"
+           height="11.346499"
+           width="31.202894" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#acacac;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="rect4398-8"
+           y="66.155869"
+           x="52.762733"
+           height="11.346502"
+           width="31.202871" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.348571;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="rect4551-5"
+           y="47.7178"
+           x="39.997952"
+           height="11.346502"
+           width="45.386024" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#acacac;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="rect4430-6"
+           y="46.299488"
+           x="38.579624"
+           height="11.346502"
+           width="45.386032" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#c8c8c8;fill-opacity:1;fill-rule:evenodd;stroke:#acacac;stroke-width:2.83663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="rect4436-7"
+           y="29.279736"
+           x="38.579647"
+           height="11.346502"
+           width="45.386032" />
+        <path
+           style="display:inline;overflow:visible;visibility:visible;fill:#d40000;fill-opacity:1;fill-rule:evenodd;stroke:#979797;stroke-width:1.44773;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+           id="path4396-9"
+           transform="matrix(1.9593699,0,0,1.9593562,-86.509754,21.850696)"
+           d="m 68.185294,26.231213 a 2.171828,2.171828 0 1 1 -4.343656,0 2.171828,2.171828 0 1 1 4.343656,0 z"
+           inkscape:connector-curvature="0" />
+        <path
+           style="display:inline;overflow:visible;visibility:visible;fill:#f44800;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="path4445-4"
+           transform="matrix(2.5342538,0,0,2.5342343,0.4673221,7.5389146)"
+           d="m 16.667518,25.574614 a 0.5050765,0.5050765 0 1 1 -1.010153,0 0.5050765,0.5050765 0 1 1 1.010153,0 z"
+           inkscape:connector-curvature="0" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8269);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4457-1"
+           y="84.593979"
+           x="48.507816"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8271);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4461-6"
+           y="84.593979"
+           x="54.181038"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8273);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4465-1"
+           y="84.593979"
+           x="59.854286"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8275);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4469-2"
+           y="84.593979"
+           x="65.527534"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8277);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4473-0"
+           y="84.593979"
+           x="71.200821"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.542857;fill:url(#linearGradient8279);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4477-4"
+           y="84.593979"
+           x="76.874069"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.16;fill:url(#linearGradient8281);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4481-4"
+           y="84.593979"
+           x="45.671154"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.291429;fill:url(#linearGradient8283);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4483-5"
+           y="84.593979"
+           x="51.34444"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.291429;fill:url(#linearGradient8285);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4485-9"
+           y="84.593979"
+           x="57.017693"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.291429;fill:url(#linearGradient8287);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4487-7"
+           y="84.593979"
+           x="62.690945"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.291429;fill:url(#linearGradient8289);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4489-5"
+           y="84.593979"
+           x="68.364159"
+           height="28.36627"
+           width="2.8366244" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;opacity:0.228571;fill:url(#linearGradient8291);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           id="rect4491-3"
+           y="84.593979"
+           x="74.037407"
+           height="28.36627"
+           width="2.8366244" />
+      </g>
+    </g>
+    <text
+       id="text4043-9"
+       y="169.60492"
+       x="36.426685"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8.46667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         id="tspan4255"
+         sodipodi:role="line"
+         x="36.426685"
+         y="169.60492">Physical</tspan></text>
+  </g>
+</svg>

--- a/docs/appendix/examples/zone-policy.rst
+++ b/docs/appendix/examples/zone-policy.rst
@@ -18,7 +18,10 @@ We have three networks.
 This specific example is for a router on a stick, but is very easily adapted
 for however many NICs you have.
 
-[https://i.imgur.com/Alz1J.png Topology Image]
+.. image:: zone-policy-diagram.svg
+   :width: 80%
+   :align: center
+   :alt: Network Topology Diagram
 
 The VyOS interface is assigned the .1/:1 address of their respective networks.
 WAN is on VLAN 10, LAN on VLAN 20, and DMZ on VLAN 30.


### PR DESCRIPTION
I have re-drawn the missing diagram on the Zone Policy Example page as an SVG.

I have missed out some of text, because I thought it confused the diagram and the information does appear in the main article text.
