### PR TITLE
deletion of note related to nat

### DIFF
--- a/docs/configuration/firewall/index.rst
+++ b/docs/configuration/firewall/index.rst
@@ -154,8 +154,6 @@ either a source or destination. Members can be added or removed from a
 group without changes to, or the need to reload, individual firewall
 rules.
 
-.. note:: Groups can also be referenced by NAT configuration.
-
 Groups need to have unique names. Even though some contain IPv4
 addresses and others contain IPv6 addresses, they still need to have
 unique names, so you may want to append "-v4" or "-v6" to your group

--- a/docs/configuration/vpn/site2site_ipsec.rst
+++ b/docs/configuration/vpn/site2site_ipsec.rst
@@ -74,15 +74,18 @@ Each site-to-site peer has the next options:
 * ``connection-type`` - how to handle this connection process. Possible
   variants:
 
- * ``initiate`` - do initial connection to remote peer immediately after
+ * ``initiate`` - does initial connection to remote peer immediately after
    configuring and after boot. In this mode the connection will not be restarted
    in case of disconnection, therefore should be used only together with DPD or
    another session tracking methods;
 
- * ``respond`` - do not try to initiate a connection to a remote peer. In this
+ * ``respond`` - does not try to initiate a connection to a remote peer. In this
    mode, the IPSec session will be established only after initiation from a
    remote peer. Could be useful when there is no direct connectivity to the
    peer due to firewall or NAT in the middle of the local and remote side.
+
+ * ``none`` - loads the connection only, which then can be manually initiated or
+   used as a responder configuration.
 
 * ``default-esp-group`` - ESP group to use by default for traffic encryption.
   Might be overwritten by individual settings for tunnel or VTI interface


### PR DESCRIPTION
Removed the note from the firewall page as nat grouping is not added yet
Added the information about new option 'none' in the site-to-site ipsec vpn
page