### PR TITLE
T5614: extend ipv4 firewall documentation on conntrack-helper matching

### DIFF
--- a/docs/configuration/firewall/ipv4.rst
+++ b/docs/configuration/firewall/ipv4.rst
@@ -906,6 +906,30 @@ geoip) to keep database and rules updated.
    Match when 'count' amount of connections are seen within 'time'. These
    matching criteria can be used to block brute-force attempts.
 
+.. cfgcmd:: set firewall ipv4 forward filter rule <1-999999>
+   conntrack-helper <module>
+.. cfgcmd:: set firewall ipv4 input filter rule <1-999999>
+   conntrack-helper <module>
+.. cfgcmd:: set firewall ipv4 output filter rule <1-999999>
+   conntrack-helper <module>
+.. cfgcmd:: set firewall ipv4 name <name> rule <1-999999>
+   conntrack-helper <module>
+
+   Match based on connection tracking protocol helper module to secure use of 
+   that helper module. See below for possible completions `<module>`. 
+
+   .. code-block:: none
+
+      Possible completions:
+          ftp                  Related traffic from FTP helper
+          h323                 Related traffic from H.323 helper
+          pptp                 Related traffic from PPTP helper
+          nfs                  Related traffic from NFS helper
+          sip                  Related traffic from SIP helper
+          tftp                 Related traffic from TFTP helper
+          sqlnet               Related traffic from SQLNet helper
+
+
 ********
 Synproxy
 ********


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Extended sagitta "configuration/firewall/ipv4.html" to include rules introduced by https://vyos.dev/T5614

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T5614

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
Related to previously merged PR #1317 in 1.5.x branch

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/master/CONTRIBUTING.md) document