### PR TITLE
Fix of sample firewall rules for ESP

### DIFF
--- a/docs/vpn/l2tp.rst
+++ b/docs/vpn/l2tp.rst
@@ -39,7 +39,6 @@ Example:
 .. code-block:: none
 
   set firewall name OUTSIDE-LOCAL rule 40 action 'accept'
-  set firewall name OUTSIDE-LOCAL rule 40 destination port '50'
   set firewall name OUTSIDE-LOCAL rule 40 protocol 'esp'
   set firewall name OUTSIDE-LOCAL rule 41 action 'accept'
   set firewall name OUTSIDE-LOCAL rule 41 destination port '500'


### PR DESCRIPTION
Removed unneeded option "set firewall name OUTSIDE-LOCAL rule 40 destination port '50'" as committing with this rule will throw error + ESP doesnt have a direct destination port number