### PR TITLE
T7116: remove mention of obsolete "internet" BGP community

### DIFF
--- a/docs/configuration/policy/community-list.rst
+++ b/docs/configuration/policy/community-list.rst
@@ -30,6 +30,6 @@ policy community-list
    Set description for rule.
 
 .. cfgcmd:: set policy community-list <text> rule <1-65535> regex
-   <aa:nn|local-AS|no-advertise|no-export|internet|additive>
+   <aa:nn|local-AS|no-advertise|no-export|additive>
 
    Regular expression to match against a community-list.

--- a/docs/configuration/policy/route-map.rst
+++ b/docs/configuration/policy/route-map.rst
@@ -366,7 +366,6 @@ List of well-known communities
    * ``local-as`` -                     Well-known communities value NO_EXPORT_SUBCONFED 0xFFFFFF03
    * ``no-advertise`` -                 Well-known communities value NO_ADVERTISE 0xFFFFFF02
    * ``no-export`` -                    Well-known communities value NO_EXPORT 0xFFFFFF01
-   * ``internet`` -                     Well-known communities value 0
    * ``graceful-shutdown`` -            Well-known communities value GRACEFUL_SHUTDOWN 0xFFFF0000
    * ``accept-own`` -                   Well-known communities value ACCEPT_OWN 0xFFFF0001
    * ``route-filter-translated-v4`` -   Well-known communities value ROUTE_FILTER_TRANSLATED_v4 0xFFFF0002


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Updating documentation to match the changes in [PR#4371](https://github.com/vyos/vyos-1x/pull/4371).

Use of the "internet" BGP community alias is already broken in 1.4 and 1.5 due to upstream changes in FRR. 

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T7116

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
* https://github.com/vyos/vyos-1x/pull/4371

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document