### PR TITLE
HTTPS API manual cert documentation

### DIFF
--- a/docs/configuration/service/https.rst
+++ b/docs/configuration/service/https.rst
@@ -72,9 +72,9 @@ Configuration
    Lifetime in days; default is 365
 
 
-*********************
-Example Configuration
-*********************
+**********************
+Example Configurations
+**********************
 
 Set an API-KEY is the minimal configuration to get a working API Endpoint.
 
@@ -82,14 +82,52 @@ Set an API-KEY is the minimal configuration to get a working API Endpoint.
 
    set service https api keys id MY-HTTPS-API-ID key MY-HTTPS-API-PLAINTEXT-KEY
 
+The following examples demonstrate how to configure TLS certificates and 
+virtual hosts.
 
-To use this full configuration we asume a public accessible hostname.
+Certbot Integration
+===================
+
+This configuration example uses Nginx's certbot integration to set up the API 
+with a TLS certificate acquired from LetsEncrypt. This will require the 
+following conditions:
+
+* The hostname points to your Vyos instance in the public DNS system
+* The instance is reachable by LetsEncrypt's public servers using that hostname
 
 .. code-block:: none
 
    set service https api keys id MY-HTTPS-API-ID key MY-HTTPS-API-PLAINTEXT-KEY
    set service https certificates certbot domain-name rtr01.example.com
    set service https certificates certbot email mail@example.com
+   set service https virtual-host rtr01 listen-address 198.51.100.2
+   set service https virtual-host rtr01 listen-port 11443
+   set service https virtual-host rtr01 server-name rtr01.example.com
+   set service https api-restrict virtual-host rtr01
+
+Manual Certificate 
+==================
+
+If the Vyos instance is not publicly accessible, certbot cannot be used directly 
+to automatically manage certificates using the HTTP challenge method. However, 
+if you have an externally acquired certificate, such as one acquired through 
+LetsEncrypt's DNS challenge method, it can be loaded directly into the PKI 
+and used from there.
+
+To see how to load a full certificate chain, refer to the 
+:ref:`pki-cert-chains-example` documentation. 
+
+As in the example, assume that the certificate in the PKI is stored as 
+``my_cert`` and the associated CA was stored as ``lets_encrypt``. After that, 
+the API can be configured as follows:
+
+.. code-block:: none
+
+   set service https api keys id MY-HTTPS-API-ID key MY-HTTPS-API-PLAINTEXT-KEY
+
+   set service https certificates ca-certificate lets_encrypt
+   set service https certificates certificate my_cert
+
    set service https virtual-host rtr01 listen-address 198.51.100.2
    set service https virtual-host rtr01 listen-port 11443
    set service https virtual-host rtr01 server-name rtr01.example.com


### PR DESCRIPTION
I was trying to set up the HTTPS API using a wildcard certificate from LetsEncrypt and the documentation was a little sparse.  I trial-and-errored my way through it and figured I'd take a crack at updating the docs for the next person.

This involved making changes to the HTTP-API page, but also putting a hand-holding example in the PKI documentation which explicitly shows how to bring in a whole certificate chain.  I suspect a lot of people going to set up the HTTP API on an instance that isn't publicly accessible won't necessarily be experts on TLS (this was me) and so could benefit from a very concrete example.

I'm happy to change and restructure things if this isn't the format or style the project is looking for.