### PR TITLE
evpn: T6306: add multihoming documentation

### DIFF
--- a/docs/_include/interface-evpn-uplink.txt
+++ b/docs/_include/interface-evpn-uplink.txt
@@ -1,0 +1,11 @@
+.. cfgcmd:: set interfaces {{ var0 }} <interface> evpn uplink
+
+  When all the underlay links go down the PE no longer has access
+  to the VxLAN +overlay. To prevent blackholing of traffic the
+  server/ES links are protodowned on the PE.
+
+  A link can be setup for uplink tracking via the following example:
+
+  .. code-block:: none
+
+    set interfaces {{ var0 }} {{ var1 }} evpn uplink

--- a/docs/configuration/interfaces/bonding.rst
+++ b/docs/configuration/interfaces/bonding.rst
@@ -286,6 +286,54 @@ Port Mirror (SPAN)
    :var1: bond1
    :var2: eth3
 
+EVPN Multihoming
+----------------
+
+All-Active Multihoming is used for redundancy and load sharing. Servers are
+attached to two or more PEs and the links are bonded (link-aggregation).
+This group of server links is referred to as an :abbr:`ES (Ethernet Segment)`.
+
+An Ethernet Segment can be configured by specifying a system-MAC and a local
+discriminator or a complete ESINAME against the bond interface on the PE.
+
+.. cfgcmd:: set interfaces bonding <interface> evpn es-id <<1-16777215|10-byte ID>
+.. cfgcmd:: set interfaces bonding <interface> evpn es-sys-mac <xx:xx:xx:xx:xx:xx>
+
+  The sys-mac and local discriminator are used for generating a 10-byte, Type-3
+  Ethernet Segment ID. ESINAME is a 10-byte, Type-0 Ethernet Segment ID -
+  "00:AA:BB:CC:DD:EE:FF:GG:HH:II".
+
+  Type-1 (EAD-per-ES and EAD-per-EVI) routes are used to advertise the locally
+  attached ESs and to learn off remote ESs in the network. Local Type-2/MAC-IP
+  routes are also advertised with a destination ESI allowing for MAC-IP syncing
+  between Ethernet Segment peers. Reference: RFC 7432, RFC 8365
+
+  EVPN-MH is intended as a replacement for MLAG or Anycast VTEPs. In multihoming
+  each PE has an unique VTEP address which requires the introduction of a new
+  dataplane construct, MAC-ECMP. Here a MAC/FDB entry can point to a list of
+  remote PEs/VTEPs.
+
+.. cfgcmd:: set interfaces bonding <interface> evpn es-df-pref <1-65535>
+
+  Type-4 (ESR) routes are used for Designated Forwarder (DF) election.
+  DFs forward BUM traffic received via the overlay network. This
+  implementation uses a preference based DF election specified by
+  draft-ietf-bess-evpn-pref-df.
+
+  The DF preference is configurable per-ES.
+
+  BUM traffic is rxed via the overlay by all PEs attached to a server but
+  only the DF can forward the de-capsulated traffic to the access port.
+  To accommodate that non-DF filters are installed in the dataplane to drop
+  the traffic.
+
+  Similarly traffic received from ES peers via the overlay cannot be forwarded
+  to the server. This is split-horizon-filtering with local bias.
+
+.. cmdinclude:: /_include/interface-evpn-uplink.txt
+   :var0: bonding
+   :var1: bond0
+
 *******
 Example
 *******
@@ -590,4 +638,3 @@ Operation
      Partner Churn State: churned
      Actor Churned Count: 1
      Partner Churned Count: 1
-

--- a/docs/configuration/interfaces/ethernet.rst
+++ b/docs/configuration/interfaces/ethernet.rst
@@ -118,6 +118,14 @@ Authentication (EAPoL)
    :var0: ethernet
    :var1: eth0
 
+EVPN Multihoming
+----------------
+
+Uplink/Core tracking.
+
+.. cmdinclude:: /_include/interface-evpn-uplink.txt
+   :var0: ethernet
+   :var1: eth0
 
 VLAN
 ====
@@ -289,4 +297,3 @@ Operation
         Date code               : 0506xx
 
 .. stop_vyoslinter
-


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add missing documentation for bond interface EVPN-MH.
Add documentation for ethernet interface EVPN MH uplink tracking

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T6306

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
* https://github.com/vyos/vyos-1x/pull/3447

## Backport
<!-- optional: the PR should backport to this documentation branch -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document