### PR TITLE
Update sstp.rst

### DIFF
--- a/docs/configuration/vpn/sstp.rst
+++ b/docs/configuration/vpn/sstp.rst
@@ -158,9 +158,6 @@ SSL Certificates
 
   Path to `<file>` pointing to the servers certificate (public portion).
 
-.. cfgcmd:: set vpn sstp ssl key-file <file>
-
-  Path to `<file>` pointing to the servers certificate (private portion).
 
 PPP Settings
 ------------


### PR DESCRIPTION
The command path:
set vpn sstp ssl key-file <file>

Does not appear to exist anymore, as per https://github.com/vyos/vyos-1x/pull/1038
Can the doc be updated with instructions on SSTP setup with new command structure?