### PR TITLE
T5258: git Actions use ubuntu-22.04 for PR conflicts checker

### DIFF
--- a/.github/workflows/pr-conflicts.yml
+++ b/.github/workflows/pr-conflicts.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   Conflict_Check:
     name: 'Check PR status: conflicts and resolution'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: check if PRs are dirty
         uses: eps1lon/actions-label-merge-conflict@releases/2.x


### PR DESCRIPTION
git Actions use ubuntu-22.04 instead of deprecated ubuntu-18.04 for PR conflicts checker
actions/runner-images#6002

https://vyos.dev/T5258