### PR TITLE
T4245: interface-eapol: Update for VyOS 1.4 PKI changes and parent CA behavior

### DIFF
--- a/docs/_include/interface-eapol.txt
+++ b/docs/_include/interface-eapol.txt
@@ -7,31 +7,35 @@ EAPoL comes with an identify option. We automatically use the interface MAC
 address as identity parameter.
 
 .. cfgcmd:: set interfaces {{ var0 }} <interface> {{ var2 }} {{ var3 }}
-  {{ var5 }} {{ var6 }} eapol ca-cert-file <file>
+  {{ var5 }} {{ var6 }} eapol ca-certificate <name>
 
-  SSL :abbr:`CA (Certificate Authority)` x509 PEM file used afor authentication
-  of the remote side.
+  Set the name of the SSL :abbr:`CA (Certificate Authority)` PKI entry used for
+  authentication of the remote side. If an intermediate CA certificate is
+  specified, then all parent CA certificates that exist in the PKI, such as the
+  root CA or additional intermediate CAs, will automatically be used during
+  certificate validation to ensure that the full chain of trust is available.
+
+  Example:
 
   .. code-block:: none
 
-    set interfaces {{ var0 }} {{ var1 }} {{ var2 }} {{ var4 }} {{ var5 }} {{ var7 }} eapol ca-cert-file /config/auth/ca.pem
+    set pki ca eapol-server-intermediate-ca <Server intermediate CA contents>
+    set pki ca eapol-server-root-ca <Server root CA contents>
+    set interfaces {{ var0 }} {{ var1 }} {{ var2 }} {{ var4 }} {{ var5 }} {{ var7 }} eapol ca-certificate eapol-server-intermediate-ca
 
 .. cfgcmd:: set interfaces {{ var0 }} <interface> {{ var2 }} {{ var3 }}
-  {{ var5 }} {{ var6 }} eapol cert-file <file>
+  {{ var5 }} {{ var6 }} eapol certificate <name>
 
-  SSL/x509 public certificate file provided by the client to authenticate
-  against the 802.1x system.
+  Set the name of the x509 client keypair used to authenticate against the
+  802.1x system. All parent CA certificates of the client certificate, such as
+  intermediate and root CAs, will be sent as part of the EAP-TLS handshake.
 
-  .. code-block:: none
-
-    set interfaces {{ var0 }} {{ var1 }} {{ var2 }} {{ var4 }} {{ var5 }} {{ var7 }} eapol cert-file /config/auth/public.pem
-
-.. cfgcmd:: set interfaces {{ var0 }} <interface> {{ var2 }} {{ var3 }}
-  {{ var5 }} {{ var6 }} eapol key-file <file>
-
-  SSL/x509 private certificate file provided by the client to authenticate
-  against the 802.1x system.
+  Example:
 
   .. code-block:: none
 
-    set interfaces {{ var0 }} {{ var1 }} {{ var2 }} {{ var4 }} {{ var5 }} {{ var7 }} eapol key-file /config/auth/private.key
+    set pki ca eapol-client-intermediate-ca <Client intermediate CA contents>
+    set pki ca eapol-client-root-ca <Client root CA contents>
+    set pki certificate eapol-client certificate <Client certificate contents>
+    set pki certificate eapol-client private key <Client private key contents>
+    set interfaces {{ var0 }} {{ var1 }} {{ var2 }} {{ var4 }} {{ var5 }} {{ var7 }} eapol certificate eapol-client


### PR DESCRIPTION
This PR updates the eapol documentation to account for the PKI changes introduced in VyOS 1.4. It also documents the parent CA behavior I've proposed at https://github.com/vyos/vyos-1x/pull/1227 (not yet merged).