### PR TITLE
syntax and grammar check

### DIFF
--- a/docs/configexamples/l3vpn-hub-and-spoke.rst
+++ b/docs/configexamples/l3vpn-hub-and-spoke.rst
@@ -104,9 +104,10 @@ Configuration
 Step-1: Configuring IGP and enabling MPLS LDP
 =============================================
 
-At the first step we need to configure the IP/MPLS backbone network using OSPF as 
-IGP protocol and LDP as label-switching protocol for the base connectivity between 
-**P** (rovider), **P** (rovider) **E** (dge) and **R** (oute) **R** (eflector) nodes:
+At the first step we need to configure the IP/MPLS backbone network using OSPF 
+as IGP protocol and LDP as label-switching protocol for the base connectivity 
+between **P** (rovider), **P** (rovider) **E** (dge) and **R** (oute) **R** 
+(eflector) nodes:
 
 - VyOS-P1:
 
@@ -333,12 +334,9 @@ VPN (L3VPN) routes between them:
    set protocols bgp neighbor 10.0.0.7 peer-group 'RR_VPNv4'
    set protocols bgp neighbor 10.0.0.8 address-family ipv4-vpn route-reflector-client
    set protocols bgp neighbor 10.0.0.8 peer-group 'RR_VPNv4'
-   set protocols bgp neighbor 10.0.0.9 address-family ipv4-vpn route-reflector-client
-   set protocols bgp neighbor 10.0.0.9 peer-group 'RR_VPNv4'
    set protocols bgp neighbor 10.0.0.10 address-family ipv4-vpn route-reflector-client
    set protocols bgp neighbor 10.0.0.10 peer-group 'RR_VPNv4'
    set protocols bgp parameters cluster-id '10.0.0.1'
-   set protocols bgp parameters default no-ipv4-unicast
    set protocols bgp parameters log-neighbor-changes
    set protocols bgp parameters router-id '10.0.0.1'
    set protocols bgp peer-group RR_VPNv4 remote-as '65001'
@@ -353,12 +351,9 @@ VPN (L3VPN) routes between them:
    set protocols bgp neighbor 10.0.0.7 peer-group 'RR_VPNv4'
    set protocols bgp neighbor 10.0.0.8 address-family ipv4-vpn route-reflector-client
    set protocols bgp neighbor 10.0.0.8 peer-group 'RR_VPNv4'
-   set protocols bgp neighbor 10.0.0.9 address-family ipv4-vpn route-reflector-client
-   set protocols bgp neighbor 10.0.0.9 peer-group 'RR_VPNv4'
    set protocols bgp neighbor 10.0.0.10 address-family ipv4-vpn route-reflector-client
    set protocols bgp neighbor 10.0.0.10 peer-group 'RR_VPNv4'
    set protocols bgp parameters cluster-id '10.0.0.1'
-   set protocols bgp parameters default no-ipv4-unicast
    set protocols bgp parameters log-neighbor-changes
    set protocols bgp parameters router-id '10.0.0.2'
    set protocols bgp peer-group RR_VPNv4 remote-as '65001'
@@ -373,7 +368,6 @@ VPN (L3VPN) routes between them:
    set protocols bgp neighbor 10.0.0.1 peer-group 'RR_VPNv4'
    set protocols bgp neighbor 10.0.0.2 address-family ipv4-vpn nexthop-self
    set protocols bgp neighbor 10.0.0.2 peer-group 'RR_VPNv4'
-   set protocols bgp parameters default no-ipv4-unicast
    set protocols bgp parameters log-neighbor-changes
    set protocols bgp parameters router-id '10.0.0.7'
    set protocols bgp peer-group RR_VPNv4 remote-as '65001'
@@ -388,7 +382,6 @@ VPN (L3VPN) routes between them:
    set protocols bgp neighbor 10.0.0.1 peer-group 'RR_VPNv4'
    set protocols bgp neighbor 10.0.0.2 address-family ipv4-vpn nexthop-self
    set protocols bgp neighbor 10.0.0.2 peer-group 'RR_VPNv4'
-   set protocols bgp parameters default no-ipv4-unicast
    set protocols bgp parameters log-neighbor-changes
    set protocols bgp parameters router-id '10.0.0.8'
    set protocols bgp peer-group RR_VPNv4 remote-as '65001'
@@ -403,7 +396,6 @@ VPN (L3VPN) routes between them:
    set protocols bgp neighbor 10.0.0.1 peer-group 'RR_VPNv4'
    set protocols bgp neighbor 10.0.0.2 address-family ipv4-vpn nexthop-self
    set protocols bgp neighbor 10.0.0.2 peer-group 'RR_VPNv4'
-   set protocols bgp parameters default no-ipv4-unicast
    set protocols bgp parameters log-neighbor-changes
    set protocols bgp parameters router-id '10.0.0.10'
    set protocols bgp peer-group RR_VPNv4 remote-as '65001'
@@ -504,13 +496,13 @@ configured L3VPN parameters.
    set interfaces ethernet eth0 address '10.50.50.2/24'
    
    # BGP for peering with PE
-   set protocols bgp 65035 address-family ipv4-unicast network 10.0.0.80/32
-   set protocols bgp 65035 neighbor 10.50.50.1 ebgp-multihop '2'
-   set protocols bgp 65035 neighbor 10.50.50.1 remote-as '65001'
-   set protocols bgp 65035 neighbor 10.50.50.1 update-source 'eth0'
-   set protocols bgp 65035 parameters default no-ipv4-unicast
-   set protocols bgp 65035 parameters log-neighbor-changes
-   set protocols bgp 65035 parameters router-id '10.50.50.2'
+   set protocols bgp local-as 65035 
+   set protocols bgp address-family ipv4-unicast network 10.0.0.80/32
+   set protocols bgp neighbor 10.50.50.1 ebgp-multihop '2'
+   set protocols bgp neighbor 10.50.50.1 remote-as '65001'
+   set protocols bgp neighbor 10.50.50.1 update-source 'eth0'
+   set protocols bgp parameters log-neighbor-changes
+   set protocols bgp parameters router-id '10.50.50.2'
 
 - VyOS-CE1-HUB:
 
@@ -521,14 +513,14 @@ configured L3VPN parameters.
    set interfaces ethernet eth0 address '10.80.80.2/24'
    
    # BGP for peering with PE
-   set protocols bgp 65035 address-family ipv4-unicast network 10.0.0.100/32
-   set protocols bgp 65035 address-family ipv4-unicast redistribute connected
-   set protocols bgp 65035 neighbor 10.80.80.1 ebgp-multihop '2'
-   set protocols bgp 65035 neighbor 10.80.80.1 remote-as '65001'
-   set protocols bgp 65035 neighbor 10.80.80.1 update-source 'eth0'
-   set protocols bgp 65035 parameters default no-ipv4-unicast
-   set protocols bgp 65035 parameters log-neighbor-changes
-   set protocols bgp 65035 parameters router-id '10.80.80.2'
+   set protocols bgp local-as 65035 
+   set protocols bgp address-family ipv4-unicast network 10.0.0.100/32
+   set protocols bgp address-family ipv4-unicast redistribute connected
+   set protocols bgp neighbor 10.80.80.1 ebgp-multihop '2'
+   set protocols bgp neighbor 10.80.80.1 remote-as '65001'
+   set protocols bgp neighbor 10.80.80.1 update-source 'eth0'
+   set protocols bgp parameters log-neighbor-changes
+   set protocols bgp parameters router-id '10.80.80.2'
 
 - VyOS-CE2-SPOKE:
 
@@ -539,13 +531,13 @@ configured L3VPN parameters.
    set interfaces ethernet eth0 address '10.60.60.2/24'
    
    # BGP for peering with PE 
-   set protocols bgp 65035 address-family ipv4-unicast network 10.0.0.90/32
-   set protocols bgp 65035 neighbor 10.60.60.1 ebgp-multihop '2'
-   set protocols bgp 65035 neighbor 10.60.60.1 remote-as '65001'
-   set protocols bgp 65035 neighbor 10.60.60.1 update-source 'eth0'
-   set protocols bgp 65035 parameters default no-ipv4-unicast
-   set protocols bgp 65035 parameters log-neighbor-changes
-   set protocols bgp 65035 parameters router-id '10.60.60.2'
+   set protocols bgp local-as 65035 
+   set protocols bgp address-family ipv4-unicast network 10.0.0.90/32
+   set protocols bgp neighbor 10.60.60.1 ebgp-multihop '2'
+   set protocols bgp neighbor 10.60.60.1 remote-as '65001'
+   set protocols bgp neighbor 10.60.60.1 update-source 'eth0'
+   set protocols bgp parameters log-neighbor-changes
+   set protocols bgp parameters router-id '10.60.60.2'
 
 
 

--- a/docs/configuration/interfaces/openvpn.rst
+++ b/docs/configuration/interfaces/openvpn.rst
@@ -332,7 +332,7 @@ before using under the openvpn interface configuration.
 
 Now we need to specify the server network settings. In all cases we need to
 specify the subnet for client tunnel endpoints. Since we want clients to access
-a specific network behind out router, we will use a push-route option for
+a specific network behind our router, we will use a push-route option for
 installing that route on clients.
 
 .. code-block:: none

--- a/docs/configuration/vrf/index.rst
+++ b/docs/configuration/vrf/index.rst
@@ -197,7 +197,7 @@ Example
 VRF route leaking
 -----------------
 
-The following example topology was build using EVE-NG.
+The following example topology was built using EVE-NG.
 
 .. figure:: /_static/images/vrf-example-topology-01.png
    :alt: VRF topology example
@@ -338,7 +338,7 @@ VRF Route Leaking
 BGP routes may be leaked (i.e. copied) between a unicast VRF RIB and the VPN
 SAFI RIB of the default VRF for use in MPLS-based L3VPNs. Unicast routes may 
 also be leaked between any VRFs (including the unicast RIB of the default BGP
-instanced). A shortcut syntax is also available for specifying leaking from 
+instance). A shortcut syntax is also available for specifying leaking from 
 one VRF to another VRF using the default instance’s VPN RIB as the intemediary
 . A common application of the VRF-VRF feature is to connect a customer’s 
 private routing domain to a provider’s VPN service. Leaking is configured from

--- a/docs/contributing/build-vyos.rst
+++ b/docs/contributing/build-vyos.rst
@@ -23,7 +23,7 @@ also set up your own build machine and run a :ref:`build_native`.
    The source code remains public and an ISO can be built using the process
    outlined in this chapter.
 
-This will guide you though the process of building a VyOS ISO using Docker_.
+This will guide you through the process of building a VyOS ISO using Docker_.
 This process has been tested on clean installs of Debian Jessie, Stretch, and
 Buster.
 
@@ -59,11 +59,11 @@ yourusername``.
 Build Container
 ---------------
 
-The container can built by hand or by fetching the pre-built one from DockerHub.
-Using the pre-built containers from the `VyOS DockerHub organisation`_ will
-ensure that the container is always up-to-date. A rebuild is triggered once the
-container changes (please note this will take 2-3 hours after pushing to the
-vyos-build repository).
+The container can be built by hand or by fetching the pre-built one from 
+DockerHub. Using the pre-built containers from the `VyOS DockerHub 
+organisation`_ will ensure that the container is always up-to-date. A rebuild 
+is triggered once the container changes (please note this will take 2-3 hours 
+after pushing to the vyos-build repository).
 
 .. note: If you are using the pre-built container, it will be automatically
    downloaded from DockerHub if it is not found on your local machine when
@@ -131,7 +131,7 @@ your development containers in your current working directory.
 
 .. note:: Some VyOS packages (namely vyos-1x) come with build-time tests which
    verify some of the internal library calls that they work as expected. Those
-   tests are carried out through the Python Unittest module. If you wan't to
+   tests are carried out through the Python Unittest module. If you want to
    build the ``vyos-1x`` package (which is our main development package) you need
    to start your Docker container using the following argument:
    ``--sysctl net.ipv6.conf.lo.disable_ipv6=0``, otherwise those tests will fail.
@@ -304,8 +304,8 @@ more or less similar looking error message:
   (10:13) vyos_bld ece068908a5b:/vyos [current] #
 
 To debug the build process and gain additional information of what could be the
-root cause wou need to `chroot` into the build directry. This is explained in
-the following step by step procedure:
+root cause, you need to use `chroot` to change into the build directry. This is 
+explained in the following step by step procedure:
 
 .. code-block:: none
 
@@ -729,7 +729,7 @@ package from our GitHub organisation - this is the place to be.
 Any "modified" package may refer to an altered version of e.g. vyos-1x package
 that you would like to test before filing a pull request on GitHub.
 
-Building an ISO with any customized package is in no way different then
+Building an ISO with any customized package is in no way different than
 building a regular (customized or not) ISO image. Simply place your modified
 `*.deb` package inside the `packages` folder within `vyos-build`. The build
 process will then pickup your custom package and integrate it into your ISO.
@@ -771,7 +771,7 @@ Virtualization Platforms
 QEMU
 ----
 
-Run following command after building the ISO image.
+Run the following command after building the ISO image.
 
 .. code-block:: none
 
@@ -780,7 +780,7 @@ Run following command after building the ISO image.
 VMware
 ------
 
-Run following command after building the QEMU image.
+Run the following command after building the QEMU image.
 
 .. code-block:: none
 


### PR DESCRIPTION
Modified the grammatical  errors and bgp syntax which is modified in the
latest rolling version
`set protocols bgp parameters default no-ipv4-unicast` doesn't exist and the setting is set by default now