### PR TITLE
FIx BGP Confederation document

### DIFF
--- a/docs/configuration/protocols/bgp.rst
+++ b/docs/configuration/protocols/bgp.rst
@@ -939,8 +939,7 @@ IBGP (called confederation BGP). Confederation mechanism is described in
    of the autonomous system that internally includes multiple sub-autonomous
    systems (a confederation).
 
-.. cfgcmd:: set protocols bgp parameters confederation confederation
-   peers <nsubasn>
+.. cfgcmd:: set protocols bgp parameters confederation peers <nsubasn>
 
    This command sets other confederations <nsubasn> as members of autonomous
    system specified by :cfgcmd:`confederation identifier <asn>`.


### PR DESCRIPTION
Fixed an incorrect command in the BGP confederation document.

`set protocols bgp parameters confederation confederation peers <nsubasn>`

to 
`set protocols bgp parameters confederation peers <nsubasn>`