### PR TITLE
DHCP HA : modified the option `name` definition which is incorrectly written

### DIFF
--- a/docs/configuration/service/dhcp-server.rst
+++ b/docs/configuration/service/dhcp-server.rst
@@ -379,9 +379,7 @@ statements on both servers:
 
 .. cfgcmd:: set service dhcp-server high-availability name <name>
 
-   A generic `<name>` referencing this sync service.
-
-   .. note:: `<name>` must be identical on both sides!
+   Define the name of the peer server to establish and identify the HA (High Availability) connection.
 
 .. cfgcmd:: set service dhcp-server high-availability status <primary
    | secondary>
@@ -610,8 +608,8 @@ Configuration of a DHCP HA pair:
 * Setup DHCP HA for network 192.0.2.0/24
 * Use active-active HA mode.
 * Default gateway and DNS server is at `192.0.2.254`
-* The primary DHCP server uses address `192.168.189.252`
-* The secondary DHCP server uses address `192.168.189.253`
+* The primary DHCP server named dhcp-primary uses address `192.168.189.252`
+* The secondary DHCP server with named dhcp-secondary uses address `192.168.189.253`
 * DHCP range spans from `192.168.189.10` - `192.168.189.250`
 
 Common configuration, valid for both primary and secondary node.
@@ -632,7 +630,7 @@ Common configuration, valid for both primary and secondary node.
 
   set service dhcp-server high-availability mode 'active-active'
   set service dhcp-server high-availability source-address '192.168.189.252'
-  set service dhcp-server high-availability name 'NET-VYOS'
+  set service dhcp-server high-availability name 'dhcp-secondary'
   set service dhcp-server high-availability remote '192.168.189.253'
   set service dhcp-server high-availability status 'primary'
 
@@ -642,7 +640,7 @@ Common configuration, valid for both primary and secondary node.
 
   set service dhcp-server high-availability mode 'active-active'
   set service dhcp-server high-availability source-address '192.168.189.253'
-  set service dhcp-server high-availability name 'NET-VYOS'
+  set service dhcp-server high-availability name 'dhcp-primary'
   set service dhcp-server high-availability remote '192.168.189.252'
   set service dhcp-server high-availability status 'secondary'
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

modified the option `name` definition which is incorrectly written, this has to be defined as the peer name of the server and then only the connection is interrupted

```
vyos@vyos# set service dhcp-server high-availability
Possible completions:
   ca-certificate       Certificate Authority in PKI configuration
   certificate          Certificate in PKI configuration
   mode                 Configure high availability mode (default: active-active)
   name                 Peer name used to identify connection
```


## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/Txxxx

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document