### PR TITLE
kea: T6211: add VRF support for KEA dhcp server

### DIFF
--- a/docs/configuration/vrf/index.rst
+++ b/docs/configuration/vrf/index.rst
@@ -122,6 +122,27 @@ routing protocol inside a given vrf:
 - :ref:`routing-ospfv3`: ``set vrf name <name> protocols ospfv3 ...``
 - :ref:`routing-static`: ``set vrf name <name> protocols static ...``
 
+Services
+-------
+
+Currently the following services can be created isolated in VRFs
+
+- :ref:`dhcp-server`
+
+The CLI configuration is same as mentioned in above articles. The only
+difference is, that each service used, must be prefixed with the `vrf
+name <name>` command.
+
+Example
+^^^^^^^
+
+The following commands would be required to set options for a given service
+inside a given vrf:
+
+- :ref:`dhcp-server`: ``set vrf name <name> service dhcp-server ...``
+- :ref:`dhcp-server`: ``set vrf name <name> service dhcpv6-server ...``
+
+
 Operation
 =========
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Documentation for T6211

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T6211

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-1x/pull/4508

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document