### PR TITLE
Small document changes.

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -410,7 +410,7 @@ working configuration indicating line changes with ``+`` for additions,
   loopback lo {
   }
 
-It is also possible to display all `set` commands within configuration
+It is also possible to display all :cfgcmd:`set` commands within configuration
 mode using :cfgcmd:`show | commands`
 
 .. code-block:: none

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -369,7 +369,7 @@ command.
 
 You are now in a sublevel relative to ``interfaces ethernet eth0``, all
 commands executed from this point on are relative to this sublevel. Use
-eithe the :cfgcmd:`top` or :cfgcmd:`exit` command to go back to the top
+either the :cfgcmd:`top` or :cfgcmd:`exit` command to go back to the top
 of the hierarchy. You can also use the :cfgcmd:`up` command to move only
 one level up at a time.
 


### PR DESCRIPTION
Corrected spelling and changed the way the 'set' command was being displayed.