### PR TITLE
router-advert: T7380: auto-ignore documentation

### DIFF
--- a/docs/configuration/service/router-advert.rst
+++ b/docs/configuration/service/router-advert.rst
@@ -46,6 +46,7 @@ Configuration
    "Interval", "interval", "Min and max intervals between unsolicited multicast RAs"
    "DNSSL", "dnssl", "DNS search list to advertise"
    "Name Server", "name-server", "Advertise DNS server per https://tools.ietf.org/html/rfc6106"
+   "Auto Ignore Prefix", "auto-ignore", "Exclude a prefix from being advertised when the wildcard ::/64 prefix is used"
 
 .. start_vyoslinter
 
@@ -56,8 +57,8 @@ Advertising a Prefix
 .. cfgcmd:: set service router-advert interface <interface> prefix <prefix/mask>
 
    .. note:: You can also opt for using `::/64` as prefix for your :abbr:`RAs (Router
-    Advertisements)`. This will take the IPv6 GUA prefix assigned to the interface,
-    which comes in handy when using DHCPv6-PD.
+    Advertisements)`. This is a special wildcard prefix that will emit :abbr:`RAs (Router Advertisements)` for every prefix assigned to the interface.
+    This comes in handy when using dynamically obtained prefixes from DHCPv6-PD.
 
 .. stop_vyoslinter
 


### PR DESCRIPTION
Add documentation for new auto-ignore prefixes feature

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add documentation for new auto-ignore prefixes feature

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
https://vyos.dev/T7380

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-1x/pull/4463

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document