### PR TITLE
Multiple certificates on a single haproxy service

### DIFF
--- a/docs/configuration/loadbalancing/haproxy.rst
+++ b/docs/configuration/loadbalancing/haproxy.rst
@@ -43,7 +43,7 @@ Service
 .. cfgcmd:: set load-balancing haproxy service <name> ssl
    certificate <name>
 
-  Set SSL certificate <name> for service <name>
+  Set SSL certificate <name> for service <name>. Multiple certificates could be defined.
 
 .. cfgcmd:: set load-balancing haproxy service <name>
   http-response-headers <header-name> value <header-value>


### PR DESCRIPTION
Minor update: haproxy handles multiple certificates within a single frontend

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T5798

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
* https://vyos.dev/rVYOSONEXfe99c45e05fd5794905145ddca80e6078145c2e8

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document