### PR TITLE
Add firewall connection-status nat documentation

### DIFF
--- a/docs/configuration/firewall/index.rst
+++ b/docs/configuration/firewall/index.rst
@@ -290,6 +290,12 @@ Matching criteria
 
 There are a lot of matching criteria against which the package can be tested.
 
+.. cfgcmd:: set firewall name <name> rule <1-999999> connection-status nat
+   [destination | source]
+.. cfgcmd:: set firewall ipv6-name <name> rule <1-999999> connection-status
+   nat [destination | source]
+
+   Match criteria based on nat connection status.
 
 .. cfgcmd:: set firewall name <name> rule <1-999999> source address
    [address | addressrange | CIDR]


### PR DESCRIPTION
Documentation for "firewall connection-status nat" feature.

cli new option:
```
vyos@vyos# set firewall name FOO rule 1 connection-status nat 
Possible completions:
   destination  Match connections that are subject to destination NAT
   source       Match connections that are subject to source NAT

vyos@vyos# set firewall ipv6-name FOO rule 1 connection-status nat 
Possible completions:
   destination  Match connections that are subject to destination NAT
   source       Match connections that are subject to source NAT
```