### PR TITLE
installation: add note about unsupported locally administered MAC addresses

### DIFF
--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -2,6 +2,17 @@
 Installation and Image Management
 #################################
 
+.. note:: This is most likely only relevant for virtual installations:
+
+   When installing VyOS ensure that the MAC address selected for your NICs is
+   not a locally administered MAC address. Locally administered addresses are
+   distinguished from universally administered addresses by setting (assigning
+   the value of 1 to) the second-least-significant bit of the first octet of
+   the address:
+
+   Example: ``02:00:00:00:00:01``, where the second-least-significant bit
+   (``02`` in hex) is set to ``1``.
+
 .. toctree::
    :maxdepth: 2
    :caption: Content


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

When installing VyOS ensure that the MAC address selected for your NICs is not a locally administered MAC address. Locally administered addresses are distinguished from universally administered addresses by setting (assigning the value of 1 to) the second-least-significant bit of the first octet of the address:

![image](https://github.com/user-attachments/assets/c1191dd1-307f-4a9a-af53-715bdd80e249)


## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->
* sagitta

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document