### PR TITLE
syslog: Add missing set in front of commands

### DIFF
--- a/docs/configuration/system/syslog.rst
+++ b/docs/configuration/system/syslog.rst
@@ -20,18 +20,18 @@ server which is reached via :abbr:`IP (Internet Protocol)` UDP/TCP.
 Global Settings
 ---------------
 
-.. cfgcmd:: system syslog marker interval <number>
+.. cfgcmd:: set system syslog marker interval <number>
 
    Interval (in seconds) for sending mark messages to the syslog input to
    indicate that the logging system is functioning.
 
    This defaults to 1200 seconds.
 
-.. cfgcmd:: system syslog marker disable
+.. cfgcmd:: set system syslog marker disable
 
    Disable periodic injection of mark messages.
 
-.. cfgcmd:: system syslog preserve-fqdn
+.. cfgcmd:: set system syslog preserve-fqdn
 
    If set, the domain part of the hostname is always sent, even within the same
    domain as the receiving system.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add missing set in front of commands
## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->


## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->

No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [*] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document