### PR TITLE
Hardware requirements RAM 1024

### DIFF
--- a/docs/installation/install.rst
+++ b/docs/installation/install.rst
@@ -44,7 +44,7 @@ any other type of storage.
 Hardware requirements
 =====================
 
-The minimum system requirements are 512 MiB RAM and 2 GiB storage.
+The minimum system requirements are 1024 MiB RAM and 2 GiB storage.
 Depending on your use, you might need additional RAM and CPU resources e.g.
 when having multiple BGP full tables in your system.
 


### PR DESCRIPTION
512 MB is not enough for the full minimum operation of VYOS.
When adding a 466 MB image, it fails to boot into RAM and throws an "out of memory" error. Please change the minimum value of RAM from 512 to 1024.