### PR TITLE
bgp: T7157: Allow using route-maps for VRF route leaking in BGP

### DIFF
--- a/docs/configuration/vrf/index.rst
+++ b/docs/configuration/vrf/index.rst
@@ -505,6 +505,12 @@ address-family.
    derived and should not be specified explicitly for either the source or
    destination VRF’s.
 
+.. cfgcmd:: set vrf name <name> protocols bgp address-family
+            <ipv4-unicast|ipv6-unicast> route-map vrf import
+            [route-map <name>]
+
+   Specifies an optional route-map to be applied to routes imported from VRFs.
+
 .. cfgcmd:: set vrf name <name> protocols bgp interface <interface> mpls
             forwarding
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow using route-maps for VRF route leaking in BGP

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T7157

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->
circinus and sagitta


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document