### PR TITLE
T6358: add documentation for container host pid

### DIFF
--- a/docs/configuration/container/index.rst
+++ b/docs/configuration/container/index.rst
@@ -44,13 +44,20 @@ Configuration
 
     Set the host name for a container.
 
+.. cfgcmd:: set container name <name> allow-host-pid
+
+    The container and the host share the same process namespace.
+    This means that processes running on the host are visible inside the
+    container, and processes inside the container are visible on the host.
+
+    The command translates to "--pid host" when the container is created.
+
 .. cfgcmd:: set container name <name> allow-host-networks
 
     Allow host networking in a container. The network stack of the container is
     not isolated from the host and will use the host IP.
 
-    The following commands translate to "--net host" when the container
-    is created
+    The command translates to "--net host" when the container is created.
 
     .. note:: **allow-host-networks** cannot be used with **network**
 


### PR DESCRIPTION
## Change Summary
Add documentation for container `allow-host-pid` config option

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
https://vyos.dev/T6358

## Related PR(s)
vyos/vyos-1x#3472

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document