### PR TITLE
reverse-proxy: T6409: Remove unused backend parameters

### DIFF
--- a/docs/configuration/loadbalancing/reverse-proxy.rst
+++ b/docs/configuration/loadbalancing/reverse-proxy.rst
@@ -118,11 +118,6 @@ Backend
 
   Configure backend `<name>` mode TCP or HTTP
 
-.. cfgcmd:: set load-balancing reverse-proxy backend <name> parameters
-   http-check
-
-  Enable layer 7 HTTP health check
-
 .. cfgcmd:: set load-balancing reverse-proxy backend <name> server
    <name> address <x.x.x.x>
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Made changes to `reverse-proxy.rst` for the following:
- Removed from documentation unused backend configuration node `parameters http-check`

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* [https://vyos.dev/T6409](https://vyos.dev/T6409)

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
- vyos/vyos-1x/pull/3531

## Backport
<!-- optional: the PR should backport to this documentation branch -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document