### PR TITLE
Update udp broadcast replay

### DIFF
--- a/docs/configuration/service/broadcast-relay.rst
+++ b/docs/configuration/service/broadcast-relay.rst
@@ -55,12 +55,12 @@ Example
 -------
 
 To forward all broadcast packets received on `UDP port 1900` on `eth3`, `eth4`
-or `eth5` to all other interfaces in this configuration.
+to all other interfaces in this configuration.
 
+Reminder: Only two interfaces allowed in UDP Broadcast Relay. If more two interfaces, UDP Broadcast Replay service not work.
 .. code-block:: none
 
   set service broadcast-relay id 1 description 'SONOS'
   set service broadcast-relay id 1 interface 'eth3'
   set service broadcast-relay id 1 interface 'eth4'
-  set service broadcast-relay id 1 interface 'eth5'
   set service broadcast-relay id 1 port '1900'


### PR DESCRIPTION
Change the example:

Currently set to eth3/eth4/eth5, when applied according to the instructions, broadcast service is not working.

Only 2 interfaces are allowed for udp broadcast replay service.