### PR TITLE
Update cloud-init.rst (added additional info on the need to run scripts as vyattacfg group)

### DIFF
--- a/docs/automation/cloud-init.rst
+++ b/docs/automation/cloud-init.rst
@@ -159,7 +159,7 @@ obtained from the EC2 metadata service.
 Please observe that the same configuration pitfall described in :ref:`command-scripting`
 exists here when running ``configure`` in any context as without user group 
 'vyattacfg' will cause the error message ``Set failed`` to appear.
-We therefor need to wrap it and have the script re-execute itself with the correct 
+We therefore need to wrap it and have the script re-execute itself with the correct 
 group permissions. 
 
 .. code-block:: yaml


### PR DESCRIPTION
Added additional documentation regarding the need to use "exec sg vyattacfg" to run script as the correct group, to avoid configuration pitfalls.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
added additional info on the need to run scripts as vyattacfg group

The previous code example will lock you out of running any set commands, so I have updated the documentation to make it more helpful for users.
## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->


## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document