### PR TITLE
Update vxlan.rst

### DIFF
--- a/docs/configuration/interfaces/vxlan.rst
+++ b/docs/configuration/interfaces/vxlan.rst
@@ -62,7 +62,7 @@ VXLAN specific options
      as the default IANA-assigned destination UDP port number. Instead VyOS
      uses the Linux default port of 8472.
 
-.. cfgcmd:: set interfaces vxlan <interface> source-address <interface>
+.. cfgcmd:: set interfaces vxlan <interface> source-address <IP address>
 
   Source IP address used for VXLAN underlay. This is mandatory when using VXLAN
   via L2VPN/EVPN.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
`set interfaces vxlan <interface> source-address <interface>`

should be 

`set interfaces vxlan <interface> source-address <IP address>`

in 1.4.1:
```
# set interfaces vxlan vxlan1 source-address
Possible completions:
   <x.x.x.x>            IPv4 source address
   <h:h:h:h:h:h:h:h>    IPv6 source address
   127.0.0.1
   ::1
```
## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/Txxxx

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document