### PR TITLE
zebra: T7349: Added FRR ip import-table x feature

### DIFF
--- a/docs/configuration/system/ip.rst
+++ b/docs/configuration/system/ip.rst
@@ -27,6 +27,20 @@ System configuration commands
 
    Use this command to use Layer 4 information for IPv4 ECMP hashing.
 
+.. cfgcmd:: set system ip import-table <table-id>
+
+   Use this command to immport the table, by given table id, into the main RIB.
+
+.. cfgcmd:: set system ip import-table <table-id> distance <distance>
+
+   Use this command to override the default distance when importing routers
+   from the alternate table.
+
+.. cfgcmd:: set system ip import-table <table-id> route-map <route-map>
+
+   Use this command to filter routes that are imported into the main table
+   from alternate table using route-map.
+
 Zebra/Kernel route filtering
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Added FRR ip import-table x feature to import routes from non-main kernel table.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T7349

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->
1.4

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document