### PR TITLE
Firewall: add warning message in firewall doc

### DIFF
--- a/docs/configuration/firewall/index.rst
+++ b/docs/configuration/firewall/index.rst
@@ -4,6 +4,11 @@
 Firewall
 ########
 
+.. warning:: Due to a race condition that can lead to a failure during boot
+   process, all interfaces are initialized before firewall is configured. This
+   leads to a situation where the system is open to all traffic, and can be
+   considered as a security risk.
+
 As VyOS is based on Linux it leverages its firewall. The Netfilter project
 created iptables and its successor nftables for the Linux kernel to
 work directly on packet data flows. This now extends the concept of 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Firewall: add warning message, saying that during boot, all interfaces are loaded before firewall.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/Txxxx
https://vyos.dev/T5794

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-1x/pull/3988
## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document