### PR TITLE
avahi: T6908: add option to define mdns-repeater max-cache entries

### DIFF
--- a/docs/configuration/service/mdns.rst
+++ b/docs/configuration/service/mdns.rst
@@ -15,6 +15,9 @@ Since the mDNS protocol sends the :abbr:`AA(Authoritative Answer)` records in
 the packet itself, the repeater does not need to forge the source address.
 Instead, the source address is of the interface that repeats the packet.
 
+.. note:: You can not run this in a VRRP setup, if multiple mDNS repeaters
+   are launched in a subnet you will experience the mDNS packet storm death!
+
 Configuration
 =============
 
@@ -43,8 +46,12 @@ Configuration
    Allow listing additional custom domains to be browsed (in addition to the
    default ``local``) so that they can be reflected.
 
-.. note:: You can not run this in a VRRP setup, if multiple mDNS repeaters
-   are launched in a subnet you will experience the mDNS packet storm death!
+.. cfgcmd:: set service mdns repeater cache-entries <entries>
+
+   Specify how many resource records are cached per interface. Bigger values
+   allow mDNS work correctly in large LANs but also increase memory consumption.
+
+   Defaults to: 4096
 
 Example
 =======


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add CLI option to configure `cache-entries-max` entries in Avahi daemon configuration.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T6908

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
* https://github.com/vyos/vyos-1x/pull/4207

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document