### PR TITLE
Route-map - Extend options for ip next-hop match

### DIFF
--- a/docs/configuration/policy/route-map.rst
+++ b/docs/configuration/policy/route-map.rst
@@ -75,9 +75,24 @@ Route Map
    IP next-hop of route to match, based on access-list.
 
 .. cfgcmd:: set policy route-map <text> rule <1-65535> match ip nexthop
+   address <x.x.x.x>
+
+   IP next-hop of route to match, based on ip address.
+
+.. cfgcmd:: set policy route-map <text> rule <1-65535> match ip nexthop
+   prefix-len <0-32>
+
+   IP next-hop of route to match, based on prefix length.
+
+.. cfgcmd:: set policy route-map <text> rule <1-65535> match ip nexthop
    prefix-list <text>
 
    IP next-hop of route to match, based on prefix-list.
+
+.. cfgcmd:: set policy route-map <text> rule <1-65535> match ip nexthop
+   type <blackhole>
+
+   IP next-hop of route to match, based on type.
 
 .. cfgcmd:: set policy route-map <text> rule <1-65535> match ip route-source
    access-list <1-2699>


### PR DESCRIPTION
Update documentation for new feature request T4449, which adds more options to route-policy match ip nexthop