### PR TITLE
firewall: add link to ZBF intro, some format and indentation

### DIFF
--- a/docs/firewall.rst
+++ b/docs/firewall.rst
@@ -3,53 +3,63 @@
 Firewall
 ========
 
-VyOS makes use of Linux `netfilter <https://netfilter.org/>`_ for packet filtering.
+VyOS makes use of Linux `netfilter <https://netfilter.org/>`_ for packet
+filtering.
 
-The firewall supports the creation of groups for ports, addresses, and networks
-(implemented using netfilter ipset) and the option of interface or zone based
-firewall policy.
+The firewall supports the creation of groups for ports, addresses, and
+networks (implemented using netfilter ipset) and the option of interface
+or zone based firewall policy.
 
-**Important note on usage of terms:** The firewall makes use of the terms
-`in`, `out`, and `local` for firewall policy. Users experienced with netfilter
-often confuse `in` to be a reference to the `INPUT` chain, and `out` the
-`OUTPUT` chain from netfilter. This is not the case. These instead indicate the
-use of the `FORWARD` chain and either the input or output interface. The
-`INPUT` chain, which is used for local traffic to the OS, is a reference to
-as `local` with respect to its input interface.
+.. note:: **Important note on usage of terms:** 
+   The firewall makes use of the terms `in`, `out`, and `local`
+   for firewall policy. Users experienced with netfilter often confuse
+   `in` to be a reference to the `INPUT` chain, and `out` the `OUTPUT`
+   chain from netfilter. This is not the case. These instead indicate
+   the use of the `FORWARD` chain and either the input or output
+   interface. The `INPUT` chain, which is used for local traffic to the
+   OS, is a reference to as `local` with respect to its input interface.
 
 Zone-based Firewall Policy
 --------------------------
 
-As an alternative to applying policy to an interface directly, a zone-based
-firewall can be created to simplify configuration when multiple interfaces
-belong to the same security zone. Instead of applying to rulesets to interfaces
-they are applied to source zone-destination zone pairs.
+As an alternative to applying policy to an interface directly, a
+zone-based firewall can be created to simplify configuration when
+multiple interfaces belong to the same security zone. Instead of
+applying to rulesets to interfaces they are applied to source
+zone-destination zone pairs.
 
-An example to zone-based firewalls can be found here: :ref:`examples-zone-policy`.
+An introduction to zone-based firewalls can be found `here
+<https://support.vyos.io/en/kb/articles/a-primer-to-zone-based-firewall>`_,
+and an example at :ref:`examples-zone-policy`.
 
 Groups
 ------
 
-Firewall groups represent collections of IP addresses, networks, or ports. Once
-created, a group can be referenced by firewall rules as either a source or
-destination. Members can be added or removed from a group without changes to
-or the need to reload individual firewall rules.
+Firewall groups represent collections of IP addresses, networks, or
+ports. Once created, a group can be referenced by firewall rules as
+either a source or destination. Members can be added or removed from a
+group without changes to or the need to reload individual firewall
+rules.
 
 .. note:: Groups can also be referenced by NAT configuration.
 
-While **network groups** accept IP networks in CIDR notation, specific IP addresses
-can be added as a 32-bit prefix. If you foresee the need to add a mix of
-addresses and networks, the network group is recommended.
+While **network groups** accept IP networks in CIDR notation, specific
+IP addresses can be added as a 32-bit prefix. If you foresee the need
+to add a mix of addresses and networks, the network group is
+recommended.
 
-Here is an example of a network group for the IP networks that make up the
-internal network:
+Here is an example of a network group for the IP networks that make up
+the internal network:
 
 .. code-block:: none
 
   set firewall group network-group NET-INSIDE network 192.168.0.0/24
   set firewall group network-group NET-INSIDE network 192.168.1.0/24
 
-Groups need to have unique names. Even though some contain IPv4 addresses and others contain IPv6 addresses, they still need to have unique names, so you may want to append "-v4" or "-v6" to your group names.
+Groups need to have unique names. Even though some contain IPv4
+addresses and others contain IPv6 addresses, they still need to have
+unique names, so you may want to append "-v4" or "-v6" to your group
+names.
 
 .. code-block:: none
 
@@ -57,10 +67,11 @@ Groups need to have unique names. Even though some contain IPv4 addresses and ot
   set firewall group ipv6-network-group NET-INSIDE-v6 network 2001:db8::/64
 
 
-A **port group** represents only port numbers, not the protocol. Port groups can
-be referenced for either TCP or UDP. It is recommended that TCP and UDP groups
-are created separately to avoid accidentally filtering unnecessary ports.
-Ranges of ports can be specified by using `-`.
+A **port group** represents only port numbers, not the protocol. Port
+groups can be referenced for either TCP or UDP. It is recommended that
+TCP and UDP groups are created separately to avoid accidentally
+filtering unnecessary ports. Ranges of ports can be specified by using
+`-`.
 
 Here is an example of a port group a server:
 
@@ -73,9 +84,10 @@ Here is an example of a port group a server:
 Rule-Sets
 ---------
 
-A rule-set is a named collection of firewall rules that can be applied to an
-interface or zone. Each rule is numbered, has an action to apply if the rule
-is matched, and the ability to specify the criteria to match.
+A rule-set is a named collection of firewall rules that can be applied
+to an interface or zone. Each rule is numbered, has an action to apply
+if the rule is matched, and the ability to specify the criteria to
+match.
 
 Example of a rule-set to filter traffic to the internal network:
 
@@ -93,8 +105,8 @@ Applying a Rule-Set to an Interface
 
 Once a rule-set is created, it can be applied to an interface.
 
-.. note:: Only one rule-set can be applied to each interface for `in`, `out`,
-   or `local` traffic for each protocol (IPv4 and IPv6).
+.. note:: Only one rule-set can be applied to each interface for `in`,
+   `out`, or `local` traffic for each protocol (IPv4 and IPv6).
 
 .. code-block:: none
 
@@ -113,23 +125,34 @@ first be created):
 How VyOS replies when being pinged
 ----------------------------------
 
-By default, when VyOS receives an ICMP echo request packet destined for itself, it will answer with an ICMP echo reply, unless you avoid it through its firewall.
+By default, when VyOS receives an ICMP echo request packet destined for
+itself, it will answer with an ICMP echo reply, unless you avoid it
+through its firewall.
 
-With the firewall you can set rules to accept, drop or reject ICMP in, out or local traffic. You can also use the general **firewall all-ping** command. This command affects only to LOCAL (packets destined for your VyOS system), not to IN or OUT traffic.
+With the firewall you can set rules to accept, drop or reject ICMP in,
+out or local traffic. You can also use the general **firewall all-ping**
+command. This command affects only to LOCAL (packets destined for your
+VyOS system), not to IN or OUT traffic.
 
-.. note:: **firewall all-ping** affects only to LOCAL and it always behaves in the most restrictive way
+.. note:: **firewall all-ping** affects only to LOCAL and it always
+   behaves in the most restrictive way
 
 .. code-block:: none
 
   set firewall all-ping enable
 
-When the command above is set, VyOS will answer every ICMP echo request addressed to itself, but that will only happen if no other rule is applied dropping or rejecting local echo requests. In case of conflict, VyOS will not answer ICMP echo requests.
+When the command above is set, VyOS will answer every ICMP echo request
+addressed to itself, but that will only happen if no other rule is
+applied dropping or rejecting local echo requests. In case of conflict,
+VyOS will not answer ICMP echo requests.
 
 .. code-block:: none
 
   set firewall all-ping disable
 
-When the command above is set, VyOS will answer no ICMP echo request addressed to itself at all, no matter where it comes from or whether more specific rules are being applied to accept them.
+When the command above is set, VyOS will answer no ICMP echo request
+addressed to itself at all, no matter where it comes from or whether
+more specific rules are being applied to accept them.
 
 Example Partial Config
 ----------------------


### PR DESCRIPTION
Add link to Zone-Based Firewall KB introduction, edit some
format and adjust texts to 72 characters.