### PR TITLE
wireless: T6318: move country-code to a system wide configuration

### DIFF
--- a/docs/configuration/interfaces/wireless.rst
+++ b/docs/configuration/interfaces/wireless.rst
@@ -36,6 +36,17 @@ Common interface configuration
    :var0: wireless
    :var1: wlan0
 
+System Wide configuration
+=========================
+
+.. cfgcmd:: set system wireless country-code <cc>
+
+  Country code (ISO/IEC 3166-1). Used to set regulatory domain. Set as needed
+  to indicate country in which device is operating. This can limit available
+  channels and transmit power.
+
+  .. note:: This option is mandatory in Access-Point mode.
+
 Wireless options
 ================
 
@@ -43,14 +54,6 @@ Wireless options
 
   Channel number (IEEE 802.11), for 2.4Ghz (802.11 b/g/n) channels range from
   1-14. On 5Ghz (802.11 a/h/j/n/ac) channels available are 0, 34 to 173
-
-.. cfgcmd:: set interfaces wireless <interface> country-code <cc>
-
-  Country code (ISO/IEC 3166-1). Used to set regulatory domain. Set as needed
-  to indicate country in which device is operating. This can limit available
-  channels and transmit power.
-
-  .. note:: This option is mandatory in Access-Point mode.
 
 .. cfgcmd:: set interfaces wireless <interface> disable-broadcast-ssid
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Wireless devices are subject to regulations issued by authorities. For any given AP or router, there will most likely be no case where one wireless NIC is located in one country and another wireless NIC in the same device is located in another country, resulting in different regulatory domains to apply to the same box.

Currently, wireless regulatory domains in VyOS need to be configured per-NIC:
  `set interfaces wireless wlan0 country-code us`

This leads to several side-effects:
* When operating multiple WiFi NICs, they all can have different regulatory domains configured which might offend legislation.
* Some NICs need additional entries to `/etc/modprobe.d/cfg80211.conf` to apply regulatory domain settings, such as: "options cfg80211 ieee80211_regdom=US" This is true for the Compex WLE600VX. This setting cannot be done per-interface.

Migrate the first found wireless module country-code from the wireless interface CLI to: `system wireless country-code`

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T6318

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
* https://github.com/vyos/vyos-1x/pull/3656

## Backport
<!-- optional: the PR should backport to this documentation branch -->

NO

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document