### PR TITLE
Correct container network prefix doc

### DIFF
--- a/docs/configuration/container/index.rst
+++ b/docs/configuration/container/index.rst
@@ -176,8 +176,8 @@ Container Networks
 
 .. cfgcmd:: set container network <name> prefix <ipv4|ipv6>
 
-    Define IPv4 or IPv6 prefix for a given network name. Only one IPv4 and
-    one IPv6 prefix can be used per network name.
+    Define IPv4 and/or IPv6 prefix for a given network name.
+    Both IPv4 and IPv6 can be used in parallel.
 
 .. cfgcmd:: set container network <name> vrf <nme>
 


### PR DESCRIPTION
## Change Summary
Container network prefix is a multi node and allows to specify IPv4 and IPv6 prefix at the same time.

## Backport
Also applies to Sagitta



## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document