### PR TITLE
bridge: typo, stp warning and indentation

### DIFF
--- a/docs/interfaces/bridge.rst
+++ b/docs/interfaces/bridge.rst
@@ -4,11 +4,15 @@
 Bridge
 ######
 
-A Bridge is a way to connect two Ethernet segments together in a protocol
-independent way. Packets are forwarded based on Ethernet address, rather than
-IP address (like a router). Since forwarding is done at Layer 2, all protocols
-can go transparently through a bridge. The Linux bridge code implements a
-subset of the ANSI/IEEE 802.1d standard.
+A Bridge is a way to connect two Ethernet segments together in a
+protocol independent way. Packets are forwarded based on Ethernet
+address, rather than IP address (like a router). Since forwarding is
+done at Layer 2, all protocols can go transparently through a bridge.
+The Linux bridge code implements a subset of the ANSI/IEEE 802.1d
+standard.
+
+.. note:: Spanning Tree Protocol is not enabled by default in VyOS.
+   :ref:`stp` can be easily enabled if needed.
 
 Configuration
 #############
@@ -16,16 +20,18 @@ Configuration
 Address
 -------
 
-.. cfgcmd:: set interfaces bridge <interface> address <address | dhcp | dhcpv6>
+.. cfgcmd:: set interfaces bridge <interface> address <address | dhcp |
+   dhcpv6>
 
-   Configure interface `<interface>` with one or more interface addresses.
+   Configure interface `<interface>` with one or more interface
+   addresses.
 
-   * **address** can be specified multiple times as IPv4 and/or IPv6 address,
-     e.g. 192.0.2.1/24 and/or 2001:db8::1/64
-   * **dhcp** interface address is received by DHCP from a DHCP server on this
-     segment.
-   * **dhcpv6** interface address is received by DHCPv6 from a DHCPv6 server on
-     this segment.
+   * **address** can be specified multiple times as IPv4 and/or IPv6
+     address, e.g. 192.0.2.1/24 and/or 2001:db8::1/64
+   * **dhcp** interface address is received by DHCP from a DHCP server
+     on this segment.
+   * **dhcpv6** interface address is received by DHCPv6 from a DHCPv6
+     server on this segment.
 
    Example:
 
@@ -41,10 +47,12 @@ Address
 
    .. include:: common-ipv6-addr-autoconf.txt
 
-.. cfgcmd:: set interfaces bridge <interface> ipv6 address eui64 <prefix>
+.. cfgcmd:: set interfaces bridge <interface> ipv6 address eui64
+   <prefix>
 
    :abbr:`EUI-64 (64-Bit Extended Unique Identifier)` as specified in
-   :rfc:`4291` allows a host to assign iteslf a unique 64-Bit IPv6 address.
+   :rfc:`4291` allows a host to assign iteslf a unique 64-Bit IPv6
+   address.
 
    .. code-block:: none
 
@@ -60,8 +68,8 @@ Address
 
    Bridge maximum aging `<time>` in seconds (default: 20).
 
-   If a another bridge in the spanning tree does not send out a hello packet
-   for a long period of time, it is assumed to be dead.
+   If a another bridge in the spanning tree does not send out a hello
+   packet for a long period of time, it is assumed to be dead.
 
 
 Link Administration
@@ -69,14 +77,14 @@ Link Administration
 
 .. cfgcmd:: set interfaces bridge <interface> description <description>
 
-   Assign given `<description>` to interface. Description will also be passed
-   to SNMP monitoring systems.
+   Assign given `<description>` to interface. Description will also be
+   passed to SNMP monitoring systems.
 
 
 .. cfgcmd:: set interfaces bridge <interface> disable
 
-   Disable given `<interface>`. It will be placed in administratively down
-   (``A/D``) state.
+   Disable given `<interface>`. It will be placed in administratively
+   down (``A/D``) state.
 
 
 .. cfgcmd:: set interfaces bridge <interface> disable-flow-control
@@ -86,8 +94,8 @@ Link Administration
 
 .. cfgcmd:: set interfaces bridge <interface> mac <mac-address>
 
-   Configure user defined :abbr:`MAC (Media Access Control)` address on given
-   `<interface>`.
+   Configure user defined :abbr:`MAC (Media Access Control)` address on
+   given `<interface>`.
 
 
 .. cfgcmd:: set interfaces bridge <interface> igmp querier
@@ -95,45 +103,53 @@ Link Administration
    Enable IGMP querier
 
 
+
 Member Interfaces
 -----------------
 
 .. cfgcmd:: set interfaces bridge <interface> member interface <member>
 
-   Assign `<member>` interface to bridge `<interface>`. A completion helper
-   will help you with all allowed interfaces which can be bridged. This includes
-   :ref:`ethernet-interface`, :ref:`bond-interface`, :ref:`l2tpv3-interface`,
-   :ref:`openvpn`, :ref:`vxlan-interface`, :ref:`wireless-interface`,
+   Assign `<member>` interface to bridge `<interface>`. A completion
+   helper will help you with all allowed interfaces which can be
+   bridged. This includes :ref:`ethernet-interface`,
+   :ref:`bond-interface`, :ref:`l2tpv3-interface`, :ref:`openvpn`,
+   :ref:`vxlan-interface`, :ref:`wireless-interface`,
    :ref:`tunnel-interface` and :ref:`geneve-interface`.
 
 
-.. cfgcmd:: set interfaces bridge <interface> member interface <member> priority <priority>
+.. cfgcmd:: set interfaces bridge <interface> member interface <member>
+   priority <priority>
 
    Configure individual bridge port `<priority>`.
 
-   Each bridge has a relative priority and cost. Each interface is associated
-   with a port (number) in the STP code. Each has a priority and a cost, that
-   is used to decide which is the shortest path to forward a packet. The lowest
-   cost path is always used unless the other path is down. If you have multiple
-   bridges and interfaces then you may need to adjust the priorities to achieve
-   optimium performance.
+   Each bridge has a relative priority and cost. Each interface is
+   associated with a port (number) in the STP code. Each has a priority
+   and a cost, that is used to decide which is the shortest path to
+   forward a packet. The lowest cost path is always used unless the
+   other path is down. If you have multiple bridges and interfaces then
+   you may need to adjust the priorities to achieve optimium
+   performance.
 
 
-.. cfgcmd:: set interfaces bridge <interface> member interface <member> cost <cost>
+.. cfgcmd:: set interfaces bridge <interface> member interface <member>
+   cost <cost>
 
-   Path `<cost>` value for Spanning Tree Protocol. Each interface in a bridge
-   could have a different speed and this value is used when deciding which
-   link to use. Faster interfaces should have lower costs.
+   Path `<cost>` value for Spanning Tree Protocol. Each interface in a
+   bridge could have a different speed and this value is used when
+   deciding which link to use. Faster interfaces should have lower
+   costs.
 
+
+.. _stp:
 
 STP Parameter
 -------------
 
 :abbr:`STP (Spanning Tree Protocol)` is a network protocol that builds a
-loop-free logical topology for Ethernet networks. The basic function of STP is
-to prevent bridge loops and the broadcast radiation that results from them.
-Spanning tree also allows a network design to include backup links providing
-fault tolerance if an active link fails.
+loop-free logical topology for Ethernet networks. The basic function of
+STP is to prevent bridge loops and the broadcast radiation that results
+from them. Spanning tree also allows a network design to include backup
+links providing fault tolerance if an active link fails.
 
 .. cfgcmd:: set interfaces bridge <interface> stp
 
@@ -145,9 +161,9 @@ fault tolerance if an active link fails.
    Spanning Tree Protocol forwarding `<delay>` in seconds (default: 15).
 
    Forwarding delay time is the time spent in each of the Listening and
-   Learning states before the Forwarding state is entered. This delay is so
-   that when a new bridge comes onto a busy network it looks at some traffic
-   before participating.
+   Learning states before the Forwarding state is entered. This delay is
+   so that when a new bridge comes onto a busy network it looks at some
+   traffic before participating.
 
 
 .. cfgcmd:: set interfaces bridge <interface> hello-time <interval>
@@ -156,14 +172,15 @@ fault tolerance if an active link fails.
    (default: 2).
 
    Periodically, a hello packet is sent out by the Root Bridge and the
-   Designated Bridges. Hello packets are used to communicate information about
-   the topology throughout the entire Bridged Local Area Network.
+   Designated Bridges. Hello packets are used to communicate information
+   about the topology throughout the entire Bridged Local Area Network.
 
 
-Exammple
---------
+Example
+-------
 
-Creating a bridge interface is very simple. In this example we will have:
+Creating a bridge interface is very simple. In this example we will
+have:
 
 * A bridge named `br100`
 * Member interfaces `eth1` and VLAN 10 on interface `eth2`
@@ -199,8 +216,8 @@ Operation
 
 .. opcmd:: show bridge
 
-   The `show bridge` operational command can be used to display configured
-   bridges:
+   The `show bridge` operational command can be used to display
+   configured bridges:
 
    .. code-block:: none
 


### PR DESCRIPTION
Fix typo, warn STP is not enabled by default, and adjust texts to 72 columns.