### PR TITLE
T4519: update documentation to reference DUID instead of IAID_DUID

### DIFF
--- a/docs/_locale/de/configuration.pot
+++ b/docs/_locale/de/configuration.pot
@@ -12421,8 +12421,8 @@ msgid "Sometimes option lines in the generated OpenVPN configuration require quo
 msgstr "Sometimes option lines in the generated OpenVPN configuration require quotes. This is done through a hack on our config generator. You can pass quotes using the ``&quot;`` statement."
 
 #: ../../configuration/service/dhcp-server.rst:771
-msgid "Sort the output by the specified key. Possible keys: expires, iaid_duid, ip, last_comm, pool, remaining, state, type (default = ip)"
-msgstr "Sort the output by the specified key. Possible keys: expires, iaid_duid, ip, last_comm, pool, remaining, state, type (default = ip)"
+msgid "Sort the output by the specified key. Possible keys: expires, duid, ip, last_comm, pool, remaining, state, type (default = ip)"
+msgstr "Sort the output by the specified key. Possible keys: expires, duid, ip, last_comm, pool, remaining, state, type (default = ip)"
 
 #: ../../configuration/service/dhcp-server.rst:566
 msgid "Sort the output by the specified key. Possible keys: ip, hardware_address, state, start, end, remaining, pool, hostname (default = ip)"
@@ -13647,8 +13647,8 @@ msgid "The hostname or IP address of the master"
 msgstr "The hostname or IP address of the master"
 
 #: ../../configuration/service/dhcp-server.rst:700
-msgid "The identifier is the device's DUID: colon-separated hex list (as used by isc-dhcp option dhcpv6.client-id). If the device already has a dynamic lease from the DHCPv6 server, its DUID can be found with ``show service dhcpv6 server leases``. The DUID begins at the 5th octet (after the 4th colon) of IAID_DUID."
-msgstr "The identifier is the device's DUID: colon-separated hex list (as used by isc-dhcp option dhcpv6.client-id). If the device already has a dynamic lease from the DHCPv6 server, its DUID can be found with ``show service dhcpv6 server leases``. The DUID begins at the 5th octet (after the 4th colon) of IAID_DUID."
+msgid "The identifier is the device's DUID: colon-separated hex list (as used by isc-dhcp option dhcpv6.client-id). If the device already has a dynamic lease from the DHCPv6 server, its DUID can be found with ``show service dhcpv6 server leases``."
+msgstr "The identifier is the device's DUID: colon-separated hex list (as used by isc-dhcp option dhcpv6.client-id). If the device already has a dynamic lease from the DHCPv6 server, its DUID can be found with ``show service dhcpv6 server leases``."
 
 #: ../../configuration/vpn/dmvpn.rst:237
 msgid "The individual spoke configurations only differ in the local IP address on the ``tun10`` interface. See the above diagram for the individual IP addresses."

--- a/docs/configuration/service/dhcp-server.rst
+++ b/docs/configuration/service/dhcp-server.rst
@@ -31,7 +31,8 @@ Configuration
    Will drop `<shared-network-name>_` from client DNS record, using only the
    host declaration name and domain: `<hostname>.<domain-name>`
 
-.. cfgcmd:: set service dhcp-server shared-network-name <name> domain-name <domain-name>
+.. cfgcmd:: set service dhcp-server shared-network-name <name>
+   domain-name <domain-name>
 
    The domain-name parameter should be the domain name that will be appended to
    the client's hostname to form a fully-qualified domain-name (FQDN) (DHCP
@@ -40,7 +41,8 @@ Configuration
    This is the configuration parameter for the entire shared network definition.
    All subnets will inherit this configuration item if not specified locally.
 
-.. cfgcmd:: set service dhcp-server shared-network-name <name> domain-search <domain-name>
+.. cfgcmd:: set service dhcp-server shared-network-name <name>
+   domain-search <domain-name>
 
    The domain-name parameter should be the domain name used when completing DNS
    request where no full FQDN is passed. This option can be given multiple times
@@ -49,7 +51,8 @@ Configuration
    This is the configuration parameter for the entire shared network definition.
    All subnets will inherit this configuration item if not specified locally.
 
-.. cfgcmd:: set service dhcp-server shared-network-name <name> name-server <address>
+.. cfgcmd:: set service dhcp-server shared-network-name <name>
+   name-server <address>
 
    Inform client that the DNS server can be found at `<address>`.
 
@@ -234,7 +237,8 @@ inside the subnet definition but can be outside of the range statement.
 
 **Example:**
 
-* IP address ``192.168.1.100`` shall be statically mapped to client named ``client1``
+* IP address ``192.168.1.100`` shall be statically mapped to
+  client named ``client1``
 
 .. code-block:: none
 

--- a/docs/configuration/service/dhcp-server.rst
+++ b/docs/configuration/service/dhcp-server.rst
@@ -724,8 +724,7 @@ be created. The following example explains the process.
 .. hint:: The identifier is the device's DUID: colon-separated hex list (as
    used by isc-dhcp option dhcpv6.client-id). If the device already has a
    dynamic lease from the DHCPv6 server, its DUID can be found with ``show
-   service dhcpv6 server leases``. The DUID begins at the 5th octet (after the
-   4th colon) of IAID_DUID.
+   service dhcpv6 server leases``.
 
 .. code-block:: none
 
@@ -778,10 +777,10 @@ Operation Mode
 .. code-block:: none
 
   vyos@vyos:~$ show dhcpv6 server leases
-  IPv6 address   State    Last communication    Lease expiration     Remaining    Type           Pool   IAID_DUID
+  IPv6 address   State    Last communication    Lease expiration     Remaining    Type           Pool   DUID
   -------------  -------  --------------------  -------------------  -----------  -------------  -----  --------------------------------------------
-  2001:db8::101  active   2019/12/05 19:40:10   2019/12/06 07:40:10  11:45:21     non-temporary  NET1   98:76:54:32:00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:ff
-  2001:db8::102  active   2019/12/05 14:01:23   2019/12/06 02:01:23  6:06:34      non-temporary  NET1   87:65:43:21:00:01:00:01:11:22:33:44:fa:fb:fc:fd:fe:ff
+  2001:db8::101  active   2019/12/05 19:40:10   2019/12/06 07:40:10  11:45:21     non-temporary  NET1   00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:ff
+  2001:db8::102  active   2019/12/05 14:01:23   2019/12/06 02:01:23  6:06:34      non-temporary  NET1   00:01:00:01:11:22:33:44:fa:fb:fc:fd:fe:ff
 
 .. hint:: Static mappings aren't shown. To show all states, use ``show dhcp
    server leases state all``.
@@ -792,7 +791,7 @@ Operation Mode
 
 .. opcmd:: show dhcpv6 server leases sort <key>
 
-   Sort the output by the specified key. Possible keys: expires, iaid_duid, ip,
+   Sort the output by the specified key. Possible keys: expires, duid, ip,
    last_comm, pool, remaining, state, type (default = ip)
 
 .. opcmd:: show dhcpv6 server leases state <state>


### PR DESCRIPTION
## Change Summary
Reflect change from IAID_DUID to DUID in op mode command

## Related Task(s)
* https://vyos.dev/T4519

## Related PR(s)
vyos/vyos-1x#3462


## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document