### PR TITLE
PING: T3634: Adding do not fragment to Ping

### DIFF
--- a/docs/troubleshooting/index.rst
+++ b/docs/troubleshooting/index.rst
@@ -36,6 +36,7 @@ section and are omitted from the output here):
        bypass-route
        count
        deadline
+       do-not-fragment
        flood
        interface
        interval


### PR DESCRIPTION
Here we're just making a small change to reflect
that we added do not fragment to ping.

Main PR is https://github.com/vyos/vyos-1x/pull/885