### PR TITLE
Fix typo in VMware section

### DIFF
--- a/docs/contributing/build-vyos.rst
+++ b/docs/contributing/build-vyos.rst
@@ -757,7 +757,9 @@ Run following command after building the ISO image.
 VMware
 ------
 
-Run following command after building the QEMU image.
+Requires ovftool already installed.
+
+Run following command after building the ISO image.
 
 .. code-block:: none
 


### PR DESCRIPTION
Fixed typo in VMware section. 
Added comment it requires ovftool already installed.