### PR TITLE
VPN IPsec: Added a note related to rsa key

### DIFF
--- a/docs/configuration/vpn/ipsec.rst
+++ b/docs/configuration/vpn/ipsec.rst
@@ -135,7 +135,8 @@ install <key-pair nam>>". You may choose different length than 2048 of course.
   set pki key-pair ipsec-LEFT private key 'MIIEvgIBADAN...'
   [edit]
 
-Configuration commands will display.
+Configuration commands for the private and public key will be displayed on the 
+screen which needs to be set on the router first.
 Note the command with the public key 
 (set pki key-pair ipsec-LEFT public key 'MIIBIjANBgkqh...'). 
 Then do the same on the opposite router:


### PR DESCRIPTION
A private key is also needed to finish the ipsec setup which is not mentioned
in the section "Source tunnel from loopbacks/Setting up IPSec". I have added
for reference.