### PR TITLE
add prefix-list6 config example

### DIFF
--- a/docs/configuration/policy/prefix-list.rst
+++ b/docs/configuration/policy/prefix-list.rst
@@ -15,7 +15,7 @@ Prefix filtering can be done using prefix-list and prefix-list6.
 Configuration
 *************
 
-Prefix Lists
+IPv4 Prefix Lists (prefix-list)
 ============
 
 .. cfgcmd:: set policy prefix-list <text>
@@ -46,7 +46,7 @@ Prefix Lists
 
    Netmask less than length
 
-Example: Prefix Lists
+Example: IPv4 Prefix Lists (prefix-list)
 ============
 
 This example creates an IPv4 prefix-list named PL4-EXAMPLE-NAME, defines 3 
@@ -62,7 +62,7 @@ rules each with 1 prefix, and matches le (less than/equal to) /32.
 .. cfgcmd:: set policy prefix-list PL4-EXAMPLE-NAME rule 30 le '32'
 .. cfgcmd:: set policy prefix-list PL4-EXAMPLE-NAME rule 30 prefix '203.0.113.0/24'
 
-IPv6 Prefix Lists
+IPv6 Prefix Lists (prefix-list6)
 =================
 
 .. cfgcmd:: set policy prefix-list6 <text>
@@ -94,3 +94,19 @@ IPv6 Prefix Lists
 .. cfgcmd:: set policy prefix-list6 <text> rule <1-65535> le <0-128>
 
    Netmask less than length
+
+Example: IPv6 Prefix Lists (prefix-list6)
+============
+
+This example creates an IPv6 prefix-list6 named PL6-EXAMPLE-NAME, defines 3 
+rules each with 1 prefix, and matches le (less than/equal to) /128.
+
+.. cfgcmd:: set policy prefix-list6 PL6-EXAMPLE-NAME rule 10 action 'permit'
+.. cfgcmd:: set policy prefix-list6 PL6-EXAMPLE-NAME rule 10 le '128'
+.. cfgcmd:: set policy prefix-list6 PL6-EXAMPLE-NAME rule 10 prefix '2001:db8:0:0::/64'
+.. cfgcmd:: set policy prefix-list6 PL6-EXAMPLE-NAME rule 20 action 'permit'
+.. cfgcmd:: set policy prefix-list6 PL6-EXAMPLE-NAME rule 20 le '128'
+.. cfgcmd:: set policy prefix-list6 PL6-EXAMPLE-NAME rule 20 prefix '2001:db8:0:1::/64'
+.. cfgcmd:: set policy prefix-list6 PL6-EXAMPLE-NAME rule 30 action 'permit'
+.. cfgcmd:: set policy prefix-list6 PL6-EXAMPLE-NAME rule 30 le '128'
+.. cfgcmd:: set policy prefix-list6 PL6-EXAMPLE-NAME rule 30 prefix '2001:db8:0:2::/64'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Add prefix-list6 example and clarifying subheadings to show syntax of "prefix-list" for IPv4 and "prefix-list6" for IPv6.

## Related Task(s)
None

## Related PR(s)
None

## Backport
N/A, documentation.



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document