### PR TITLE
fix a forgotten "set"

### DIFF
--- a/docs/configuration/container/index.rst
+++ b/docs/configuration/container/index.rst
@@ -117,7 +117,7 @@ Configuration
 
    Add a host device to the container.
 
-.. cfgcmd:: container name <name> cap-add <text>
+.. cfgcmd:: set container name <name> cap-add <text>
 
    Set container capabilities or permissions.
 


### PR DESCRIPTION
very little fix, a "set" was forgotten in the container documentation