### PR TITLE
Fix mistake in RPKI documentation about the use of TLS

### DIFF
--- a/docs/configuration/protocols/rpki.rst
+++ b/docs/configuration/protocols/rpki.rst
@@ -140,11 +140,13 @@ Configuration
 SSH
 ===
 
-Connections to the RPKI caching server can not only be established by HTTP/TLS
-but you can also rely on a secure SSH session to the server. To enable SSH,
-first you need to create an SSH client keypair using ``generate ssh
-client-key /config/auth/id_rsa_rpki``. Once your key is created you can setup
-the connection.
+Connections to the RPKI caching server can not only be established by TCP using
+the RTR protocol but you can also rely on a secure SSH session to the server.
+This provides transport integrity and confidentiality and it is a good idea if
+your validation software supports it.  To enable SSH, first you need to create
+an SSH client keypair using ``generate ssh client-key
+/config/auth/id_rsa_rpki``. Once your key is created you can setup the
+connection.
 
 .. cfgcmd:: set protocols rpki cache <address> ssh username <user>
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

HTTP is not used for RPKI information, the RTR protocol is used, which works on top of plain TCP. Although some implementations can use TLS, VyOS (and FRR) do not support it, and use either plain TCP or SSH.

This Pull Request corrects the docs to reflect that.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->

FRR and VyOS never supported TLS and HTTP, so this should be backportable to 1.3 / 1.4 too.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/master/CONTRIBUTING.md) document