### PR TITLE
T6927: adds documentation for name server setting

### DIFF
--- a/docs/configuration/container/index.rst
+++ b/docs/configuration/container/index.rst
@@ -74,6 +74,12 @@ Configuration
     .. note:: The first IP in the container network is reserved by the
        engine and cannot be used
 
+.. cfgcmd:: set container name <name> name-server <address>
+
+    Optionally set a custom name server.
+    If a container network is used with DNS enabled,
+    this setting will not have any effect.
+
 .. cfgcmd:: set container name <name> description <text>
 
     Set a container description


### PR DESCRIPTION
## Change Summary
Add documentation for container name server setting

## Related Task(s)
* https://vyos.dev/T6927

## Related PR(s)
vyos/vyos-1x#4218

## Backport

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document