### PR TITLE
Add information about specific VRF routing

### DIFF
--- a/docs/configuration/system/name-server.rst
+++ b/docs/configuration/system/name-server.rst
@@ -4,6 +4,8 @@
 System DNS
 ##########
 
+.. warning:: If you are configuring a VRF for management purposes, there is
+   currently no way to force system DNS traffic via a specific VRF.
 
 This section describes configuring DNS on the system, namely:
 


### PR DESCRIPTION
As this thread states:
https://forum.vyos.io/t/system-name-server-vrf-aware/6710

There is no way to force system DNS traffic via a specific VRF, which is a pretty common scenario.
For example one could expect that all system services like DNS, auth, syslog, NTP, etc would use the management VRF (as specified by the user).