### PR TITLE
Fix DHCP address syntax

### DIFF
--- a/docs/_include/interface-address-with-dhcp.txt
+++ b/docs/_include/interface-address-with-dhcp.txt
@@ -17,5 +17,5 @@
 
     set interfaces {{ var0 }} {{ var1 }} {{ var2 }} {{ var4 }} {{ var5 }} {{ var7 }} address 192.0.2.1/24
     set interfaces {{ var0 }} {{ var1 }} {{ var2 }} {{ var4 }} {{ var5 }} {{ var7 }} address 2001:db8::1/64
-    set interfaces {{ var0 }} {{ var1 }} {{ var2 }} {{ var4 }} {{ var5 }} {{ var7 }} dhcp
-    set interfaces {{ var0 }} {{ var1 }} {{ var2 }} {{ var4 }} {{ var5 }} {{ var7 }} dhcpv6
+    set interfaces {{ var0 }} {{ var1 }} {{ var2 }} {{ var4 }} {{ var5 }} {{ var7 }} address dhcp
+    set interfaces {{ var0 }} {{ var1 }} {{ var2 }} {{ var4 }} {{ var5 }} {{ var7 }} address dhcpv6


### PR DESCRIPTION
`dhcp` and `dhcpv6` were missing the `address` part of the line, and the command does not work.

Tested in 1.3.0 rc1