### PR TITLE
Added line in the example to match "Resulting in"

### DIFF
--- a/docs/configuration/interfaces/wireless.rst
+++ b/docs/configuration/interfaces/wireless.rst
@@ -306,6 +306,7 @@ default physical device (``phy0``) is used.
   set interfaces wireless wlan0 address dhcp
   set interfaces wireless wlan0 ssid Test
   set interfaces wireless wlan0 security wpa
+  set interfaces wireless wlan0 security wpa passphrase '12345678'
 
 Resulting in
 

--- a/docs/configuration/interfaces/wireless.rst
+++ b/docs/configuration/interfaces/wireless.rst
@@ -305,7 +305,6 @@ default physical device (``phy0``) is used.
   set interfaces wireless wlan0 type station
   set interfaces wireless wlan0 address dhcp
   set interfaces wireless wlan0 ssid Test
-  set interfaces wireless wlan0 security wpa
   set interfaces wireless wlan0 security wpa passphrase '12345678'
 
 Resulting in


### PR DESCRIPTION
Added line in the "Wireless options (Station/Client)" section to better match the output in "Resulting in" section. 