### PR TITLE
Changed parameter flavor from iso to generic for 1.5 (circinus, current)

### DIFF
--- a/docs/contributing/build-vyos.rst
+++ b/docs/contributing/build-vyos.rst
@@ -65,9 +65,13 @@ To start, clone the repository to your local machine:
   $ ./configure --architecture amd64 --build-by "j.randomhacker@vyos.io"
   $ sudo make iso
 
-  # For VyOS 1.4 (sagitta) and VyOS 1.5 (circinus,current)
+  # For VyOS 1.4 (sagitta)
   $ sudo make clean
   $ sudo ./build-vyos-image iso --architecture amd64 --build-by "j.randomhacker@vyos.io"
+
+  # For VyOS 1.5 (circinus,current)
+  $ sudo make clean
+  $ sudo ./build-vyos-image generic --architecture amd64 --build-by "j.randomhacker@vyos.io"
 
 For the packages required, you can refer to the ``docker/Dockerfile`` file
 in the repository_. The ``./build-vyos-image`` script will also warn you if any
@@ -274,9 +278,13 @@ Start the build:
   vyos_bld@8153428c7e1f:/vyos$ ./configure --architecture amd64 --build-by "j.randomhacker@vyos.io"
   vyos_bld@8153428c7e1f:/vyos$ sudo make iso
 
-  # For VyOS 1.4 (sagitta) For VyOS 1.5 (circinus,current)
+  # For VyOS 1.4 (sagitta)
   vyos_bld@8153428c7e1f:/vyos$ sudo make clean
   vyos_bld@8153428c7e1f:/vyos$ sudo ./build-vyos-image iso --architecture amd64 --build-by "j.randomhacker@vyos.io"
+
+  # For VyOS 1.5 (circinus,current)
+  vyos_bld@8153428c7e1f:/vyos$ sudo make clean
+  vyos_bld@8153428c7e1f:/vyos$ sudo ./build-vyos-image generic --architecture amd64 --build-by "j.randomhacker@vyos.io"
 
 When the build is successful, the resulting iso can be found inside the
 ``build`` directory as ``live-image-[architecture].hybrid.iso``.


### PR DESCRIPTION
The flavor has been renamed in this branch.
https://vyos.dev/T6414

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Changed parameter flavor from iso to generic for 1.5 (circinus, current)
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T6414


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document