### PR TITLE
tunnel-mac: mac addr option unavailable for tunnel interface

### DIFF
--- a/docs/_include/interface-common-without-dhcp1.txt
+++ b/docs/_include/interface-common-without-dhcp1.txt
@@ -1,0 +1,7 @@
+.. cmdinclude:: /_include/interface-address.txt
+  :var0: {{ var0 }}
+  :var1: {{ var1 }}
+
+.. cmdinclude:: /_include/interface-common-without-mac.txt
+  :var0: {{ var0 }}
+  :var1: {{ var1 }}

--- a/docs/_include/interface-common-without-mac.txt
+++ b/docs/_include/interface-common-without-mac.txt
@@ -1,0 +1,31 @@
+.. cmdinclude:: /_include/interface-description.txt
+  :var0: {{ var0 }}
+  :var1: {{ var1 }}
+
+.. cmdinclude:: /_include/interface-disable.txt
+  :var0: {{ var0 }}
+  :var1: {{ var1 }}
+
+.. cmdinclude:: /_include/interface-disable-flow-control.txt
+  :var0: {{ var0 }}
+  :var1: {{ var1 }}
+
+.. cmdinclude:: /_include/interface-disable-link-detect.txt
+  :var0: {{ var0 }}
+  :var1: {{ var1 }}
+
+.. cmdinclude:: /_include/interface-mtu.txt
+  :var0: {{ var0 }}
+  :var1: {{ var1 }}
+
+.. cmdinclude:: /_include/interface-ip.txt
+  :var0: {{ var0 }}
+  :var1: {{ var1 }}
+
+.. cmdinclude:: /_include/interface-ipv6.txt
+  :var0: {{ var0 }}
+  :var1: {{ var1 }}
+
+.. cmdinclude:: /_include/interface-vrf.txt
+  :var0: {{ var0 }}
+  :var1: {{ var1 }}

--- a/docs/configuration/interfaces/tunnel.rst
+++ b/docs/configuration/interfaces/tunnel.rst
@@ -18,7 +18,7 @@ a closer look at the protocols and options currently supported by VyOS.
 Common interface configuration
 ------------------------------
 
-.. cmdinclude:: /_include/interface-common-without-dhcp.txt
+.. cmdinclude:: /_include/interface-common-without-dhcp1.txt
    :var0: tunnel
    :var1: tun0
 


### PR DESCRIPTION
Mac address option is not present for tunnel interface so had to remove from the documentation. As the include pages are called, added two new files to reflect the changes