### PR TITLE
Update firewall policy application commands in quick-start.rst

### DIFF
--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -168,8 +168,8 @@ Apply the firewall policies:
 
 .. code-block:: none
 
-  set interfaces ethernet eth0 firewall in name 'OUTSIDE-IN'
-  set interfaces ethernet eth0 firewall local name 'OUTSIDE-LOCAL'
+  set firewall interface eth0 in name 'OUTSIDE-IN'
+  set firewall interface eth0 local name 'OUTSIDE-LOCAL'
 
 Commit changes, save the configuration, and exit configuration mode:
 


### PR DESCRIPTION
Updated commands to apply firewall policies to interfaces. Old commands were invalid.