### PR TITLE
Add ISIS fast reroute documentation

### DIFF
--- a/docs/configuration/protocols/isis.rst
+++ b/docs/configuration/protocols/isis.rst
@@ -302,6 +302,34 @@ Timers
   control the timing of the execution of SPF calculations in response
   to IGP events. The process described in :rfc:`8405`.
 
+Loop Free Alternate (LFA)
+-------------------------
+
+.. cfgcmd:: set protocols isis fast-reroute lfa remote prefix-list <name>
+  <level-1|level-2>
+
+  This command enables IP fast re-routing that is part of :rfc:`5286`.
+  Specifically this is a prefix list which references a prefix in which
+  will select eligible PQ nodes for remote LFA backups. 
+
+.. cfgcmd:: set protocols isis fast-reroute lfa local load-sharing disable
+  <level-1|level-2>
+
+  This command disables the load sharing across multiple LFA backups.
+
+.. cfgcmd:: set protocols isis fast-reroute lfa local tiebreaker
+  <downstream|lowest-backup-metric|node-protecting> index <number>
+  <level-1|level-2>
+
+  This command will configure a tie-breaker for multiple local LFA backups.
+  The lower index numbers will be processed first.
+  
+.. cfgcmd:: set protocols isis fast-reroute lfa local priority-limit
+  <medium|high|critical> <level-1|level-2>
+  
+  This command will limit LFA backup computation up to the specified
+  prefix priority. 
+
 
 ********
 Examples


### PR DESCRIPTION
Adding basic descriptions of ISIS fast reroute documentation. It's sparse because FRR didn't really document it very deeply. But we'll get more as time goes on. This is part of https://vyos.dev/T5530