### PR TITLE
ipsec: T4118: Change IPSec syntax

### DIFF
--- a/docs/configuration/vpn/site2site_ipsec.rst
+++ b/docs/configuration/vpn/site2site_ipsec.rst
@@ -27,7 +27,8 @@ Each site-to-site peer has the next options:
 * ``authentication`` - configure authentication between VyOS and a remote peer.
   Suboptions:
 
- * ``id`` - ID for the local VyOS router. If defined, during the authentication
+ * ``local-id`` - ID for the local VyOS router. If defined, during the
+   authentication
    it will be send to remote peer;
 
  * ``mode`` - mode for authentication between VyOS and remote peer:
@@ -96,21 +97,15 @@ Each site-to-site peer has the next options:
 * ``dhcp-interface`` - use an IP address, received from DHCP for IPSec
   connection with this peer, instead of ``local-address``;
 
-* ``force-encapsulation`` - force encapsulation of ESP into UDP datagrams.
+* ``force-udp-encapsulation`` - force encapsulation of ESP into UDP datagrams.
   Useful in case if between local and remote side is firewall or NAT, which not
   allows passing plain ESP packets between them;
 
 * ``ike-group`` - IKE group to use for key exchanges;
 
 * ``ikev2-reauth`` - reauthenticate remote peer during the rekeying process.
-  Can be used only with IKEv2:
-
- * ``yes`` - create a new IKE_SA from the scratch and try to recreate all
-   IPsec SAs;
-
- * ``no`` - rekey without uninstalling the IPsec SAs;
-
- * ``inherit`` - use default behavior for the used IKE group.
+  Can be used only with IKEv2.
+  Create a new IKE_SA from the scratch and try to recreate all IPsec SAs;
 
 * ``local-address`` - local IP address for IPSec connection with this peer.
   If defined ``any``, then an IP address which configured on interface with
@@ -170,50 +165,46 @@ Example:
 .. code-block:: none
 
   # server config
-  set vpn ipsec esp-group office-srv-esp compression 'disable'
   set vpn ipsec esp-group office-srv-esp lifetime '1800'
   set vpn ipsec esp-group office-srv-esp mode 'tunnel'
   set vpn ipsec esp-group office-srv-esp pfs 'enable'
   set vpn ipsec esp-group office-srv-esp proposal 1 encryption 'aes256'
   set vpn ipsec esp-group office-srv-esp proposal 1 hash 'sha1'
-  set vpn ipsec ike-group office-srv-ike ikev2-reauth 'no'
   set vpn ipsec ike-group office-srv-ike key-exchange 'ikev1'
   set vpn ipsec ike-group office-srv-ike lifetime '3600'
   set vpn ipsec ike-group office-srv-ike proposal 1 encryption 'aes256'
   set vpn ipsec ike-group office-srv-ike proposal 1 hash 'sha1'
   set vpn ipsec interface 'eth1'
-  set vpn ipsec site-to-site peer 203.0.113.2 authentication mode 'pre-shared-secret'
-  set vpn ipsec site-to-site peer 203.0.113.2 authentication pre-shared-secret 'SomePreSharedKey'
-  set vpn ipsec site-to-site peer 203.0.113.2 ike-group 'office-srv-ike'
-  set vpn ipsec site-to-site peer 203.0.113.2 local-address '198.51.100.3'
-  set vpn ipsec site-to-site peer 203.0.113.2 tunnel 0 allow-nat-networks 'disable'
-  set vpn ipsec site-to-site peer 203.0.113.2 tunnel 0 allow-public-networks 'disable'
-  set vpn ipsec site-to-site peer 203.0.113.2 tunnel 0 esp-group 'office-srv-esp'
-  set vpn ipsec site-to-site peer 203.0.113.2 tunnel 0 local prefix '192.168.0.0/24'
-  set vpn ipsec site-to-site peer 203.0.113.2 tunnel 0 remote prefix '10.0.0.0/21'
+  set vpn ipsec site-to-site peer OFFICE-B authentication mode 'pre-shared-secret'
+  set vpn ipsec site-to-site peer OFFICE-B authentication pre-shared-secret 'SomePreSharedKey'
+  set vpn ipsec site-to-site peer OFFICE-B authentication remote-id '203.0.113.2'
+  set vpn ipsec site-to-site peer OFFICE-B ike-group 'office-srv-ike'
+  set vpn ipsec site-to-site peer OFFICE-B local-address '198.51.100.3'
+  set vpn ipsec site-to-site peer OFFICE-B remote-address '203.0.113.2'
+  set vpn ipsec site-to-site peer OFFICE-B tunnel 0 esp-group 'office-srv-esp'
+  set vpn ipsec site-to-site peer OFFICE-B tunnel 0 local prefix '192.168.0.0/24'
+  set vpn ipsec site-to-site peer OFFICE-B tunnel 0 remote prefix '10.0.0.0/21'
 
   # remote office config
-  set vpn ipsec esp-group office-srv-esp compression 'disable'
   set vpn ipsec esp-group office-srv-esp lifetime '1800'
   set vpn ipsec esp-group office-srv-esp mode 'tunnel'
   set vpn ipsec esp-group office-srv-esp pfs 'enable'
   set vpn ipsec esp-group office-srv-esp proposal 1 encryption 'aes256'
   set vpn ipsec esp-group office-srv-esp proposal 1 hash 'sha1'
-  set vpn ipsec ike-group office-srv-ike ikev2-reauth 'no'
   set vpn ipsec ike-group office-srv-ike key-exchange 'ikev1'
   set vpn ipsec ike-group office-srv-ike lifetime '3600'
   set vpn ipsec ike-group office-srv-ike proposal 1 encryption 'aes256'
   set vpn ipsec ike-group office-srv-ike proposal 1 hash 'sha1'
   set vpn ipsec interface 'eth1'
-  set vpn ipsec site-to-site peer 198.51.100.3 authentication mode 'pre-shared-secret'
-  set vpn ipsec site-to-site peer 198.51.100.3 authentication pre-shared-secret 'SomePreSharedKey'
-  set vpn ipsec site-to-site peer 198.51.100.3 ike-group 'office-srv-ike'
-  set vpn ipsec site-to-site peer 198.51.100.3 local-address '203.0.113.2'
-  set vpn ipsec site-to-site peer 198.51.100.3 tunnel 0 allow-nat-networks 'disable'
-  set vpn ipsec site-to-site peer 198.51.100.3 tunnel 0 allow-public-networks 'disable'
-  set vpn ipsec site-to-site peer 198.51.100.3 tunnel 0 esp-group 'office-srv-esp'
-  set vpn ipsec site-to-site peer 198.51.100.3 tunnel 0 local prefix '10.0.0.0/21'
-  set vpn ipsec site-to-site peer 198.51.100.3 tunnel 0 remote prefix '192.168.0.0/24'
+  set vpn ipsec site-to-site peer OFFICE-A authentication mode 'pre-shared-secret'
+  set vpn ipsec site-to-site peer OFFICE-A authentication pre-shared-secret 'SomePreSharedKey'
+  set vpn ipsec site-to-site peer OFFICE-A authentication remote-id '198.51.100.3'
+  set vpn ipsec site-to-site peer OFFICE-A ike-group 'office-srv-ike'
+  set vpn ipsec site-to-site peer OFFICE-A local-address '203.0.113.2'
+  set vpn ipsec site-to-site peer OFFICE-A remote-address '198.51.100.3'
+  set vpn ipsec site-to-site peer OFFICE-A tunnel 0 esp-group 'office-srv-esp'
+  set vpn ipsec site-to-site peer OFFICE-A tunnel 0 local prefix '10.0.0.0/21'
+  set vpn ipsec site-to-site peer OFFICE-A tunnel 0 remote prefix '192.168.0.0/24'
 
 Show status of new setup:
 
@@ -292,30 +283,28 @@ Imagine the following topology
 
   set interfaces vti vti10 address '10.0.0.2/31'
 
-  set vpn ipsec esp-group ESP_DEFAULT compression 'disable'
   set vpn ipsec esp-group ESP_DEFAULT lifetime '3600'
   set vpn ipsec esp-group ESP_DEFAULT mode 'tunnel'
   set vpn ipsec esp-group ESP_DEFAULT pfs 'dh-group19'
   set vpn ipsec esp-group ESP_DEFAULT proposal 10 encryption 'aes256gcm128'
   set vpn ipsec esp-group ESP_DEFAULT proposal 10 hash 'sha256'
-  set vpn ipsec ike-group IKEv2_DEFAULT ikev2-reauth 'no'
   set vpn ipsec ike-group IKEv2_DEFAULT key-exchange 'ikev2'
   set vpn ipsec ike-group IKEv2_DEFAULT lifetime '10800'
-  set vpn ipsec ike-group IKEv2_DEFAULT mobike 'disable'
+  set vpn ipsec ike-group IKEv2_DEFAULT disable-mobike
   set vpn ipsec ike-group IKEv2_DEFAULT proposal 10 dh-group '19'
   set vpn ipsec ike-group IKEv2_DEFAULT proposal 10 encryption 'aes256gcm128'
   set vpn ipsec ike-group IKEv2_DEFAULT proposal 10 hash 'sha256'
   set vpn ipsec interface 'eth0.201'
-  set vpn ipsec site-to-site peer 172.18.202.10 authentication id '172.18.201.10'
-  set vpn ipsec site-to-site peer 172.18.202.10 authentication mode 'pre-shared-secret'
-  set vpn ipsec site-to-site peer 172.18.202.10 authentication pre-shared-secret 'secretkey'
-  set vpn ipsec site-to-site peer 172.18.202.10 authentication remote-id '172.18.202.10'
-  set vpn ipsec site-to-site peer 172.18.202.10 connection-type 'respond'
-  set vpn ipsec site-to-site peer 172.18.202.10 ike-group 'IKEv2_DEFAULT'
-  set vpn ipsec site-to-site peer 172.18.202.10 ikev2-reauth 'inherit'
-  set vpn ipsec site-to-site peer 172.18.202.10 local-address '192.168.0.10'
-  set vpn ipsec site-to-site peer 172.18.202.10 vti bind 'vti10'
-  set vpn ipsec site-to-site peer 172.18.202.10 vti esp-group 'ESP_DEFAULT'
+  set vpn ipsec site-to-site peer OFFICE-B authentication local-id '172.18.201.10'
+  set vpn ipsec site-to-site peer OFFICE-B authentication mode 'pre-shared-secret'
+  set vpn ipsec site-to-site peer OFFICE-B authentication pre-shared-secret 'secretkey'
+  set vpn ipsec site-to-site peer OFFICE-B authentication remote-id '172.18.202.10'
+  set vpn ipsec site-to-site peer OFFICE-B connection-type 'respond'
+  set vpn ipsec site-to-site peer OFFICE-B ike-group 'IKEv2_DEFAULT'
+  set vpn ipsec site-to-site peer OFFICE-B local-address '192.168.0.10'
+  set vpn ipsec site-to-site peer OFFICE-B remote-address '172.18.202.10'
+  set vpn ipsec site-to-site peer OFFICE-B vti bind 'vti10'
+  set vpn ipsec site-to-site peer OFFICE-B vti esp-group 'ESP_DEFAULT'
 
 **right**
 
@@ -323,7 +312,6 @@ Imagine the following topology
 
   set interfaces vti vti10 address '10.0.0.3/31'
 
-  set vpn ipsec esp-group ESP_DEFAULT compression 'disable'
   set vpn ipsec esp-group ESP_DEFAULT lifetime '3600'
   set vpn ipsec esp-group ESP_DEFAULT mode 'tunnel'
   set vpn ipsec esp-group ESP_DEFAULT pfs 'dh-group19'
@@ -332,31 +320,30 @@ Imagine the following topology
   set vpn ipsec ike-group IKEv2_DEFAULT dead-peer-detection action 'restart'
   set vpn ipsec ike-group IKEv2_DEFAULT dead-peer-detection interval '30'
   set vpn ipsec ike-group IKEv2_DEFAULT dead-peer-detection timeout '120'
-  set vpn ipsec ike-group IKEv2_DEFAULT ikev2-reauth 'no'
   set vpn ipsec ike-group IKEv2_DEFAULT key-exchange 'ikev2'
   set vpn ipsec ike-group IKEv2_DEFAULT lifetime '10800'
-  set vpn ipsec ike-group IKEv2_DEFAULT mobike 'disable'
+  set vpn ipsec ike-group IKEv2_DEFAULT disable-mobike
   set vpn ipsec ike-group IKEv2_DEFAULT proposal 10 dh-group '19'
   set vpn ipsec ike-group IKEv2_DEFAULT proposal 10 encryption 'aes256gcm128'
   set vpn ipsec ike-group IKEv2_DEFAULT proposal 10 hash 'sha256'
   set vpn ipsec interface 'eth0.202'
-  set vpn ipsec site-to-site peer 172.18.201.10 authentication id '172.18.202.10'
-  set vpn ipsec site-to-site peer 172.18.201.10 authentication mode 'pre-shared-secret'
-  set vpn ipsec site-to-site peer 172.18.201.10 authentication pre-shared-secret 'secretkey'
-  set vpn ipsec site-to-site peer 172.18.201.10 authentication remote-id '172.18.201.10'
-  set vpn ipsec site-to-site peer 172.18.201.10 connection-type 'initiate'
-  set vpn ipsec site-to-site peer 172.18.201.10 ike-group 'IKEv2_DEFAULT'
-  set vpn ipsec site-to-site peer 172.18.201.10 ikev2-reauth 'inherit'
-  set vpn ipsec site-to-site peer 172.18.201.10 local-address '172.18.202.10'
-  set vpn ipsec site-to-site peer 172.18.201.10 vti bind 'vti10'
-  set vpn ipsec site-to-site peer 172.18.201.10 vti esp-group 'ESP_DEFAULT'
+  set vpn ipsec site-to-site peer OFFICE-A authentication local-id '172.18.202.10'
+  set vpn ipsec site-to-site peer OFFICE-A authentication mode 'pre-shared-secret'
+  set vpn ipsec site-to-site peer OFFICE-A authentication pre-shared-secret 'secretkey'
+  set vpn ipsec site-to-site peer OFFICE-A authentication remote-id '172.18.201.10'
+  set vpn ipsec site-to-site peer OFFICE-A connection-type 'initiate'
+  set vpn ipsec site-to-site peer OFFICE-A ike-group 'IKEv2_DEFAULT'
+  set vpn ipsec site-to-site peer OFFICE-A local-address '172.18.202.10'
+  set vpn ipsec site-to-site peer OFFICE-A remote-address '172.18.201.10'
+  set vpn ipsec site-to-site peer OFFICE-A vti bind 'vti10'
+  set vpn ipsec site-to-site peer OFFICE-A vti esp-group 'ESP_DEFAULT'
 
 Key Parameters:
 
-* ``authentication id/remote-id`` - IKE identification is used for validation 
-  of VPN peer devices during IKE negotiation. If you do not configure local/
-  remote-identity, the device uses the IPv4 or IPv6 address that corresponds 
-  to the local/remote peer by default.
+* ``authentication local-id/remote-id`` - IKE identification is used for
+  validation of VPN peer devices during IKE negotiation. If you do not configure
+  local/remote-identity, the device uses the IPv4 or IPv6 address that 
+  corresponds to the local/remote peer by default.
   In certain network setups (like ipsec interface with dynamic address, or 
   behind the NAT ), the IKE ID received from the peer does not match the IKE 
   gateway configured on the device. This can lead to a Phase 1 validation 


### PR DESCRIPTION
Migration and Change boolean nodes "enable/disable" to
disable-xxxx, enable-xxxx and just xxx for VPN IPsec
configurations

  - IKE changes:
      - replace 'ipsec ike-group <tag> mobike disable'
             => 'ipsec ike-group <tag> disable-mobike'
      - replace 'ipsec ike-group <tag> ikev2-reauth yes|no'
             => 'ipsec ike-group <tag> ikev2-reauth'
  - ESP changes:
      - replace 'ipsec esp-group <tag> compression enable'
             => 'ipsec esp-group <tag> compression'
  - PEER changes:
      - replace: 'peer <tag> id xxx'
              => 'peer <tag> local-id xxx'
      - replace: 'peer <tag> force-encapsulation enable'
              => 'peer <tag> force-udp-encapsulation'
      - add option: 'peer <tag> remote-address x.x.x.x'

If peer name is IPv4 or IPv6 address add remote-address via
migration script