### PR TITLE
policy: added set vrf and mark matching documentation

### DIFF
--- a/docs/configuration/policy/route.rst
+++ b/docs/configuration/policy/route.rst
@@ -51,6 +51,20 @@ in this section.
 
   Set match criteria based on connection mark.
 
+.. cfgcmd:: set policy route <name> rule <n> mark <match_criteria>
+.. cfgcmd:: set policy route6 <name> rule <n> mark <match_criteria>
+
+  Match based on the firewall mark (fwmark), where <match_criteria> can be:
+
+   * <0-2147483647> a single fwmark
+   * !<0-2147483647> everything except a single fwmark
+   * <start-end> a range of marks
+   * !<start-end> everything except the range of marks
+
+   .. note:: When using the ``set table`` or ``set vrf`` commands the mark
+      settings are ignored and overwritten with a table-specific mark that
+      is set to 0x7FFFFFFF - the id of the table/VRF.
+
 .. cfgcmd:: set policy route <name> rule <n> source address
    <match_criteria>
 .. cfgcmd:: set policy route <name> rule <n> destination address
@@ -273,7 +287,20 @@ setting a different routing table.
 
    Set the routing table to forward packet with.
 
+   .. note:: When using the ``set table`` or ``set vrf`` commands matching
+      against the mark is not possible, because it gets overwritten with a
+      table-specific mark that is 0x7FFFFFFF - the id of the table/VRF.
+
 .. cfgcmd:: set policy route <name> rule <n> set tcp-mss <500-1460>
 .. cfgcmd:: set policy route6 <name> rule <n> set tcp-mss <500-1460>
 
    Set packet modifications: Explicitly set TCP Maximum segment size value.
+
+.. cfgcmd:: set policy route <name> rule <n> set vrf <default | text >
+.. cfgcmd:: set policy route6 <name> rule <n> set vrf <default | text >
+
+   Set the VRF to forward packet with.
+
+   .. note:: When using the ``set table`` or ``set vrf`` commands matching
+      against the mark is not possible, because it gets overwritten with a
+      table-specific mark that is 0x7FFFFFFF - the id of the table/VRF.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
I added the documentation for the `set vrf` option in policies.
I also added the documentation for matching firewall marks.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T6430

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-1x/pull/3740

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document

## Further notes

The way the marks are handled for VRFs/tables has some limitations. It limits the user to a single fwmark per VRF/table. the underlying linux kernel allows e.g. for matching with masks. This would allow it to seperate the 32 Bits (of which only 31 can be matched due to the restrictions in the CLI) into multiple chunks and e.g. use the lower 8 bits for mapping into a VRF while using the upper 24 bits to match to firewall-rules, shapers, etc. By limiting the mapping to a VRF/table to a single mark this is no longer possible.

Judging from the comment here https://github.com/vyos/vyos-1x/pull/3581#issuecomment-2164410426 it appears like there is a distinction between "VRF" and "non-VRF" table IDs, however I could not find anything in the documentation that explicitly states that.