### PR TITLE
T7635: OpenConnect certificate based authentication mode

### DIFF
--- a/docs/configuration/vpn/openconnect.rst
+++ b/docs/configuration/vpn/openconnect.rst
@@ -47,7 +47,7 @@ Server Configuration
 .. code-block:: none
 
   set vpn openconnect authentication local-users username <user> password <pass>
-  set vpn openconnect authentication mode <local password|radius>
+  set vpn openconnect authentication mode <local password|radius|certificate>
   set vpn openconnect network-settings client-ip-settings subnet <subnet>
   set vpn openconnect network-settings name-server <address>
   set vpn openconnect network-settings name-server <address>
@@ -77,6 +77,19 @@ For generating an OTP key in VyOS, you can use the CLI command
 .. code-block:: none
 
   generate openconnect username <user> otp-key hotp-time
+
+User Certificate Authentication
+===============================
+
+You can configure users to be authenticated by certificate by setting the authentication mode to certificate, and defining what field (by OID) in the certificate will be used to identify the username. Two pre-defined shortcuts for Common Name (OID 2.5.4.3) and User ID (OID 0.9.2342.19200300.100.1.1) have been provide as cn or uid. Otherwise a specific OID value must be provided.
+
+The user's certificate must be signed by the certificate authority defined in the configuration for it to be validated for authentication.
+
+.. code-block:: none
+
+  set vpn openconnect authentication mode certificate
+  set vpn openconnect authentication mode certificate user-identifier-field cn
+  set vpn openconnect ssl ca-certificate <cert>
 
 ************
 Verification


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Shows that certificate authentication is an available option

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T7635

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-1x/pull/4618

## Backport
<!-- optional: the PR should backport to this documentation branch -->
If vyos-1x is backported to circinus and/or sagitta, this doc change should be as well.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document