### PR TITLE
haproxy: T7081: Document usage of HTTP compression option

### DIFF
--- a/docs/configuration/loadbalancing/haproxy.rst
+++ b/docs/configuration/loadbalancing/haproxy.rst
@@ -57,6 +57,16 @@ Service
   For an explanation on :ref:`syslog_facilities` and :ref:`syslog_severity_level`
   see tables in syslog configuration section.
 
+.. cfgcmd:: set load-balancing haproxy service <name> http-compression algorithm
+  <gzip | deflate | identity | raw-deflate>
+
+  Set the compression algorithm to be used when compressing HTTP responses.
+
+.. cfgcmd:: set load-balancing haproxy service <name> http-compression mime-type
+  <mime-type>
+
+  Set the list of HTTP response MIME types which haproxy will attempt to
+  compress, if received uncompressed from backend server.
 
 Rules
 ^^^^^


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Made changes to `haproxy.rst` for the following:
- Documented usage of http-compression option

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* [https://vyos.dev/T7081](https://vyos.dev/T7081)

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
- vyos/vyos-1x/pull/4314

## Backport
<!-- optional: the PR should backport to this documentation branch -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document