### PR TITLE
T1771: automatic reboot of system into previous image

### DIFF
--- a/docs/configuration/system/option.rst
+++ b/docs/configuration/system/option.rst
@@ -18,6 +18,16 @@ General
 
    Automatically reboot system on kernel panic after 60 seconds.
 
+.. cfgcmd:: set system option reboot-on-upgrade-failure <timeout>
+
+   Automatically reboot after `timeout` minutes into the previous running
+   image, that was used to perform the image upgrade.
+
+   Reboot `timeout` is configurable in minutes. This gives the user the change
+   to log into the system and perform some analysis before automatic rebooting.
+
+   Automatic reboot can be cancelled after login using: :opcmd:`reboot cancel`
+
 .. cfgcmd:: set system option startup-beep
 
     Play an audible beep to the system speaker when system is ready.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Automatically reboot into previous image when image upgrade failed.


## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T1771

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
* https://github.com/vyos/vyos-1x/pull/4501
* https://github.com/vyos/vyos-build/pull/965


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document