### PR TITLE
BGP: add documentation for <solo> option in neighbor configuration

### DIFF
--- a/docs/configuration/protocols/bgp.rst
+++ b/docs/configuration/protocols/bgp.rst
@@ -850,6 +850,9 @@ For outbound updates the order of preference is:
    must create an IP prefix list for the specified BGP peer applied in inbound
    derection.
 
+.. cfgcmd:: set protocols bgp neighbor <address|interface> solo
+
+   This command prevents from sending back prefixes learned from the neighbor.
 
 BGP Scaling Configuration
 -------------------------


### PR DESCRIPTION
Add docuemntation for:
``
vyos@vyos# set protocols bgp 65540 neighbor 192.0.2.2 

Possible completions:
...
   solo   --->   Do not send back prefixes learned from the neighbor
...
``

