### PR TITLE
config-mgmt: T5976: add missing node in commit-confirm path

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -671,7 +671,7 @@ different levels in the hierarchy.
 
    .. code-block:: none
 
-     vyos@vyos# set system config-management commit-confirm
+     vyos@vyos# set system config-management commit-confirm action
      Possible completions:
      reload               Reload previous configuration if not confirmed
      reboot               Reboot to saved configuration if not confirmed (default)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

A late adjustment to the path for setting soft-reload for commit-confirm did not make it into the docs; fix.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/Txxxx

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document