### PR TITLE
openvpn option: "--client-cert-not-required" is not accepted

### DIFF
--- a/docs/configuration/interfaces/openvpn.rst
+++ b/docs/configuration/interfaces/openvpn.rst
@@ -547,7 +547,7 @@ example:
        openvpn-option "--plugin /usr/lib/openvpn/openvpn-auth-ldap.so /config/auth/ldap-auth.config"
        openvpn-option "--push redirect-gateway"
        openvpn-option --duplicate-cn
-       openvpn-option --client-cert-not-required
+       openvpn-option "--verify-client-cert none"
        openvpn-option --comp-lzo
        openvpn-option --persist-key
        openvpn-option --persist-tun


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
openvpn option: "--client-cert-not-required" is not accepted and openvpn service goes down, need to replace with new value "--verify-client-cert none" in the define example
## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/Txxxx

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->
backported to Sagitta


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/master/CONTRIBUTING.md) document