### PR TITLE
Docs: Fix typo and code-block errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Documentation Contribution
 
-Please follow the guid in our documentation. It can be found here:
+Please follow the guide in our documentation. It can be found here:
 https://docs.vyos.io/en/latest/contributing/documentation.html

--- a/docs/contributing/build-vyos.rst
+++ b/docs/contributing/build-vyos.rst
@@ -149,7 +149,7 @@ for whatever reason and you supect its a problem with APT dependencies or
 installation you can add this small patch which increases the APT verbosity
 during ISO build.
 
-.. code-block:: Python
+.. code-block:: diff
 
   diff --git i/scripts/live-build-config w/scripts/live-build-config
   index 1b3b454..3696e4e 100755

--- a/docs/routing/arp.rst
+++ b/docs/routing/arp.rst
@@ -26,7 +26,7 @@ Configure
 
    Example:
 
-   .. code-block::
+   .. code-block:: none
 
      set protocols static arp 192.0.2.100 hwaddr 00:53:27:de:23:aa
 


### PR DESCRIPTION
Typo fixed in CONTRIBUTING.md
docs/routing/arp.rst was missing an example because of a missing language tag
docs/contributing/build-vyos.rst troubleshooting diff highlighting wasn't working because the Python lexer didn't understand the code