### PR TITLE
VxLAN default port

### DIFF
--- a/docs/configuration/interfaces/vxlan.rst
+++ b/docs/configuration/interfaces/vxlan.rst
@@ -31,10 +31,6 @@ If configuring VXLAN in a VyOS virtual machine, ensure that MAC spoofing
 (Hyper-V) or Forged Transmits (ESX) are permitted, otherwise forwarded frames
 may be blocked by the hypervisor.
 
-.. note:: As VyOS is based on Linux and there was no official IANA port assigned
-   for VXLAN, VyOS uses a default port of 8472. You can change the port on a
-   per VXLAN interface basis to get it working across multiple vendors.
-
 Configuration
 =============
 
@@ -327,10 +323,9 @@ multicast-address.
 
   set interfaces vxlan vxlan241 port 12345
 
-The destination port used for creating a VXLAN interface in Linux defaults to
-its pre-standard value of 8472 to preserve backward compatibility. A
-configuration directive to support a user-specified destination port to override
-that behavior is available using the above command.
+The destination port used for creating a VXLAN interface defaults to
+4789. Aconfiguration directive to support a user-specified destination port
+to override that behavior is available using the above command.
 
 Unicast VXLAN
 =============
@@ -350,5 +345,5 @@ set directly. Let's change the Multicast example from above:
   # leaf3
   set interface vxlan vxlan241 remote 10.1.2.2
 
-The default port udp is set to 8472.
+The default port udp is set to 4789.
 It can be changed with ``set interface vxlan <vxlanN> port <port>``

--- a/docs/configuration/interfaces/vxlan.rst
+++ b/docs/configuration/interfaces/vxlan.rst
@@ -42,7 +42,7 @@ Common interface configuration
 ------------------------------
 
 .. cmdinclude:: /_include/interface-common-without-dhcp.txt
-  :var0: vxlan4
+  :var0: vxlan
   :var1: vxlan0
 
 VXLAN specific options

--- a/docs/configuration/interfaces/vxlan.rst
+++ b/docs/configuration/interfaces/vxlan.rst
@@ -42,7 +42,7 @@ Common interface configuration
 ------------------------------
 
 .. cmdinclude:: /_include/interface-common-without-dhcp.txt
-  :var0: vxlan
+  :var0: vxlan4
   :var1: vxlan0
 
 VXLAN specific options
@@ -57,10 +57,6 @@ VXLAN specific options
 .. cfgcmd:: set interfaces vxlan <interface> port <port>
 
   Configure port number of remote VXLAN endpoint.
-
-  .. note:: As VyOS is Linux based the default port used is not using 4789
-     as the default IANA-assigned destination UDP port number. Instead VyOS
-     uses the Linux default port of 8472.
 
 .. cfgcmd:: set interfaces vxlan <interface> source-address <IP address>
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
remove 
> As VyOS is Linux based the default port used is not using 4789 as the default IANA-assigned destination UDP port number. Instead VyOS uses the Linux default port of 8472.

See 
* https://github.com/vyos/vyos-1x/blob/current/src/conf_mode/interfaces_vxlan.py#L226
* https://github.com/vyos/vyos-1x/blob/current/interface-definitions/interfaces_vxlan.xml.in#L105

Looks like VyOS DOES use 4789 and not 8472 by default. Dear VyOS team, please document these changes.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/Txxxx

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document