### PR TITLE
container: T7185: Allow tmpfs mounts within containers

### DIFF
--- a/docs/configuration/container/index.rst
+++ b/docs/configuration/container/index.rst
@@ -124,6 +124,15 @@ Configuration
 
     Volume is either mounted as rw (read-write - default) or ro (read-only)
 
+.. cfgcmd:: set container name <name> tmpfs <tmpfsname> destination <path>
+
+    Mount a tmpfs *(ramdisk)* filesystem to the given path within the container.
+
+.. cfgcmd:: set container name <name> tmpfs <tmpfsname> size <MB>
+
+    Size in MB for tmpfs filesystem, maximum size is 64GB or 50% of the
+    systems total available memory.
+
 .. cfgcmd:: set container name <name> uid <number>
 .. cfgcmd:: set container name <name> gid <number>
 


### PR DESCRIPTION
## Change Summary
Made changes to `container/index.rst` for the following:
- Documented usage of tmpfs option

## Related Task(s)
* [https://vyos.dev/T7185](https://vyos.dev/T7185)

## Related PR(s)
- vyos/vyos-1x/pull/4358

## Backport

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document