### PR TITLE
Update script ex with the correct "source" syntax

### DIFF
--- a/docs/automation/command-scripting.rst
+++ b/docs/automation/command-scripting.rst
@@ -94,7 +94,7 @@ Here is a simple example:
   #!/bin/vbash
   source /opt/vyatta/etc/functions/script-template
   configure
-  source < /config/scripts/setfirewallgroup.py
+  source <(/config/scripts/setfirewallgroup.py)
   commit
 
 


### PR DESCRIPTION
In case of using current example for sourcing commands from non-shell scripts, I have faced with issue like next:

```shell
/home/vyos/update-network-groups-wrapper.sh: line 14: source: filename argument required
source: usage: source filename [arguments]
```

We have to use [process substitution](https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html) here instead of input redirection.