### PR TITLE
T6944: adds documentation for switchdev mode

### DIFF
--- a/docs/configuration/interfaces/ethernet.rst
+++ b/docs/configuration/interfaces/ethernet.rst
@@ -20,6 +20,17 @@ Common interface configuration
    :var0: ethernet
    :var1: eth0
 
+.. cfgcmd:: set interface ethernet <interface> switchdev
+
+  Switches this interface to `switchdev` mode that allows network interfaces to offload
+  certain networking functions directly to hardware, like a network switch or a SmartNIC.
+  This enables higher performance and lower latency for network processing by
+  bypassing the kernel's network stack for supported operations.
+
+.. note:: This is only supported on certain physical network interfaces
+   and depends on specific models and drivers.
+
+
 Ethernet options
 ================
 


### PR DESCRIPTION
## Change Summary
Add documentation for ethernet interface switchdev mode

## Related Task(s)
* https://vyos.dev/T6944

## Related PR(s)
vyos/vyos-1x#4235

## Backport


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document