### PR TITLE
Changed IPv6 pool documentation in accel-ppp services

### DIFF
--- a/docs/configuration/service/ipoe-server.rst
+++ b/docs/configuration/service/ipoe-server.rst
@@ -72,8 +72,9 @@ IPv6 DNS addresses are optional.
 
   set service ipoe-server authentication interface eth3 mac 08:00:27:2F:D8:06
   set service ipoe-server authentication mode 'local'
-  set service ipoe-server client-ipv6-pool delegate '2001:db8:1::/48' delegation-prefix '56'
-  set service ipoe-server client-ipv6-pool prefix '2001:db8::/48' mask '64'
+  set service ipoe-server client-ipv6-pool IPv6-POOL delegate '2001:db8:1::/48' delegation-prefix '56'
+  set service ipoe-server client-ipv6-pool IPv6-POOL prefix '2001:db8::/48' mask '64'
+  set service ipoe-server default-ipv6-pool IPv6-POOL
   set service ipoe-server name-server '2001:db8::'
   set service ipoe-server name-server '2001:db8:aaa::'
   set service ipoe-server name-server '2001:db8:bbb::'
@@ -171,8 +172,9 @@ Server configuration
     set service ipoe-server authentication interface eth1.51 mac 00:0c:29:b7:49:a7 rate-limit upload '50000'
     set service ipoe-server authentication mode 'local'
     
-    set service ipoe-server client-ipv6-pool delegate 2001:db8:ffff::/48 delegation-prefix '56'
-    set service ipoe-server client-ipv6-pool prefix 2001:db8:fffe::/48 mask '64'
+    set service ipoe-server client-ipv6-pool IPv6-POOL delegate 2001:db8:ffff::/48 delegation-prefix '56'
+    set service ipoe-server client-ipv6-pool IPv6-POOL prefix 2001:db8:fffe::/48 mask '64'
+    set service ipoe-server default-ipv6-pool IPv6-POOL
     set service ipoe-server interface eth1.50 client-subnet '100.64.50.0/24'
     set service ipoe-server interface eth1.50 mode 'l2'
     set service ipoe-server interface eth1.51 client-subnet '100.64.51.0/24'

--- a/docs/configuration/service/pppoe-server.rst
+++ b/docs/configuration/service/pppoe-server.rst
@@ -266,11 +266,11 @@ other servers. Last command says that this PPPoE server can serve only
 IPv6
 ----
 
-IPv6 client's prefix assignment
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+IPv6 client's prefix
+^^^^^^^^^^^^^^^^^^^^
 
-.. cfgcmd:: set service pppoe-server client-ipv6-pool prefix <address>
-   mask <number-of-bits>
+.. cfgcmd:: set service pppoe-server client-ipv6-pool <IPv6-POOL-NAME>
+   prefix <address> mask <number-of-bits>
 
    Use this comand to set the IPv6 address pool from which a PPPoE
    client will get an IPv6 prefix of your defined length (mask) to
@@ -281,14 +281,22 @@ IPv6 client's prefix assignment
 IPv6 Prefix Delegation
 ^^^^^^^^^^^^^^^^^^^^^^
 
-.. cfgcmd:: set service pppoe-server client-ipv6-pool delegate <address>
-   delegation-prefix <number-of-bits>
+.. cfgcmd:: set service pppoe-server client-ipv6-pool <IPv6-POOL-NAME>
+   delegate <address> delegation-prefix <number-of-bits>
 
    Use this command to configure DHCPv6 Prefix Delegation (RFC3633). You
    will have to set your IPv6 pool and the length of the delegation
    prefix. From the defined IPv6 pool you will be handing out networks
    of the defined length (delegation-prefix). The length of the
    delegation prefix can be set from 32 to 64 bit long.
+
+
+IPv6 default client's pool assignment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. cfgcmd:: set service pppoe-server default-ipv6-pool <POOL-NAME>
+
+   Use this command to define default IPv6 address pool name.
 
 
 Maintenance mode
@@ -374,8 +382,9 @@ The example below covers a dual-stack configuration via pppoe-server.
   set service pppoe-server authentication mode 'local'
   set service pppoe-server client-ip-pool IP-POOL range '192.168.0.1/24'
   set service pppoe-server default-pool 'IP-POOL'
-  set service pppoe-server client-ipv6-pool delegate '2001:db8:8003::/48' delegation-prefix '56'
-  set service pppoe-server client-ipv6-pool prefix '2001:db8:8002::/48' mask '64'
+  set service pppoe-server client-ipv6-pool IPv6-POOL delegate '2001:db8:8003::/48' delegation-prefix '56'
+  set service pppoe-server client-ipv6-pool IPV6-POOL prefix '2001:db8:8002::/48' mask '64'
+  set service pppoe-server default-ipv6-pool IPv6-POOL
   set service pppoe-server ppp-options ipv6 allow
   set service pppoe-server name-server '10.1.1.1'
   set service pppoe-server name-server '2001:db8:4860::8888'

--- a/docs/configuration/vpn/sstp.rst
+++ b/docs/configuration/vpn/sstp.rst
@@ -132,7 +132,8 @@ Configuration
    Use this command to define default address pool name.
 
 
-.. cfgcmd:: set vpn sstp client-ipv6-pool prefix <address> mask <number-of-bits>
+.. cfgcmd:: set vpn sstp client-ipv6-pool <IPv6-POOL-NAME> prefix <address>
+   mask <number-of-bits>
 
   Use this comand to set the IPv6 address pool from which an SSTP client
   will get an IPv6 prefix of your defined length (mask) to terminate the
@@ -140,14 +141,19 @@ Configuration
   bit long, the default value is 64.
 
 
-.. cfgcmd:: set vpn sstp client-ipv6-pool delegate <address> delegation-prefix
-   <number-of-bits>
+.. cfgcmd:: set vpn sstp client-ipv6-pool <IPv6-POOL-NAME> delegate <address>
+   delegation-prefix <number-of-bits>
 
   Use this command to configure DHCPv6 Prefix Delegation (RFC3633) on
   SSTP. You will have to set your IPv6 pool and the length of the
   delegation prefix. From the defined IPv6 pool you will be handing out
   networks of the defined length (delegation-prefix). The length of the
   delegation prefix can be set from 32 to 64 bit long.
+
+
+.. cfgcmd:: set vpn sstp default-ipv6-pool <IPv6-POOL-NAME>
+
+   Use this command to define default IPv6 address pool name.
 
 
 .. cfgcmd:: set vpn sstp name-server <address>


### PR DESCRIPTION
Changed IPv6 pool documentation in accel-ppp services to named IPv6 pools.
https://vyos.dev/T5865