### PR TITLE
update firewall example in nat44.rst

### DIFF
--- a/docs/configuration/nat/nat44.rst
+++ b/docs/configuration/nat/nat44.rst
@@ -585,7 +585,7 @@ rule, using ``connection-status`` matcher:
 
   set firewall ipv4 forward filter rule 10 action accept
   set firewall ipv4 forward filter rule 10 connection-status nat destination
-  set firewall ipv4 forward filter rule 10 state new enable
+  set firewall ipv4 forward filter rule 10 state new
 
 This would generate the following configuration:
 
@@ -599,9 +599,7 @@ This would generate the following configuration:
                   connection-status {
                       nat destination
                   }
-                  state {
-                      new enable
-                  }
+                  state new
               }
           }
       }


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Update firewall example in nat44.rst. When following along with it the other day I noticed it no longer behaves like documented. Not sure since when this was the case but its no longer valid now.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document