### PR TITLE
configuration: Fix typo in tacacs commands in login.rst

### DIFF
--- a/docs/configuration/system/login.rst
+++ b/docs/configuration/system/login.rst
@@ -319,28 +319,28 @@ TACACS is defined in :rfc:`8907`.
 Configuration
 -------------
 
-.. cfgcmd:: set system login tacas server <address> key <secret>
+.. cfgcmd:: set system login tacacs server <address> key <secret>
 
    Specify the IP `<address>` of the TACACS server user with the pre-shared-secret
    given in `<secret>`.
 
    Multiple servers can be specified.
 
-.. cfgcmd:: set system login tacas server <address> port <port>
+.. cfgcmd:: set system login tacacs server <address> port <port>
 
    Configure the discrete port under which the TACACS server can be reached.
 
    This defaults to 49.
 
-.. cfgcmd:: set system login tacas server <address> disable
+.. cfgcmd:: set system login tacacs server <address> disable
 
    Temporary disable this TACACS server. It won't be queried.
 
-.. cfgcmd:: set system login tacas server <address> timeout <timeout>
+.. cfgcmd:: set system login tacacs server <address> timeout <timeout>
 
    Setup the `<timeout>` in seconds when querying the TACACS server.
 
-.. cfgcmd:: set system login tacas source-address <address>
+.. cfgcmd:: set system login tacacs source-address <address>
 
    TACACS servers could be hardened by only allowing certain IP addresses to
    connect. As of this the source address of each TACACS query can be
@@ -350,7 +350,7 @@ Configuration
    interface address pointing towards the server - making it error prone on
    e.g. OSPF networks when a link fails and a backup route is taken.
 
-.. cfgcmd:: set system login tacas vrf <name>
+.. cfgcmd:: set system login tacacs vrf <name>
 
    Source all connections to the TACACS servers from given VRF `<name>`.
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

`tacas` is used instead of `tacacs` in the CLI examples.
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
N/A

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
N/A

## Backport
<!-- optional: the PR should backport to this documentation branch -->
N/A



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document