### PR TITLE
ocserv. Added show user OTP key

### DIFF
--- a/docs/configuration/vpn/openconnect.rst
+++ b/docs/configuration/vpn/openconnect.rst
@@ -215,3 +215,9 @@ and then the OTP key.
 .. warning:: When using Time-based one-time password (TOTP) (OTP HOTP-time),
   be sure that the time on the server and the 
   OTP token generator are synchronized by NTP
+
+To display the configured OTP user settings, use the command:
+
+.. code-block:: none
+
+  show openconnect-server user <username> otp <full|key-b32|key-hex|qrcode|uri>


### PR DESCRIPTION
Information about command added:
`show openconnect-server user <username> otp <full | key-b32 | key-hex | qrcode | uri >`
[https://phabricator.vyos.net/T4420](https://phabricator.vyos.net/T4420)
