### PR TITLE
T2891: add documentation for ring-buffer option

### DIFF
--- a/docs/configuration/interfaces/ethernet.rst
+++ b/docs/configuration/interfaces/ethernet.rst
@@ -52,6 +52,14 @@ Ethernet options
 
    VyOS default will be `auto`.
 
+.. cfgcmd:: set interface ethernet <interface> ring-buffer rx <value>
+.. cfgcmd:: set interface ethernet <interface> ring-buffer tx <value>
+
+  Configures the ring buffer size of the interface.
+
+  The supported values for a specific interface can be obtained
+  with: `ethtool -g <interface>`
+
 
 Offloading
 ----------
@@ -295,5 +303,3 @@ Operation
         BR margin, min          : 0%
         Vendor SN               : FNS092xxxxx
         Date code               : 0506xx
-
-.. stop_vyoslinter


### PR DESCRIPTION
## Change Summary
add documentation for ring-buffer configuration

## Related Task(s)
https://vyos.dev/T2891

## Related PR(s)

## Backport
also applies to older branches

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document