### PR TITLE
Update link to the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Documentation Contribution
 
 Please follow the guide in our documentation. It can be found here:
-https://docs.vyos.io/en/latest/contributing/documentation.html
+https://docs.vyos.io/en/latest/documentation.html


### PR DESCRIPTION
The link in the contribution guide is now a 404. I believe this URL is what it's meant to point to.