### PR TITLE
DHCP HA: change docs for failover featur in dhcp-server. Node has mig…

### DIFF
--- a/docs/configuration/service/dhcp-server.rst
+++ b/docs/configuration/service/dhcp-server.rst
@@ -166,28 +166,44 @@ Unifi controller at ``172.16.100.1`` to clients of that subnet.
   '172.18.201.0/24' option vendor-option ubiquiti '172.16.100.1'
 
 
-Failover
---------
+High Availability
+-----------------
 
-VyOS provides support for DHCP failover. DHCP failover must be configured
-explicitly by the following statements.
+VyOS provides High Availability support for DHCP server. DHCP High
+Availability can act in two different modes:
 
-.. cfgcmd:: set service dhcp-server failover source-address <address>
+* **Active-active**: both DHCP servers will respond to DHCP requests. If
+  ``mode`` is not defined, this is the default behavior.
 
-   Local IP `<address>` used when communicating to the failover peer.
+* **Active-passive**: only ``primary`` server will respond to DHCP requests.
+  If this server goes offline, then ``secondary`` server will take place.
 
-.. cfgcmd:: set service dhcp-server failover remote <address>
+DHCP High Availability must be configured explicitly by the following
+statements on both servers:
 
-   Remote peer IP `<address>` of the second DHCP server in this failover
+.. cfgcmd:: set service dhcp-server high-availability mode [active-active
+   | active-passive]
+
+   Define operation mode of High Availability feature. Default value if command
+   is not specified is `active-active`
+
+.. cfgcmd:: set service dhcp-server high-availability source-address <address>
+
+   Local IP `<address>` used when communicating to the HA peer.
+
+.. cfgcmd:: set service dhcp-server high-availability remote <address>
+
+   Remote peer IP `<address>` of the second DHCP server in this HA
    cluster.
 
-.. cfgcmd:: set service dhcp-server failover name <name>
+.. cfgcmd:: set service dhcp-server high-availability name <name>
 
    A generic `<name>` referencing this sync service.
 
    .. note:: `<name>` must be identical on both sides!
 
-.. cfgcmd:: set service dhcp-server failover status <primary | secondary>
+.. cfgcmd:: set service dhcp-server high-availability status <primary
+   | secondary>
 
    The primary and secondary statements determines whether the server is primary
    or secondary.
@@ -196,12 +212,12 @@ explicitly by the following statements.
       their lease tables in sync, they must be able to reach each other on TCP
       port 647. If you have firewall rules in effect, adjust them accordingly.
 
-   .. hint:: The dialogue between failover partners is neither encrypted nor
+   .. hint:: The dialogue between HA partners is neither encrypted nor
       authenticated. Since most DHCP servers exist within an organisation's own
       secure Intranet, this would be an unnecessary overhead. However, if you
-      have DHCP failover peers whose communications traverse insecure networks,
+      have DHCP HA peers whose communications traverse insecure networks,
       then we recommend that you consider the use of VPN tunneling between them
-      to ensure that the failover partnership is immune to disruption
+      to ensure that the HA partnership is immune to disruption
       (accidental or otherwise) via third parties.
 
 Static mappings
@@ -405,12 +421,13 @@ Please see the :ref:`dhcp-dns-quick-start` configuration.
 
 .. _dhcp-server:v4_example_failover:
 
-Failover
---------
+High Availability
+-----------------
 
-Configuration of a DHCP failover pair
+Configuration of a DHCP HA pair:
 
-* Setup DHCP failover for network 192.0.2.0/24
+* Setup DHCP HA for network 192.0.2.0/24
+* Use active-active HA mode.
 * Default gateway and DNS server is at `192.0.2.254`
 * The primary DHCP server uses address `192.168.189.252`
 * The secondary DHCP server uses address `192.168.189.253`
@@ -432,19 +449,21 @@ Common configuration, valid for both primary and secondary node.
 
 .. code-block:: none
 
-  set service dhcp-server failover source-address '192.168.189.252'
-  set service dhcp-server failover name 'NET-VYOS'
-  set service dhcp-server failover remote '192.168.189.253'
-  set service dhcp-server failover status 'primary'
+  set service dhcp-server high-availability mode 'active-active'
+  set service dhcp-server high-availability source-address '192.168.189.252'
+  set service dhcp-server high-availability name 'NET-VYOS'
+  set service dhcp-server high-availability remote '192.168.189.253'
+  set service dhcp-server high-availability status 'primary'
 
 **Secondary**
 
 .. code-block:: none
 
-  set service dhcp-server failover source-address '192.168.189.253'
-  set service dhcp-server failover name 'NET-VYOS'
-  set service dhcp-server failover remote '192.168.189.252'
-  set service dhcp-server failover status 'secondary'
+  set service dhcp-server high-availability mode 'active-active'
+  set service dhcp-server high-availability source-address '192.168.189.253'
+  set service dhcp-server high-availability name 'NET-VYOS'
+  set service dhcp-server high-availability remote '192.168.189.252'
+  set service dhcp-server high-availability status 'secondary'
 
 .. _dhcp-server:v4_example_raw:
 


### PR DESCRIPTION
…rated to <high-availability> and also command <mode> was added.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Change documentation becaus command was moved from:
```
set service dhcp-server failover ...
```
To:
```
set service dhcp-server high-availability ...
```
Also, one option was added:
```
set service dhcp-server high-availability mode [active-active | active-passive]
```

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T6068
* https://vyos.dev/T6171

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
For 1.5:
* https://github.com/vyos/vyos-1x/pull/3188
* https://github.com/vyos/vyos-1x/pull/3214
For 1.4:
* https://github.com/vyos/vyos-1x/pull/3239

## Backport
<!-- optional: the PR should backport to this documentation branch -->
This documentation should be backported to Sagitta, since command and syntax for DHCP HA are the same.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/master/CONTRIBUTING.md) document