### PR TITLE
ipsec: T4925: Added PRF information in IPSEC documentation

### DIFF
--- a/docs/configuration/vpn/ipsec.rst
+++ b/docs/configuration/vpn/ipsec.rst
@@ -111,6 +111,8 @@ VyOS IKE group has the next options:
 
  * ``hash`` hash algorithm.
 
+ * ``prf`` pseudo-random function.
+
 ***********************************************
 ESP (Encapsulating Security Payload) Attributes
 ***********************************************


### PR DESCRIPTION
Added Pseudo-Random Functions (PRF) information
in IPSEC documentation.