### PR TITLE
op-mode: T6601: move "reset ip(v6) arp|neighbor" to "clear ip(v6) arp|neighbor"

### DIFF
--- a/docs/configuration/system/ip.rst
+++ b/docs/configuration/system/ip.rst
@@ -90,8 +90,24 @@ See below the different parameters available for the IPv4 **show** command:
      rip           Show Routing Information Protocol (RIP) information
      route         Show IP routes
 
+Clear commands
+^^^^^^^^^^^^^^
 
-reset commands
+.. opcmd:: clear ip arp <address | interface | table>
+
+   Use this command to reset IPv6 Neighbor Discovery Protocol cache for
+   an address or interface.
+
+.. opcmd:: clear ip arp table
+
+   Flush entire ARP cache
+
+.. opcmd:: clear ip route cache
+
+   Use this command to flush the kernel IPv6 route cache.
+   An address can be added to flush it only for that route.
+
+Reset commands
 ^^^^^^^^^^^^^^
 
 And the different IPv4 **reset** commands available:

--- a/docs/configuration/system/ip.rst
+++ b/docs/configuration/system/ip.rst
@@ -110,14 +110,26 @@ Clear commands
 Reset commands
 ^^^^^^^^^^^^^^
 
-And the different IPv4 **reset** commands available:
+.. opcmd:: reset bgp ipv4 <address>
 
-.. code-block:: none
+   Use this command to reset :abbr:`BGP (Border Gateway Protocol)` session to
+   address.
 
-   vyos@vyos:~$ reset ip
-   Possible completions:
-     arp           Reset Address Resolution Protocol (ARP) cache
-     bgp           Clear Border Gateway Protocol (BGP) statistics or status
-     igmp          IGMP clear commands
-     multicast     IP multicast routing table
-     route         Reset IP route
+.. opcmd:: reset bgp ipv4 <1-4294967295>
+
+   Use this command to reset :abbr:`BGP (Border Gateway Protocol)` session to
+   specific ASN.
+
+.. opcmd:: reset bgp ipv4 all
+
+   Use this command to reset all :abbr:`BGP (Border Gateway Protocol)` sessions.
+
+.. opcmd:: reset bgp ipv4 external
+
+   Use this command to reset all external :abbr:`BGP (Border Gateway Protocol)`
+   sessions.
+
+.. opcmd:: reset bgp ipv4 peer-group <name>
+
+   Use this command to reset all :abbr:`BGP (Border Gateway Protocol)` member
+   sessions of a peer-group.

--- a/docs/configuration/system/ipv6.rst
+++ b/docs/configuration/system/ipv6.rst
@@ -158,6 +158,22 @@ Show commands
 
    Use this command to show the status of the RIPNG protocol
 
+Clear commands
+^^^^^^^^^^^^^^
+
+.. opcmd:: clear ipv6 neighbors <address | interface>
+
+   Use this command to reset IPv6 Neighbor Discovery Protocol cache for
+   an address or interface.
+
+.. opcmd:: clear ipv6 neighbors table
+
+   Flush entire IPv6 ND cache
+
+.. opcmd:: clear ipv6 route cache
+
+   Use this command to flush the kernel IPv6 route cache.
+   An address can be added to flush it only for that route.
 
 Reset commands
 ^^^^^^^^^^^^^^

--- a/docs/configuration/system/ipv6.rst
+++ b/docs/configuration/system/ipv6.rst
@@ -180,16 +180,24 @@ Reset commands
 
 .. opcmd:: reset bgp ipv6 <address>
 
-   Use this command to clear Border Gateway Protocol statistics or
-   status.
+   Use this command to reset :abbr:`BGP (Border Gateway Protocol)` session to
+   address.
 
+.. opcmd:: reset bgp ipv6 <1-4294967295>
 
-.. opcmd:: reset ipv6 neighbors <address | interface>
+   Use this command to reset :abbr:`BGP (Border Gateway Protocol)` session to
+   specific ASN.
 
-   Use this command to reset IPv6 Neighbor Discovery Protocol cache for
-   an address or interface.
+.. opcmd:: reset bgp ipv6 all
 
-.. opcmd:: reset ipv6 route cache
+   Use this command to reset all :abbr:`BGP (Border Gateway Protocol)` sessions.
 
-   Use this command to flush the kernel IPv6 route cache.
-   An address can be added to flush it only for that route.
+.. opcmd:: reset bgp ipv6 external
+
+   Use this command to reset all external :abbr:`BGP (Border Gateway Protocol)`
+   sessions.
+
+.. opcmd:: reset bgp ipv6 peer-group <name>
+
+   Use this command to reset all :abbr:`BGP (Border Gateway Protocol)` member
+   sessions of a peer-group.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Move reset ip(v6) arp|neighbor to clear ip(v6) arp|neighbor

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T6601

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
* https://github.com/vyos/vyos-1x/pull/3885

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document