### PR TITLE
Fix not visible code block on Quick Start

### DIFF
--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -305,6 +305,7 @@ the DNS recursor we configured earlier, accepting traffic bound for port 53 from
 all hosts on the ``NET-INSIDE-v4`` network:
 
 .. code-block:: none
+
   set firewall ipv4 input filter rule 30 action 'accept'
   set firewall ipv4 input filter rule 30 icmp type-name 'echo-request'
   set firewall ipv4 input filter rule 30 protocol 'icmp'


### PR DESCRIPTION
Adding space for correct code block display on: Quick Start / Allow Access to Services: 
![image](https://github.com/vyos/vyos-documentation/assets/12866519/e602e980-d9ee-428e-a125-d2d6a597809a)