### PR TITLE
replace zeroconf address in mDNS repeater doc

### DIFF
--- a/docs/services/mdns-repeater.rst
+++ b/docs/services/mdns-repeater.rst
@@ -5,7 +5,7 @@ Starting with VyOS 1.2 a :abbr:`mDNS (Multicast DNS)` repeater functionality is
 provided. Additional information can be obtained from
 https://en.wikipedia.org/wiki/Multicast_DNS.
 
-Multicast DNS uses the 224.0.0.51 address, which is "administratively scoped"
+Multicast DNS uses the 224.0.0.251 address, which is "administratively scoped"
 and does not leave the subnet. It retransmits mDNS packets from one interface
 to other interfaces. This enables support for e.g. Apple Airplay devices across
 multiple VLANs.


### PR DESCRIPTION
The address 224.0.0.51 is a Zeroconf address, and not the address associated with mDNS (224.0.0.251) as outlined in the docs. This patch simply changes the zerconf address to be the appropriate mDNS address.

The Multicast address registry I used from IANA can be found here: https://www.iana.org/assignments/multicast-addresses/multicast-addresses.xhtml under `Local Network Control Block`