### PR TITLE
lldp: T7165: add support to enable only rx or tx on specific interface

### DIFF
--- a/docs/configuration/service/lldp.rst
+++ b/docs/configuration/service/lldp.rst
@@ -49,10 +49,16 @@ Configuration
    Enable transmission of LLDP information on given `<interface>`. You can also
    say ``all`` here so LLDP is turned on on every interface.
 
-.. cfgcmd:: set service lldp interface <interface> disable
+.. cfgcmd:: set service lldp interface <interface> mode [disable|rx-tx|rx|tx]
 
-   Disable transmit of LLDP frames on given `<interface>`. Useful to exclude
-   certain interfaces from LLDP when ``all`` have been enabled.
+    Configure the administrative status of the given port.
+
+    By default, all ports are configured to be in rx-tx mode. This means they
+    can receive and transmit LLDP frames.
+
+    In rx mode, they won't emit any frames. In tx mode, they won't receive
+    any frames. In disabled mode, no frame will be sent and any incoming frame
+    will be discarded.
 
 .. cfgcmd:: set service lldp snmp
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

LLDP is a stateless protocol which does not necessitate sending to receive advertisements. There are multiple scenarios such as provider peering links in which it is advantageous to receive LLDP but not disclose internal information to the provider.

Add new CLI commands:
`set service lldp interface <name> mode [disable|rx-and-tx|rx-only|tx-only]`

The default is unchanged and will be rx-and-tx.

Furthermore if an interface has an explicit LLDP disable configured under `set service lldp interface <name> disable` this will be migrated to `set service lldp interface <name> mode disable`


## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T7165

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
* https://github.com/vyos/vyos-1x/pull/4365

## Backport
<!-- optional: the PR should backport to this documentation branch -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document