### PR TITLE
conntrack-sync: T1244: Support for StartupResync in conntrackd

### DIFF
--- a/docs/configuration/service/conntrack-sync.rst
+++ b/docs/configuration/service/conntrack-sync.rst
@@ -102,7 +102,7 @@ Configuration
 
    Disable connection logging via Syslog.
 
-.. cfgcmd:: set service conntrack-sync enable-startup-resync
+.. cfgcmd:: set service conntrack-sync startup-resync
 
    Order conntrackd to request a complete conntrack table resync against
    the other node at startup.

--- a/docs/configuration/service/conntrack-sync.rst
+++ b/docs/configuration/service/conntrack-sync.rst
@@ -102,6 +102,11 @@ Configuration
 
    Disable connection logging via Syslog.
 
+.. cfgcmd:: set service conntrack-sync enable-startup-resync
+
+   Order conntrackd to request a complete conntrack table resync against
+   the other node at startup.
+
 *********
 Operation
 *********


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
one option was added:
```
set service conntrack-sync startup-resync
```
## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T1244

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
1.5:
https://github.com/vyos/vyos-1x/pull/3254

1.3:
https://github.com/vyos/vyos-1x/pull/3256

## Backport
<!-- optional: the PR should backport to this documentation branch -->
This should be backported to 1.4 and 1.3 too


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/master/CONTRIBUTING.md) document