### PR TITLE
T7629: load-balancing: remove limit defaults

### DIFF
--- a/docs/configuration/loadbalancing/wan.rst
+++ b/docs/configuration/loadbalancing/wan.rst
@@ -84,11 +84,9 @@ below a specified threshold. To configure the rate limiting use:
     set load-balancing wan rule <rule> limit <parameter>
 
 * ``burst``: Number of packets allowed to overshoot the limit within ``period``.
-  Default 5.
 * ``period``: Time window for rate calculation. Possible values:
   ``second`` (one second), ``minute`` (one minute), ``hour`` (one hour).
-  Default is ``second``.
-* ``rate``: Number of packets. Default 5.
+* ``rate``: Number of packets.
 * ``threshold``: ``below`` or ``above`` the specified rate limit.
 
 Flow and packet-based balancing


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Remove the default values for `limit` configuration in WAN load balancer rules.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
https://vyos.dev/T7629

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-1x/pull/4607

## Backport
<!-- optional: the PR should backport to this documentation branch -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document