### PR TITLE
Update dns.rst with forwarding source-address

### DIFF
--- a/docs/configuration/service/dns.rst
+++ b/docs/configuration/service/dns.rst
@@ -111,6 +111,11 @@ avoid being tracked by the provider of your upstream DNS server.
    The local IPv4 or IPv6 addresses to bind the DNS forwarder to. The forwarder
    will listen on this address for incoming connections.
 
+.. cfgcmd:: set service dns forwarding source-address <address>
+
+   The local IPv4 or IPv6 addresses to use as a source address for sending queries.
+   The forwarder will send forwarded outbound DNS requests from this address.
+
 .. cfgcmd:: set service dns forwarding no-serve-rfc1918
 
    This makes the server authoritatively not aware of: 10.in-addr.arpa,


### PR DESCRIPTION
Add documentation for "set service dns forwarding source-address <address>"
We needed this setting in a split-horizon DNS down a VPN tunnel to force the source address to a an IP that can be routed back instead of the VPN tunnel endpoint, but can only find it described in the command line currently.