### PR TITLE
T2468: clarify password encoding requirement

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -872,6 +872,9 @@ be ``config.boot-hostname.YYYYMMDD_HHMMSS``.
   * ``tftp://<host>/<dir>``
   * ``git+https://<user>:<passwd>@<host>/<path>``
 
+  Since username and password are part of the URI, they need to be
+  properly url encoded if containing special characters.
+
   .. note:: The number of revisions don't affect the commit-archive.
 
   .. note:: You may find VyOS not allowing the secure connection because


### PR DESCRIPTION
## Change Summary
Add a note that especially passwords may need to be url encoded.

## Related Task(s)
https://vyos.dev/T2468

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document