### PR TITLE
T6013: Add docs for ssh trusted-user-ca-key feature

### DIFF
--- a/docs/configuration/service/ssh.rst
+++ b/docs/configuration/service/ssh.rst
@@ -129,6 +129,12 @@ Configuration
   ``rsa-sha2-256-cert-v01@openssh.com``, ``rsa-sha2-512``,
   ``rsa-sha2-512-cert-v01@openssh.com``
 
+.. cfgcmd::set service ssh trusted-user-ca-key ca-certificate <ca_cert_name>
+
+  Specify the name of the CA certificate that will be used to verify the user
+  certificates.
+  You can use it by adding the CA certificate with the PKI command.
+
 Dynamic-protection
 ==================
 Protects host from brute-force attacks against


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR adds support for configuring a trusted user CA key for SSH services. It integrates with the VyOS PKI system, ensuring secure management of CA certificates directly from the CLI. This implementation replaces direct file path usage with PKI-managed CA certificates.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T6013

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-1x/pull/4234

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document