### PR TITLE
Revert "T6719: document local host name config option"

### DIFF
--- a/docs/configuration/system/syslog.rst
+++ b/docs/configuration/system/syslog.rst
@@ -30,10 +30,6 @@ indicate that the logging system is functioning.
 If set, the domain part of the hostname is always sent,
 even within the same domain as the receiving system.
 
-.. cfgcmd:: system syslog global local-host-name <fqdn>
-
-Overwrites the local system host name used in syslogs.
-
 .. cfgcmd:: system rsyslog global facility <keyword> level <keyword>
 
 Filter syslog messages based on facility and level.


### PR DESCRIPTION
Reverts vyos/vyos-documentation#1550

It was decided in vyos/vyos-1x#4079 to not expose this as a dedicated config option but auto-configure when existing `preserve-fqdn` is enabled.