### PR TITLE
sstp: T4393: Add support to configure host-name (SNI)

### DIFF
--- a/docs/configuration/vpn/sstp.rst
+++ b/docs/configuration/vpn/sstp.rst
@@ -471,6 +471,11 @@ Global Advanced options
 
   Windows Internet Name Service (WINS) servers propagated to client
 
+.. cfgcmd:: set vpn sstp host-name <hostname>
+
+  If this option is given, only SSTP connections to the specified host
+  and with the same TLS SNI will be allowed.
+
 ***********************
 Configuring SSTP client
 ***********************


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->
Add option to vpn sstp ```set vpn sstp host-name <hostname>```
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T4393

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-1x/pull/3436
## Backport
<!-- optional: the PR should backport to this documentation branch -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document