### PR TITLE
interface: correct documentation for dhcpv6-options no-release

### DIFF
--- a/docs/_include/interface-dhcpv6-options.txt
+++ b/docs/_include/interface-dhcpv6-options.txt
@@ -14,8 +14,8 @@
 .. cfgcmd:: set interfaces {{ var0 }} <interface> {{ var2 }} {{ var3 }}
   {{ var5 }} {{ var6 }} dhcpv6-options no-release
 
-  When no-release is specified, dhcp6c will send a release message on client
-  exit to prevent losing an assigned address or prefix.
+  When no-release is specified, dhcp6c will avoid sending a release message on
+  client exit in order to prevent losing an assigned address or prefix.
 
   .. code-block:: none
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The current documentation makes it sound like the `no-release` option does the opposite of what it actually does. It was clearly a simple typo. :slightly_smiling_face: 

I decided to modify the wording slightly to make it even more clear.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document