### PR TITLE
Fix code-blocks not displaying

### DIFF
--- a/docs/configuration/system/ip.rst
+++ b/docs/configuration/system/ip.rst
@@ -32,7 +32,7 @@ show commands
 
 See below the different parameters available for the IPv4 **show** command:
 
-.. code-block::
+.. code-block:: none
 
    vyos@vyos:~$ show ip
    Possible completions:
@@ -64,7 +64,7 @@ reset commands
 
 And the different IPv4 **reset** commands available:
 
-.. code-block::
+.. code-block:: none
 
    vyos@vyos:~$ reset ip 
    Possible completions:

--- a/docs/installation/cloud/cloud-init.rst
+++ b/docs/installation/cloud/cloud-init.rst
@@ -26,7 +26,7 @@ proper commands list by copying it from another router.
 
 Usage example (User-Data content):
 
-.. code-block::
+.. code-block:: none
 
    #cloud-config
    vyos_config_commands:

--- a/docs/installation/cloud/index.rst
+++ b/docs/installation/cloud/index.rst
@@ -5,6 +5,7 @@ Running VyOS in Cloud Environments
 
 
 .. toctree::
+   :maxdepth: 1
    :caption: Content
    
    cloud-init


### PR DESCRIPTION
- code-blocks were not displaying in two files
- lowered TOC depth in docs/installation/cloud/index.rst