### PR TITLE
Added info how to use DNAT and VRRP with rfc3768-compatibility

### DIFF
--- a/docs/configuration/highavailability/index.rst
+++ b/docs/configuration/highavailability/index.rst
@@ -163,6 +163,7 @@ messages sent by the active node. When the rfc3768-compatibility option is set,
 a new VRRP interface is created, to which the MAC address and the virtual IP 
 address is automatically assigned.
 
+
 .. code-block:: none
 
    set high-availability vrrp group Foo rfc3768-compatibility
@@ -177,6 +178,10 @@ Verification
    link/ether 00:00:5e:00:01:0a brd ff:ff:ff:ff:ff:ff
    inet 172.25.0.247/16 scope global eth0v10
    valid_lft forever preferred_lft forever
+
+.. warning:: RFC 3768 creates a virtual interface. If you want to apply 
+   the destination NAT rule to the traffic sent to the virtual MAC, set 
+   the created virtual interface as `inbound-interface`.
 
 Scripting
 ---------


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added warning info on how to use DNAT and VRRP with
rfc3768-compatibility.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document