### PR TITLE
docs(syslog.rst): corrected en to an

### DIFF
--- a/docs/system/syslog.rst
+++ b/docs/system/syslog.rst
@@ -22,7 +22,7 @@ Console
 
 .. cfgcmd:: set system syslog console facility <keyword> level <keyword>
 
-Log syslog messages to ``/dev/console``, for en explanation on
+Log syslog messages to ``/dev/console``, for an explanation on
 :ref:`syslog_facilities` keywords and :ref:`syslog_severity_level` keywords
 see tables below.
 


### PR DESCRIPTION
This is a simple typo change, I noticed it when reading the documentation for syslog earlier.
It corrects `en` to `an`.

I have also noticed this is in `crux` as well, please let me know if I should raise a 2nd PR fixing it this branch.

Thanks,
dannyt66