### PR TITLE
route-map match prefix-len command

### DIFF
--- a/docs/configuration/policy/route-map.rst
+++ b/docs/configuration/policy/route-map.rst
@@ -69,6 +69,13 @@ Route Map
 
    IP address of route to match, based on prefix-list.
 
+.. cfgcmd:: set policy route-map <text> rule <1-65535> match ip address
+   prefix-len <0-32>
+
+   IP address of route to match, based on specified prefix-length.
+   Note that this does not work with BGP routes.
+   When applied to BGP it can lead to unexpected results.
+
 .. cfgcmd:: set policy route-map <text> rule <1-65535> match ip nexthop
    access-list <1-2699>
 
@@ -98,6 +105,13 @@ Route Map
    prefix-list <text>
 
    IPv6 address of route to match, based on IPv6 prefix-list.
+
+.. cfgcmd:: set policy route-map <text> rule <1-65535> match ipv6 address
+   prefix-len <0-128>
+
+   IPv6 address of route to match, based on specified prefix-length.
+   Note that this match rule does not work with BGP routes.
+   When applied to BGP it can lead to unexpected results.
 
 .. cfgcmd:: set policy route-map <text> rule <1-65535> match ipv6 nexthop
    <h:h:h:h:h:h:h:h>


### PR DESCRIPTION
Information about commands added:
set policy route-map <text> rule <1-65535> match ipv address
   prefix-len <0-32>
set policy route-map <text> rule <1-65535> match ipv6 address
   prefix-len <0-128>