### PR TITLE
Update Prefix delegation

### DIFF
--- a/docs/configuration/service/dhcp-server.rst
+++ b/docs/configuration/service/dhcp-server.rst
@@ -682,7 +682,8 @@ server. The following example describes a common scenario.
 
 .. code-block:: none
 
-  set service dhcpv6-server shared-network-name 'NET1' subnet 2001:db8::/64 range 1 start 2001:db8::100 stop 2001:db8::199
+  set service dhcpv6-server shared-network-name 'NET' interface 'eth1'
+  set service dhcpv6-server shared-network-name 'NET1' subnet 2001:db8::/64 range 1 start 2001:db8::100
   set service dhcpv6-server shared-network-name 'NET1' subnet 2001:db8::/64 range 1 stop 2001:db8::199
   set service dhcpv6-server shared-network-name 'NET1' subnet 2001:db8::/64 option name-server 2001:db8::ffff
   set service dhcpv6-server shared-network-name 'NET1' subnet 2001:db8::/64 subnet-id 1

--- a/docs/configuration/service/dhcp-server.rst
+++ b/docs/configuration/service/dhcp-server.rst
@@ -776,10 +776,12 @@ Operation Mode
 .. code-block:: none
 
   vyos@vyos:~$ show dhcpv6 server leases
-  IPv6 address   State    Last communication    Lease expiration     Remaining    Type           Pool   IAID_DUID
-  -------------  -------  --------------------  -------------------  -----------  -------------  -----  --------------------------------------------
-  2001:db8::101  active   2019/12/05 19:40:10   2019/12/06 07:40:10  11:45:21     non-temporary  NET1   98:76:54:32:00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:ff
-  2001:db8::102  active   2019/12/05 14:01:23   2019/12/06 02:01:23  6:06:34      non-temporary  NET1   87:65:43:21:00:01:00:01:11:22:33:44:fa:fb:fc:fd:fe:ff
+  IPv6 address      State    Last communication    Lease expiration     Remaining    Type   Pool      DUID
+  ----------------  -------  --------------------  -------------------  -----------  -----  --------  --------------------------------------------
+  2001:db8::101     active   2019/12/05 19:40:10   2019/12/06 07:40:10  11:45:21     IA_NA  NET1      98:76:54:32:00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:ff
+  2001:db8::102     active   2019/12/05 14:01:23   2019/12/06 02:01:23  6:06:34      IA_NA  NET1      87:65:43:21:00:01:00:01:11:22:33:44:fa:fb:fc:fd:fe:ff
+  2001:db8:10::/64  active   2019/12/05 23:20:10   2019/12/06 11:40:10  11:45:21     IA_PD  PD-NET1   98:76:54:32:00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:ff
+
 
 .. hint:: Static mappings aren't shown. To show all states, use ``show dhcp
    server leases state all``.

--- a/docs/configuration/service/dhcp-server.rst
+++ b/docs/configuration/service/dhcp-server.rst
@@ -627,15 +627,44 @@ used:
 
 
 .. cfgcmd:: set service dhcpv6-server shared-network-name <name> subnet
-   <prefix> prefix-delegation start <address> prefix-length <length>
+   <prefix> prefix-delegation prefix <pd-prefix> prefix-length <lenght>
 
-   Hand out prefixes of size `<length>` to clients in subnet `<prefix>` when
-   they request for prefix delegation.
+   Delegate prefixes from `<pd-prefix>` to clients in subnet `<prefix>`. Range
+   is defined by `<lenght>` in bits, 32 to 64.
 
 .. cfgcmd:: set service dhcpv6-server shared-network-name <name> subnet
-   <prefix> prefix-delegation start <address> stop <address>
+   <prefix> prefix-delegation prefix <pd-prefix> delegated-length <lenght>
 
-   Delegate prefixes from the range indicated by the start and stop qualifier.
+   Hand out prefixes of size `<length>` in bits from `<pd-prefix>` to clients
+   in subnet `<prefix>` when the request for prefix delegation.
+
+.. cfgcmd:: set service dhcpv6-server shared-network-name <name> subnet
+   <prefix> prefix-delegation prefix <pd-prefix> excluded-prefix <exclude-prefix>
+
+   Exclude `<exclude-prefix>` from `<pd-prefix>`.
+
+
+.. cfgcmd:: set service dhcpv6-server shared-network-name <name> subnet
+   <prefix> prefix-delegation prefix <pd-prefix> excluded-prefix-length <length> 
+
+   Define lenght of exclude prefix in `<pd-prefix>`.
+
+**Example:**
+
+* A shared network named ``PD-NET`` serves subnet ``2001:db8::/64``.
+* It is connected to ``eth1``.
+* Address pool shall be ``2001:db8::100`` through ``2001:db8::199``.
+* It hands out prefixes ``2001:db8:0:10::/64`` through ``2001:db8:0:1f::/64``.
+
+.. code-block:: none
+
+  set service dhcpv6-server shared-network-name 'PD-NET' interface 'eth1'
+  set service dhcpv6-server shared-network-name 'PD-NET' subnet 2001:db8::/64 range 1 start 2001:db8::100
+  set service dhcpv6-server shared-network-name 'PD-NET' subnet 2001:db8::/64 range 1 stop 2001:db8::199
+  set service dhcpv6-server shared-network-name 'PD-NET' subnet 2001:db8::/64 prefix-delegation prefix 2001:db8:0:10:: delegated-length '64'
+  set service dhcpv6-server shared-network-name 'PD-NET' subnet 2001:db8::/64 prefix-delegation prefix 2001:db8:0:10:: prefix-length '60'
+  
+
 
 Address pools
 -------------


### PR DESCRIPTION
- After the KEA dhcp server update the syntax of prefix delegation has
  changed. This PR reflects the changes.
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Prefix delegation syntax changed with KEA, this reflects the new syntx.
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/Txxxx

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document