### PR TITLE
Correct the scp URI

### DIFF
--- a/docs/configuration-overview.rst
+++ b/docs/configuration-overview.rst
@@ -320,7 +320,7 @@ different levels in the hierarchy.
      Possible completions:
        <Enter>       Save to system config file
        <file>        Save to file on local machine
-       scp://<user>:<passwd>@<host>/<file> Save to file on remote machine
+       scp://<user>:<passwd>@<host>:/<file> Save to file on remote machine
        ftp://<user>:<passwd>@<host>/<file> Save to file on remote machine
        tftp://<host>/<file>      Save to file on remote machine
      vyos@vyos# save tftp://192.168.0.100/vyos-test.config.boot
@@ -659,7 +659,7 @@ be ``config.boot-hostname.YYYYMMDD_HHMMSS``.
    Specify remote location of commit archive as any of the below
    :abbr:`URI (Uniform Resource Identifier)`
 
-   * ``scp://<user>:<passwd>@<host>/<dir>``
+   * ``scp://<user>:<passwd>@<host>:/<dir>``
    * ``sftp://<user>:<passwd>@<host>/<dir>``
    * ``ftp://<user>:<passwd>@<host>/<dir>``
    * ``tftp://<host>/<dir>``
@@ -699,7 +699,7 @@ to load it with the ``load`` command:
      Possible completions:
        <Enter>				        Load from system config file
        <file>			        	Load from file on local machine
-       scp://<user>:<passwd>@<host>/<file>	Load from file on remote machine
+       scp://<user>:<passwd>@<host>:/<file>	Load from file on remote machine
        sftp://<user>:<passwd>@<host>/<file>	Load from file on remote machine
        ftp://<user>:<passwd>@<host>/<file>	Load from file on remote machine
        http://<host>/<file>			Load from file on remote machine

--- a/docs/system/user-management.rst
+++ b/docs/system/user-management.rst
@@ -78,7 +78,7 @@ The third part is simply an identifier, and is for your own reference.
    using one of the following :abbr:`URIs (Uniform Resource Identifier)`:
 
    * ``<file>`` - Load from file on local filesystem path
-   * ``scp://<user>@<host>/<file>`` - Load via SCP from remote machine
+   * ``scp://<user>@<host>:/<file>`` - Load via SCP from remote machine
    * ``sftp://<user>@<host>/<file>`` - Load via SFTP from remote machine
    * ``ftp://<user>@<host>/<file>`` - Load via FTP from remote machine
    * ``http://<host>/<file>`` - Load via HTTP from remote machine


### PR DESCRIPTION
A standard `scp` call implies a ":" between the remote host
and the remote path. Let's reflect it in the doc to avoid
any confusion.