### PR TITLE
CI: T7579: fix of the run trigger for CLA

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -7,7 +7,7 @@ permissions:
   statuses: write
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, closed]
   issue_comment:
     types: [created]
@@ -15,5 +15,4 @@ on:
 jobs:
   call-cla-assistant:
     uses: vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@current
-    secrets:
-      CLA_PAT: ${{ secrets.CLA_PAT }}
+    secrets: inherit


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
The current implementation of the CLA has an issue when the CLA check workflow fails due to insufficient access to the necessary GA secret. This problem arises from an incorrect run trigger `pull_request`, which needs to be replaced with the appropriate trigger `pull_request_target`.

## Related Task(s)
https://vyos.dev/T7579

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document