### PR TITLE
Update documentation.rst

### DIFF
--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -392,7 +392,7 @@ All RST files must follow the same TOC Level syntax and have to start with
 .. code-block::
 
    #####
-   Titel
+   Title
    #####
 
 Configuration mode pages


### PR DESCRIPTION
Fixed typo in the 'page content' section. "Title" was misspelt.