### PR TITLE
Fixed lxml build (Python 3.12 issue)

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -13,9 +13,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set Up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: 3.11.x
 
       - name: install lxml dependencies
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ Sphinx==4.5.0
 sphinx-rtd-theme==1.0.0
 sphinx-autobuild==2021.3.14
 sphinx-notfound-page==0.8
-lxml==4.8.0
+lxml==4.9.1
 myst-parser==0.17.1
 sphinx-panels==0.6.0


### PR DESCRIPTION
Looks like lxml build stopped to work because actions/setup-python started to install Python of version 3.12 which has some changes regarding ob_digit usage

https://github.com/cython/cython/issues/5238

Temporary solution is to use Python 3.11.x. Also reverted unnecessary lxml downgrade in requirements.txt
