### PR TITLE
http-api: T6135: add details on op 'exists' for retrieve endpoint

### DIFF
--- a/docs/automation/vyos-api.rst
+++ b/docs/automation/vyos-api.rst
@@ -125,6 +125,38 @@ For example, get the addresses of a ``dum0`` interface.
       "error": null
    }
 
+To check existence of a configuration path, use the ``exists`` operation.
+
+For example, check an existing path:
+
+.. code-block:: none
+
+   curl -k --location --request POST 'https://vyos/retrieve' \
+   --form data='{"op": "exists", "path": ["service","https","api"]}' \
+   --form key='MY-HTTPS-API-PLAINTEXT-KEY'
+
+   response:
+   {
+      "success": true,
+      "data": true,
+      "error": null
+   }
+
+versus a non-existent path:
+
+.. code-block:: none
+
+   curl -k --location --request POST 'https://vyos/retrieve' \
+   --form data='{"op": "exists", "path": ["service","non","existent","path"]}' \
+   --form key='MY-HTTPS-API-PLAINTEXT-KEY'
+
+   response:
+   {
+      "success": true,
+      "data": false,
+      "error": null
+   }
+
 /reset
 ======
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add missing example of operation 'exists' for retrieve endpoint.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T6135

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/master/CONTRIBUTING.md) document