### PR TITLE
T6794: Clarification on appropriate URL for update-check

### DIFF
--- a/docs/installation/update.rst
+++ b/docs/installation/update.rst
@@ -78,10 +78,15 @@ You can use ``latest`` option. It loads the latest available Rolling release.
 
      vyos@vyos:~$ add system image latest
 
-.. note:: To use the `latest` option the "system update-check url" must be configured.
+.. note:: To use the `latest` option the "system update-check url" must be configured 
+   appropriately for the installed release. 
+
+   For updates to the Rolling Release for AMD64, the following URL may be used:
+
+   https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/current/version.json
 
 .. hint:: The most up-do-date Rolling Release for AMD64 can be accessed using
-   the following URL:
+   the following URL from a web browser:
    
    https://vyos.net/get/nightly-builds/
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
* Looks like some people have been trying to use the nightly-build list (or other repo URLs) as an update-check URL
* This modification provides a metadata URL for the rolling-release and attempts to make more obvious the difference between that and the rolling image list.

I understand there's some big changes coming down the pipe that will need equally large changes to doco. If my changes aren't appropriate or incorrect, let me know and I'll drop the PR or tweak it further. 

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T6794

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document. It was a very short read. 