### PR TITLE
T6219: Add doc for container sysctl parameter

### DIFF
--- a/docs/configuration/container/index.rst
+++ b/docs/configuration/container/index.rst
@@ -168,6 +168,17 @@ Configuration
      setdomainame)
    - **sys-time**: Permission to set system clock
 
+.. cfgcmd:: set container name <name> sysctl parameter <parameter> value <value>
+
+   Set container sysctl values.
+
+   The subset of possible parameters are:
+
+   - Kernel Parameters: kernel.msgmax, kernel.msgmnb, kernel.msgmni, kernel.sem,
+     kernel.shmall, kernel.shmmax, kernel.shmmni, kernel.shm_rmid_forced
+   - Parameters beginning with fs.mqueue.*
+   - Parameters beginning with net.* (only if user-defined network is used)
+
 .. cfgcmd:: set container name <name> label <label> value <value>
 
    Add metadata label for this container.


### PR DESCRIPTION
## Change Summary
Documentation for container sysctl parameter

## Related Task(s)
https://vyos.dev/T6219

## Related PR(s)
vyos/vyos-1x#3614

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document