### PR TITLE
Add protocol failover route policy

### DIFF
--- a/docs/configuration/protocols/failover.rst
+++ b/docs/configuration/protocols/failover.rst
@@ -32,6 +32,19 @@ Failover Routes
 
    Default is ``icmp``.
 
+.. cfgcmd:: set protocols failover route <subnet> next-hop <address> check
+   policy <policy>
+
+   Policy for checking targets
+
+* ``all-available`` all checking target addresses must be available to pass
+  this check
+
+* ``any-available`` any of the checking target addresses must be available
+  to pass this check
+
+   Default is ``any-available``.
+
 .. cfgcmd:: set protocols failover route <subnet> next-hop <address> 
    interface <interface>
 


### PR DESCRIPTION
Add protocol failover route policy.
```
set protocols failover route 192.0.2.55/32 next-hop 192.168.122.1 check policy 'any-available'
set protocols failover route 192.0.2.55/32 next-hop 192.168.122.1 check target '192.168.122.25'
set protocols failover route 192.0.2.55/32 next-hop 192.168.122.1 check target '192.168.122.1'
```
merged in https://github.com/vyos/vyos-1x/pull/1966