### PR TITLE
Fix mDNS documentation to correct Example issue

### DIFF
--- a/docs/configuration/service/mdns.rst
+++ b/docs/configuration/service/mdns.rst
@@ -47,7 +47,7 @@ Configuration
    are launched in a subnet you will experience the mDNS packet storm death!
 
 Example
--------
+=======
 
 To listen on both `eth0` and `eth1` mDNS packets and also repeat packets
 received on `eth0` to `eth1` (and vice-versa) use the following commands:


### PR DESCRIPTION
Browsing the v1.5.x docs, I noticed in the Services configuration guide [the example](https://docs.vyos.io/en/latest/configuration/service/mdns.html#example) for mDNS not being correctly formatted to be subsection of mDNS Repeater in the navigation tree. It appears #1147 introduced that change. 