### PR TITLE
config-sync: adding initial user documentation for this feature

### DIFF
--- a/docs/configexamples/autotest/tunnelbroker/_include/vyos-wan_tun0.conf
+++ b/docs/configexamples/autotest/tunnelbroker/_include/vyos-wan_tun0.conf
@@ -1,8 +1,8 @@
-set interfaces tunnel tun0 address '2001:470:6c:779::2/64' #Tunnelbroker Client IPv6 Address
+set interfaces tunnel tun0 address '2001:470:6c:779::2/64' #Tunnelbroker Client IPv6 address
 set interfaces tunnel tun0 description 'HE.NET IPv6 Tunnel'
 set interfaces tunnel tun0 encapsulation 'sit'
-set interfaces tunnel tun0 remote '216.66.86.114' #Tunnelbroker Server IPv4 Address
-set interfaces tunnel tun0 source-address '172.29.129.60' # Tunnelbroker Client IPv4 Address or if there is NAT the current WAN interface address
+set interfaces tunnel tun0 remote '216.66.86.114' #Tunnelbroker Server IPv4 address
+set interfaces tunnel tun0 source-address '172.29.129.60' # Tunnelbroker Client IPv4 address. See note below
 
 set protocols static route6 ::/0 interface tun0
 

--- a/docs/configexamples/autotest/tunnelbroker/tunnelbroker.rst
+++ b/docs/configexamples/autotest/tunnelbroker/tunnelbroker.rst
@@ -48,7 +48,15 @@ Now we are able to setup the tunnel interface.
    :language: none
    :lines: 1-5
 
-Setup the ipv6 default route to the tunnel interface
+.. note:: The `source-address` is the Tunnelbroker client IPv4 
+          address or if there is NAT the current WAN interface address.
+
+          If `source-address` is  dynamic, the tunnel will cease working once 
+          the address changes. To avoid having to manually update
+          `source-address` each time the dynamic IP changes, an address of  
+          '0.0.0.0' can be specified.
+
+Setup the IPv6 default route to the tunnel interface
 
 .. literalinclude:: _include/vyos-wan_tun0.conf
    :language: none
@@ -204,4 +212,5 @@ instead of `set firewall name NAME`, you would use `set firewall ipv6-name
 NAME`.
 
 Similarly, to attach the firewall, you would use `set interfaces ethernet eth0
-firewall in ipv6-name` or `et firewall zone LOCAL from WAN firewall ipv6-name`.
+firewall in ipv6-name` or `set firewall zone LOCAL from WAN firewall 
+ipv6-name`.

--- a/docs/configuration/service/config-sync.rst
+++ b/docs/configuration/service/config-sync.rst
@@ -1,0 +1,117 @@
+.. _config-sync:
+
+###########
+Config Sync
+###########
+
+Configuration synchronization (config sync) is a feature of VyOS that 
+permits synchronization of the configuration of one VyOS router to 
+another in a network. 
+
+The main benefit to configuration synchronization is that it eliminates having  
+to manually replicate configuration changes made on the primary router to the  
+secondary (replica) router.
+
+The writing of the configuration to the secondary router is performed through 
+the VyOS HTTP API. The user can specify which portion(s) of the configuration will 
+be synchronized and the mode to use - whether to replace or add. 
+
+To prevent issues with divergent configurations between the pair of routers, 
+synchronization is strictly unidirectional from primary to replica. Both 
+routers should be online and run the same version of VyOS.
+
+Configuration
+-------------
+
+.. cfgcmd:: set service config-sync section secondary 
+   <address|key|timeout|port>
+
+   Specify the address, API key, timeout and port of the secondary router. 
+   You need to enable and configure the HTTP API service on the secondary 
+   router for config sync to operate.
+   
+.. cfgcmd:: set service config-sync section <section>
+
+   Specify the section of the configuration to synchronize. If more than one 
+   section is to be synchronized, repeat the command to add additional 
+   sections as required.
+
+.. cfgcmd:: set service config-sync mode <load|set>
+
+   Two options are available for `mode`: either `load` and replace or `set`
+   the configuration section.
+
+.. code-block:: none
+
+    Supported options for <section> include:
+        firewall
+        interfaces <interface>
+        nat
+        nat66
+        pki
+        policy
+        protocols <protocol>
+        qos <interface|policy>
+        service <service>
+        system <conntrack| 
+        flow-accounting|option|sflow|static-host-mapping|sysctl|time-zone>
+        vpn
+        vrf
+
+Example
+-------
+* Synchronize the time-zone and OSPF configuration from Router A to Router B
+* The address Router B is 10.0.20.112 and the port used is 8443
+
+Configure the HTTP API service on Router B
+
+.. code-block:: none
+
+    set service https api graphql authentication expiration '31536000'
+    set service https api graphql authentication type 'token'
+    set service https api graphql introspection
+    set service https api keys id KID key 'foo'
+    set service https listen-address '10.0.20.112'
+    set service https port '8443'
+
+Configure the config-sync service on Router A
+
+.. code-block:: none
+
+    set service config-sync mode 'load'
+    set service config-sync secondary address '10.0.20.112'
+    set service config-sync secondary port '8443'
+    set service config-sync secondary key 'foo'
+    set service config-sync section protocols 'ospf'
+    set service config-sync section system 'time-zone'
+
+Make config-sync relevant changes to Router A's configuration
+
+.. code-block:: none
+
+   vyos@vyos-A# set system time-zone 'America/Los_Angeles'
+   vyos@vyos-A# commit
+   INFO:vyos_config_sync:Config synchronization: Mode=load, 
+   Secondary=10.0.20.112
+   vyos@vyos-A# save
+
+   vyos@vyos-A# set protocols ospf area 0 network '10.0.48.0/30'
+   vyos@vyos-A# commit
+   INFO:vyos_config_sync:Config synchronization: Mode=load, 
+   Secondary=10.0.20.112
+   yos@vyos-A# save
+
+Verify configuration changes have been replicated to Router B
+
+.. code-block:: none
+
+   vyos@vyos-B:~$ show configuration commands | match time-zone
+   set system time-zone 'America/Los_Angeles'
+   vyos@vyos-B:~$ show configuration commands | match ospf
+   set protocols ospf area 0 network '10.0.48.0/30'
+   vyos@vyos-B:~$ 
+
+Known issues
+------------
+Configuration resynchronization. With the current implementation of `service 
+config-sync`, the secondary node must be online.

--- a/docs/configuration/service/index.rst
+++ b/docs/configuration/service/index.rst
@@ -8,6 +8,7 @@ Service
    :includehidden:
 
    broadcast-relay
+   config-sync
    conntrack-sync
    console-server
    dhcp-relay


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
User documentation created for the config-sync service.
Adds a new page called "Config Sync" under Configuration Guide > Service

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T775 
* https://vyos.dev/T6121

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->
Sagitta

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document