### PR TITLE
T4886: Add connection-mark information to firewall and policy docs.

### DIFF
--- a/docs/configuration/firewall/general.rst
+++ b/docs/configuration/firewall/general.rst
@@ -345,6 +345,13 @@ There are a lot of matching criteria against which the package can be tested.
 
    Match criteria based on nat connection status.
 
+.. cfgcmd:: set firewall name <name> rule <1-999999> connection-mark
+   <1-2147483647>
+.. cfgcmd:: set firewall ipv6-name <name> rule <1-999999> connection-mark
+   <1-2147483647>
+
+   Match criteria based on connection mark.
+
 .. cfgcmd:: set firewall name <name> rule <1-999999> source address
    [address | addressrange | CIDR]
 .. cfgcmd:: set firewall name <name> rule <1-999999> destination address

--- a/docs/configuration/policy/route.rst
+++ b/docs/configuration/policy/route.rst
@@ -41,6 +41,11 @@ There are a lot of matching criteria options available, both for
 ``policy route`` and ``policy route6``. These options are listed
 in this section.
 
+.. cfgcmd:: set policy route <name> rule <n> connection-mark <1-2147483647>
+.. cfgcmd:: set policy route6 <name> rule <n> connection-mark <1-2147483647>
+
+  Set match criteria based on connection mark.
+
 .. cfgcmd:: set policy route <name> rule <n> source address
    <match_criteria>
 .. cfgcmd:: set policy route <name> rule <n> destination address
@@ -226,6 +231,13 @@ setting a different routing table.
 
    Set rule action to drop.
 
+.. cfgcmd:: set policy route <name> rule <n> set connection-mark
+   <1-2147483647>
+.. cfgcmd:: set policy route6 <name> rule <n> set connection-mark
+   <1-2147483647>
+
+   Set a specific connection mark.
+
 .. cfgcmd:: set policy route <name> rule <n> set dscp <0-63>
 .. cfgcmd:: set policy route6 <name> rule <n> set dscp <0-63>
 
@@ -234,12 +246,12 @@ setting a different routing table.
 .. cfgcmd:: set policy route <name> rule <n> set mark <1-2147483647>
 .. cfgcmd:: set policy route6 <name> rule <n> set mark <1-2147483647>
 
-   Set packet modifications: Packet marking
+   Set a specific packet mark.
 
 .. cfgcmd:: set policy route <name> rule <n> set table <main | 1-200>
 .. cfgcmd:: set policy route6 <name> rule <n> set table <main | 1-200>
 
-   Set packet modifications: Routing table to forward packet with.
+   Set the routing table to forward packet with.
 
 .. cfgcmd:: set policy route <name> rule <n> set tcp-mss <500-1460>
 .. cfgcmd:: set policy route6 <name> rule <n> set tcp-mss <500-1460>


### PR DESCRIPTION
Phabricator task for such new feature: https://phabricator.vyos.net/T4886
PR already merged in vyos-1x: https://github.com/vyos/vyos-1x/pull/1718