### PR TITLE
Add additional step to ingress shaping

### DIFF
--- a/docs/configuration/trafficpolicy/index.rst
+++ b/docs/configuration/trafficpolicy/index.rst
@@ -1203,6 +1203,8 @@ That is how it is possible to do the so-called "ingress shaping".
    set qos interface ifb0 egress MY-INGRESS-SHAPING
    set interfaces ethernet eth0 redirect ifb0
 
+   set interfaces input ifb0
+
 .. warning::
 
   Do not configure IFB as the first step. First create everything else


### PR DESCRIPTION
In order to set up ingress shaping using the example, you also need to create the ifb0 interface.  

Otherwise by following just the commands given you will receive a "Requested redirect interface "ifb0" does not exist!" error.  

At least to me it was not clear if these commands also created the IFB interface.