### PR TITLE
Update dhcp-relay

### DIFF
--- a/docs/configuration/service/dhcp-relay.rst
+++ b/docs/configuration/service/dhcp-relay.rst
@@ -78,6 +78,7 @@ The generated configuration will look like:
 
   show service dhcp-relay
       interface eth1
+      interface eth2
       server 10.0.1.4
       relay-options {
          relay-agents-packets discard


### PR DESCRIPTION
Add interface configuration which was missing in the example.
It is required to define both interfaces in the config, otherwise it doesn't work.
In 1.4 docs this config is OK. Now adding it to equuleus