### PR TITLE
Update missing matcher options in firewall and policy route: packet-l…

### DIFF
--- a/docs/configuration/firewall/general.rst
+++ b/docs/configuration/firewall/general.rst
@@ -297,9 +297,9 @@ the action of the rule will be executed.
    Use this command to enable the logging of the default action.
 
 .. cfgcmd:: set firewall name <name> rule <1-999999> action [accept | drop |
-   jump | reject | return]
+   jump | queue | reject | return]
 .. cfgcmd:: set firewall ipv6-name <name> rule <1-999999> action [accept |
-   drop | jump | reject | return]
+   drop | jump | queue | reject | return]
 
    This required setting defines the action of the current rule. If action
    is set to ``jump``, then ``jump-target`` is also needed.
@@ -309,6 +309,20 @@ the action of the rule will be executed.
 
    To be used only when ``action`` is set to ``jump``. Use this
    command to specify jump target.
+
+.. cfgcmd:: set firewall name <name> rule <1-999999> queue <0-65535>
+.. cfgcmd:: set firewall ipv6-name <name> rule <1-999999> queue <0-65535>
+
+   Use this command to set the target to use. Action queue must be defined
+   to use this setting
+
+.. cfgcmd:: set firewall name <name> rule <1-999999> queue-options
+   <bypass-fanout>
+.. cfgcmd:: set firewall ipv6-name <name> rule <1-999999> queue-options
+   <bypass-fanout>
+
+   Options used for queue target. Action queue must be defined to use this
+   setting
 
 .. cfgcmd:: set firewall name <name> rule <1-999999> description <text>
 .. cfgcmd:: set firewall ipv6-name <name> rule <1-999999> description <text>
@@ -611,6 +625,13 @@ geoip) to keep database and rules updated.
 
    Match based on packet length criteria. Multiple values from 1 to 65535
    and ranges are supported.
+
+.. cfgcmd:: set firewall name <name> rule <1-999999> packet-type
+   [broadcast | host | multicast | other]
+.. cfgcmd:: set firewall ipv6-name <name> rule <1-999999> packet-type
+   [broadcast | host | multicast | other]
+
+   Match based on packet type criteria.
 
 .. cfgcmd:: set firewall name <name> rule <1-999999> protocol [<text> |
    <0-255> | all | tcp_udp]

--- a/docs/configuration/policy/route.rst
+++ b/docs/configuration/policy/route.rst
@@ -168,6 +168,21 @@ And for ipv6:
    ``tcp_udp`` for tcp and udp based packets. The ``!`` negates the selected
    protocol.
 
+.. cfgcmd:: set policy route <name> rule <n> packet-length <text>
+.. cfgcmd:: set policy route6 <name> rule <n> packet-length <text>
+.. cfgcmd:: set policy route <name> rule <n> packet-length-exclude <text>
+.. cfgcmd:: set policy route6 <name> rule <n> packet-length-exclude <text>
+
+   Match based on packet length criteria. Multiple values from 1 to 65535
+   and ranges are supported.
+
+.. cfgcmd:: set policy route <name> rule <n> packet-type [broadcast | host
+   | multicast | other]
+.. cfgcmd:: set policy route6 <name> rule <n> packet-type [broadcast | host
+   | multicast | other]
+
+   Match based on packet type criteria.
+
 .. cfgcmd:: set policy route <name> rule <n> recent count <1-255>
 .. cfgcmd:: set policy route6 <name> rule <n> recent count <1-255>
 .. cfgcmd:: set policy route <name> rule <n> recent time <1-4294967295>


### PR DESCRIPTION
Updates:  packet-length in policy route, queue action and queue options in firewall, and packet-type on both firewall and policy route

Related task in phabricator:
- https://vyos.dev/T5037
- https://vyos.dev/T5055
- https://vyos.dev/T4651