### PR TITLE
cli: T6002: Added hint for commit message

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -501,6 +501,9 @@ different levels in the hierarchy.
     Warning: configuration changes have not been saved.
     vyos@vyos:~$
 
+.. hint:: You can specify a commit message with
+  :cfgcmd:`commit comment <message>`.
+
 .. _save:
 
 .. cfgcmd:: save


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Made changes to `cli.rst` for the following:
- Added hint to showcase support for commit messages.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
- https://vyos.dev/T6002

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/master/CONTRIBUTING.md) document