### PR TITLE
sstp: T4444. Port number changing support

### DIFF
--- a/docs/configuration/vpn/sstp.rst
+++ b/docs/configuration/vpn/sstp.rst
@@ -111,6 +111,11 @@ Configuration
   interfaces.
 
 
+.. cfgcmd:: set vpn sstp port <port>
+
+  Specifies the port `<port>` that the SSTP port will listen on (default 443).
+
+
 .. cfgcmd:: set vpn sstp client-ip-pool subnet <subnet>
 
   Use `<subnet>` as the IP pool for all connecting clients.


### PR DESCRIPTION
Added information on how to change the SSTP server port according to:
[sstp: T4444. Port number changing support](https://phabricator.vyos.net/T4444)
