### PR TITLE
T1771: link to automatic reboot timeout command

### DIFF
--- a/docs/configuration/system/option.rst
+++ b/docs/configuration/system/option.rst
@@ -23,7 +23,7 @@ General
    Automatically reboot after `timeout` minutes into the previous running
    image, that was used to perform the image upgrade.
 
-   Reboot `timeout` is configurable in minutes. This gives the user the change
+   Reboot `timeout` is configurable in minutes. This gives the user the chance
    to log into the system and perform some analysis before automatic rebooting.
 
    Automatic reboot can be cancelled after login using: :opcmd:`reboot cancel`

--- a/docs/configuration/system/option.rst
+++ b/docs/configuration/system/option.rst
@@ -66,17 +66,19 @@ Kernel
 
     The available modes are:
 
-    * ``active`` This is the low-level firmware control mode based on the profile
-      set and the system governor has no effect.
+    * ``active`` This is the low-level firmware control mode based
+      on the profile set and the system governor has no effect.
     * ``passive`` The driver allows the system governor to manage CPU frequency
       while providing available performance states.
-    * ``guided`` The driver allows to set desired performance levels and the firmware
-      selects a performance level in this range and fitting to the current workload.
+    * ``guided`` The driver allows to set desired performance levels
+      and the firmware selects a performance level in this
+      range and fitting to the current workload.
 
     This will add the following two options to the Kernel commandline:
 
-    * ``initcall_blacklist=acpi_cpufreq_init`` Disable default ACPI CPU frequency scale
-    * ``amd_pstate={mode}`` Sets the p-state mode
+    * ``initcall_blacklist=acpi_cpufreq_init`` Disable default ACPI CPU
+      frequency scale.
+    * ``amd_pstate={mode}`` Sets the p-state mode.
 
     .. note:: Setting will only become active with the next reboot!
 
@@ -123,8 +125,8 @@ Keyboard Layout
 ***************
 
 When starting a VyOS live system (the installation CD) the configured keyboard
-layout defaults to US. As this might not suite everyone's use case you can adjust
-the used keyboard layout on the system console.
+layout defaults to US. As this might not suite everyone's use case you can
+adjust the used keyboard layout on the system console.
 
 .. cfgcmd:: set system option keyboard-layout <us | fr | de | fi | no | dk>
 

--- a/docs/installation/update.rst
+++ b/docs/installation/update.rst
@@ -93,7 +93,10 @@ You can use ``latest`` option. It loads the latest available Rolling release.
 If an Upgrade Fails
 """"""""""""""""""
 
-If an image upgrade fails, VyOS will automatically reboot after 5 minutes using the previously running image. For more information and configuration options, see the :cfgcmd:`set system option reboot-on-upgrade-failure` :ref:`command <system_option>`.
+If an image upgrade fails, VyOS will automatically reboot after 5 minutes
+using the previously running image. For more information and
+configuration options, see the
+:cfgcmd:`set system option reboot-on-upgrade-failure` :ref:`command <system_option>`.
 
 After a successful reboot, verify the VyOS version with
 the :opcmd:`show version` command.

--- a/docs/installation/update.rst
+++ b/docs/installation/update.rst
@@ -78,7 +78,8 @@ You can use ``latest`` option. It loads the latest available Rolling release.
 
      vyos@vyos:~$ add system image latest
 
-.. note:: To use the `latest` option the "system update-check url" must be configured
+.. note:: To use the `latest` option the "system update-check url"
+   must be configured
    appropriately for the installed release.
 
    For updates to the Rolling Release for AMD64, the following URL may be used:
@@ -91,12 +92,13 @@ You can use ``latest`` option. It loads the latest available Rolling release.
    https://vyos.net/get/nightly-builds/
 
 If an Upgrade Fails
-""""""""""""""""""
+"""""""""""""""""""
 
 If an image upgrade fails, VyOS will automatically reboot after 5 minutes
 using the previously running image. For more information and
 configuration options, see the
-:cfgcmd:`set system option reboot-on-upgrade-failure` :ref:`command <system_option>`.
+:cfgcmd:`set system option reboot-on-upgrade-failure`
+:ref:`command <system_option>`.
 
 After a successful reboot, verify the VyOS version with
 the :opcmd:`show version` command.

--- a/docs/installation/update.rst
+++ b/docs/installation/update.rst
@@ -78,8 +78,8 @@ You can use ``latest`` option. It loads the latest available Rolling release.
 
      vyos@vyos:~$ add system image latest
 
-.. note:: To use the `latest` option the "system update-check url" must be configured 
-   appropriately for the installed release. 
+.. note:: To use the `latest` option the "system update-check url" must be configured
+   appropriately for the installed release.
 
    For updates to the Rolling Release for AMD64, the following URL may be used:
 
@@ -87,8 +87,13 @@ You can use ``latest`` option. It loads the latest available Rolling release.
 
 .. hint:: The most up-do-date Rolling Release for AMD64 can be accessed using
    the following URL from a web browser:
-   
+
    https://vyos.net/get/nightly-builds/
 
-After reboot you might want to verify the version you are running with
+If an Upgrade Fails
+""""""""""""""""""
+
+If an image upgrade fails, VyOS will automatically reboot after 5 minutes using the previously running image. For more information and configuration options, see the :cfgcmd:`set system option reboot-on-upgrade-failure` :ref:`command <system_option>`.
+
+After a successful reboot, verify the VyOS version with
 the :opcmd:`show version` command.


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
* Adds a link on the [Update VyOS](https://docs.vyos.io/en/1.4/installation/update.html#update-vyos) page to

  `set system option reboot-on-upgrade-failure`the [system configuration command](https://docs.vyos.io/en/latest/configuration/system/option.html#cfgcmd-set-system-option-reboot-on-upgrade-failure-timeout) for setting the
  timeout of the automatic reboot after a failed image upgrade. Added for better visibility of the auto reboot feature on a page users are likely to land on while attempting to upgrade VyOS.

* Fixes a typo in the   `set system option reboot-on-upgrade-failure` command's description.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T1771

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-documentation/pull/1635

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document