### PR TITLE
Deleted non-existing options in geneve interface

### DIFF
--- a/docs/configuration/interfaces/geneve.rst
+++ b/docs/configuration/interfaces/geneve.rst
@@ -41,9 +41,33 @@ Configuration
 Common interface configuration
 ==============================
 
-.. cmdinclude:: /_include/interface-common-without-dhcp.txt
-   :var0: geneve
-   :var1: gnv0
+.. cmdinclude:: /_include/interface-address.txt
+  :var0: geneve
+  :var1: gnv0
+
+.. cmdinclude:: /_include/interface-description.txt
+  :var0: geneve
+  :var1: gnv0
+
+.. cmdinclude:: /_include/interface-disable.txt
+  :var0: geneve
+  :var1: gnv0
+
+.. cmdinclude:: /_include/interface-mac.txt
+  :var0: geneve
+  :var1: gnv0
+
+.. cmdinclude:: /_include/interface-mtu.txt
+  :var0: geneve
+  :var1: gnv0
+
+.. cmdinclude:: /_include/interface-ip.txt
+  :var0: geneve
+  :var1: gnv0
+
+.. cmdinclude:: /_include/interface-ipv6.txt
+  :var0: geneve
+  :var1: gnv0
 
 GENEVE options
 ==============


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Deleted not existing options in geneve interface.
`set interfaces geneve <interface> disable-link-detect`
`set interfaces geneve <interface> disable-flow-control`
`set interfaces geneve <interface> vrf <vrf>`

Now in VyOS 1.5 and 1.4.0:
```
vyos@vyos# set interfaces geneve gnv0
Possible completions:
+  address              IP address
   description          Description
   disable              Administratively disable interface
 > ip                   IPv4 routing parameters
 > ipv6                 IPv6 routing parameters
   mac                  Media Access Control (MAC) address
 > mirror               Mirror ingress/egress packets
   mtu                  Maximum Transmission Unit (MTU) (default: 1500)
 > parameters           GENEVE tunnel parameters
   redirect             Redirect incoming packet to destination
   remote               Tunnel remote address
   vni                  Virtual Network Identifier

```
## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->


## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document