### PR TITLE
T7531: Add documentation for no-ipv6-auto-ra

### DIFF
--- a/docs/configuration/protocols/bgp.rst
+++ b/docs/configuration/protocols/bgp.rst
@@ -627,6 +627,12 @@ Common parameters
 
    Disable immediate session reset if peer's connected link goes down.
 
+.. cfgcmd:: set protocols bgp parameters no-ipv6-auto-ra
+
+   By default, FRR sends router advertisement packets when Extended Next Hop is
+   on or when a connection is established directly using the device name (Unnumbered BGP).
+   Setting this option prevents FRR from sending router advertisement packets, but could break Unnumbered BGP.
+
 .. cfgcmd:: set protocols bgp listen range <prefix> peer-group <name>
 
    This command is useful if one desires to loosen the requirement for BGP


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add documentation for no-ipv6-auto-ra

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
https://vyos.dev/T7531

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-1x/pull/4568

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document