### PR TITLE
quick-start: firewall has a new recent time syntax

### DIFF
--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -77,7 +77,7 @@ on specific addresses only.
 DHCP/DNS quick-start
 ####################
 
-The following settings will configure DHCP and DNS services on 
+The following settings will configure DHCP and DNS services on
 your internal/LAN network, where VyOS will act as the default gateway and
 DNS server.
 
@@ -156,7 +156,7 @@ blocks brute-forcing attempts:
   set firewall name OUTSIDE-LOCAL rule 30 destination port '22'
   set firewall name OUTSIDE-LOCAL rule 30 protocol 'tcp'
   set firewall name OUTSIDE-LOCAL rule 30 recent count '4'
-  set firewall name OUTSIDE-LOCAL rule 30 recent time '60'
+  set firewall name OUTSIDE-LOCAL rule 30 recent time 'minute'
   set firewall name OUTSIDE-LOCAL rule 30 state new 'enable'
 
   set firewall name OUTSIDE-LOCAL rule 31 action 'accept'


### PR DESCRIPTION
The syntax changed from integer to one of `second`, `minute`, `hour`.