### PR TITLE
traffic-policy: T2721: Update docs to indicate fq-codel is the default leaf queuing discipline for shaper/HTB

### DIFF
--- a/docs/configuration/trafficpolicy/index.rst
+++ b/docs/configuration/trafficpolicy/index.rst
@@ -325,7 +325,7 @@ setting allows these combinations. You will be able to use it
 in many policies.
 
 .. note:: Some policies already include other embedded policies inside.
-   That is the case of Shaper_: each of its classes use fair-queue
+   That is the case of Shaper_: each of its classes use fq-codel
    unless you change it.
 
 .. _creating_a_traffic_policy:


### PR DESCRIPTION
This is the documentation update for [https://github.com/vyos/vyatta-cfg-qos/pull/17](https://github.com/vyos/vyatta-cfg-qos/pull/17) to indicate that the default leaf qdisc is now `fq-codel` as opposed to `fair-queue`.