### PR TITLE
Rewrite eBGP example comments

### DIFF
--- a/docs/configuration/protocols/bgp.rst
+++ b/docs/configuration/protocols/bgp.rst
@@ -1043,9 +1043,9 @@ A simple eBGP configuration:
   set protocols bgp 65535 parameters router-id '192.168.0.2'
 
 
-Don't forget, the CIDR declared in the network statement MUST **exist in your
-routing table (dynamic or static), the best way to make sure that is true is
-creating a static route:**
+By default the prefix declared in the network statement does not need to exist in your
+routing table, but it is conventional to add it to prevent routing loops. 
+The best way to do that is to creat a static route:
 
 **Node 1:**
 
@@ -1087,9 +1087,9 @@ A simple BGP configuration via IPv6.
   set protocols bgp 65535 address-family ipv6-unicast network '2001:db8:2::/48'
   set protocols bgp 65535 parameters router-id '10.1.1.2'
 
-Don't forget, the CIDR declared in the network statement **MUST exist in your
-routing table (dynamic or static), the best way to make sure that is true is
-creating a static route:**
+By default the prefix declared in the network statement does not need to exist in your
+routing table, but it is conventional to add it to prevent routing loops. 
+The best way to do that is to creat a static route:
 
 **Node 1:**
 


### PR DESCRIPTION
Since 1.3 , prefixes used in BGP `network` statements don't need to exist in your routing table by default, but the examples at the bottom of the page hadn't been updated for this change.