### PR TITLE
Changed typo in DHCP Failover

### DIFF
--- a/docs/configuration/service/dhcp-server.rst
+++ b/docs/configuration/service/dhcp-server.rst
@@ -357,7 +357,7 @@ Common configuration, valid for both primary and secondary node.
   set service dhcp-server shared-network-name NET-VYOS subnet 192.0.2.0/24 failover local-address '192.168.189.253'
   set service dhcp-server shared-network-name NET-VYOS subnet 192.0.2.0/24 failover name 'NET-VYOS'
   set service dhcp-server shared-network-name NET-VYOS subnet 192.0.2.0/24 failover peer-address '192.168.189.252'
-  set service dhcp-server shared-network-name NET-VYOS subnet 192.0.2.0/24 failover status 'primary'
+  set service dhcp-server shared-network-name NET-VYOS subnet 192.0.2.0/24 failover status 'secondary'
 
 .. _dhcp-server:v4_example_raw:
 


### PR DESCRIPTION
The secondary server in the DHCP failover example was set to primary. I assume this should be 'secondary' instead?

Edit: Should probably also be pushed/cherry picked in `equuleus` branch?