### PR TITLE
Quick Start - Set interface description to match DHCP scope

### DIFF
--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -56,7 +56,7 @@ commands:
   set interfaces ethernet eth0 address dhcp
   set interfaces ethernet eth0 description 'OUTSIDE'
   set interfaces ethernet eth1 address '192.168.0.1/24'
-  set interfaces ethernet eth1 description 'INSIDE'
+  set interfaces ethernet eth1 description 'LAN'
 
 
 SSH Management


### PR DESCRIPTION
New to VyOS (thus reading the quick start guide) so if this is not how it's supposed to work I apologize, but in order for the DHCP scope to work properly as laid out in the quick start guide I had to set the shared-network-name to the same as the interface description. I figured updating the interface description in the guide would be easier than modifying the scopes, and would help others getting started.