### PR TITLE
bgp: T7760: remove per vrf instance system-as node

### DIFF
--- a/docs/configexamples/autotest/L3VPN_EVPN/_include/PE1.conf
+++ b/docs/configexamples/autotest/L3VPN_EVPN/_include/PE1.conf
@@ -45,7 +45,6 @@ set interfaces vxlan vxlan2000 vni '2000'
 
 set vrf name blue protocols bgp address-family ipv4-unicast redistribute connected
 set vrf name blue protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
-set vrf name blue protocols bgp system-as '100'
 set vrf name blue table '2000'
 set vrf name blue vni '2000'
 
@@ -57,7 +56,6 @@ set interfaces vxlan vxlan3000 vni '3000'
 
 set vrf name red protocols bgp address-family ipv4-unicast redistribute connected
 set vrf name red protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
-set vrf name red protocols bgp system-as '100'
 set vrf name red table '3000'
 set vrf name red vni '3000'
 
@@ -69,7 +67,6 @@ set interfaces vxlan vxlan4000 vni '4000'
 
 set vrf name green protocols bgp address-family ipv4-unicast redistribute connected
 set vrf name green protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
-set vrf name green protocols bgp system-as '100'
 set vrf name green table '4000'
 set vrf name green vni '4000'
 

--- a/docs/configexamples/autotest/L3VPN_EVPN/_include/PE2.conf
+++ b/docs/configexamples/autotest/L3VPN_EVPN/_include/PE2.conf
@@ -45,7 +45,6 @@ set interfaces vxlan vxlan2000 vni '2000'
 
 set vrf name blue protocols bgp address-family ipv4-unicast redistribute connected
 set vrf name blue protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
-set vrf name blue protocols bgp system-as '100'
 set vrf name blue table '2000'
 set vrf name blue vni '2000'
 
@@ -57,7 +56,6 @@ set interfaces vxlan vxlan3000 vni '3000'
 
 set vrf name red protocols bgp address-family ipv4-unicast redistribute connected
 set vrf name red protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
-set vrf name red protocols bgp system-as '100'
 set vrf name red table '3000'
 set vrf name red vni '3000'
 
@@ -69,7 +67,6 @@ set interfaces vxlan vxlan4000 vni '4000'
 
 set vrf name green protocols bgp address-family ipv4-unicast redistribute connected
 set vrf name green protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
-set vrf name green protocols bgp system-as '100'
 set vrf name green table '4000'
 set vrf name green vni '4000'
 

--- a/docs/configexamples/autotest/L3VPN_EVPN/_include/PE3.conf
+++ b/docs/configexamples/autotest/L3VPN_EVPN/_include/PE3.conf
@@ -45,7 +45,6 @@ set interfaces vxlan vxlan2000 vni '2000'
 
 set vrf name blue protocols bgp address-family ipv4-unicast redistribute connected
 set vrf name blue protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
-set vrf name blue protocols bgp system-as '100'
 set vrf name blue table '2000'
 set vrf name blue vni '2000'
 
@@ -57,7 +56,6 @@ set interfaces vxlan vxlan3000 vni '3000'
 
 set vrf name red protocols bgp address-family ipv4-unicast redistribute connected
 set vrf name red protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
-set vrf name red protocols bgp system-as '100'
 set vrf name red table '3000'
 set vrf name red vni '3000'
 
@@ -69,7 +67,6 @@ set interfaces vxlan vxlan4000 vni '4000'
 
 set vrf name green protocols bgp address-family ipv4-unicast redistribute connected
 set vrf name green protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
-set vrf name green protocols bgp system-as '100'
 set vrf name green table '4000'
 set vrf name green vni '4000'
 

--- a/docs/configexamples/inter-vrf-routing-vrf-lite.rst
+++ b/docs/configexamples/inter-vrf-routing-vrf-lite.rst
@@ -242,7 +242,6 @@ to inject configured networks into the BGP process but still inside the VRF.
    set protocols bgp system-as <ASN>
 
    # set BGP VRF local-as and redistribution
-   set vrf name <VRF> protocols bgp system-as <ASN>
    set vrf name <VRF> protocols bgp address-family <AF IPv4/IPv6> redistribute static
 
 - Verification
@@ -642,7 +641,6 @@ Full configuration from all devices
    set vrf name Internet protocols bgp address-family ipv6-unicast rd vpn export '64496:100'
    set vrf name Internet protocols bgp address-family ipv6-unicast route-target vpn export '64496:100'
    set vrf name Internet protocols bgp address-family ipv6-unicast route-target vpn import '64496:1 64496:2'
-   set vrf name Internet protocols bgp system-as '64496'
    set vrf name Internet protocols bgp neighbor 10.2.2.2 address-family ipv4-unicast
    set vrf name Internet protocols bgp neighbor 10.2.2.2 remote-as '64497'
    set vrf name Internet protocols bgp neighbor 2001:db8::7 address-family ipv6-unicast
@@ -660,7 +658,6 @@ Full configuration from all devices
    set vrf name LAN1 protocols bgp address-family ipv6-unicast redistribute static
    set vrf name LAN1 protocols bgp address-family ipv6-unicast route-target vpn export '64496:1'
    set vrf name LAN1 protocols bgp address-family ipv6-unicast route-target vpn import '64496:100 64496:50 64496:2'
-   set vrf name LAN1 protocols bgp system-as '64496'
    set vrf name LAN1 protocols static route 10.0.0.0/24 next-hop 10.1.1.2
    set vrf name LAN1 protocols static route6 2001:db8:0:1::/64 next-hop 2001:db8::1
    set vrf name LAN1 table '101'
@@ -676,7 +673,6 @@ Full configuration from all devices
    set vrf name LAN2 protocols bgp address-family ipv6-unicast redistribute static
    set vrf name LAN2 protocols bgp address-family ipv6-unicast route-target vpn export '64496:2'
    set vrf name LAN2 protocols bgp address-family ipv6-unicast route-target vpn import '64496:100 64496:50 64496:1'
-   set vrf name LAN2 protocols bgp system-as '64496'
    set vrf name LAN2 protocols static route 172.16.0.0/24 next-hop 172.16.2.2
    set vrf name LAN2 protocols static route6 2001:db8:0:2::/64 next-hop 2001:db8::3
    set vrf name LAN2 table '102'
@@ -692,7 +688,6 @@ Full configuration from all devices
    set vrf name Management protocols bgp address-family ipv6-unicast redistribute static
    set vrf name Management protocols bgp address-family ipv6-unicast route-target vpn export '64496:50'
    set vrf name Management protocols bgp address-family ipv6-unicast route-target vpn import '64496:1 64496:2'
-   set vrf name Management protocols bgp system-as '64496'
    set vrf name Management protocols static route 192.168.0.0/24 next-hop 192.168.3.2
    set vrf name Management protocols static route6 2001:db8:0:3::/64 next-hop 2001:db8::5
    set vrf name Management table '103'

--- a/docs/configexamples/l3vpn-hub-and-spoke.rst
+++ b/docs/configexamples/l3vpn-hub-and-spoke.rst
@@ -424,7 +424,6 @@ import/export based on the pre-defined parameters.
    set vrf name BLUE_SPOKE protocols bgp address-family ipv4-unicast redistribute connected
    set vrf name BLUE_SPOKE protocols bgp address-family ipv4-unicast route-target vpn export '65035:1011'
    set vrf name BLUE_SPOKE protocols bgp address-family ipv4-unicast route-target vpn import '65035:1030'
-   set vrf name BLUE_SPOKE protocols bgp system-as '65001'
    set vrf name BLUE_SPOKE protocols bgp neighbor 10.50.50.2 address-family ipv4-unicast as-override
    set vrf name BLUE_SPOKE protocols bgp neighbor 10.50.50.2 remote-as '65035'
    
@@ -446,7 +445,6 @@ import/export based on the pre-defined parameters.
    set vrf name BLUE_HUB protocols bgp address-family ipv4-unicast redistribute connected
    set vrf name BLUE_HUB protocols bgp address-family ipv4-unicast route-target vpn export '65035:1030'
    set vrf name BLUE_HUB protocols bgp address-family ipv4-unicast route-target vpn import '65035:1011 65050:2011 65035:1030'
-   set vrf name BLUE_HUB protocols bgp system-as '65001'
    set vrf name BLUE_HUB protocols bgp neighbor 10.80.80.2 address-family ipv4-unicast as-override
    set vrf name BLUE_HUB protocols bgp neighbor 10.80.80.2 remote-as '65035'
    
@@ -468,7 +466,6 @@ import/export based on the pre-defined parameters.
    set vrf name BLUE_SPOKE protocols bgp address-family ipv4-unicast redistribute connected
    set vrf name BLUE_SPOKE protocols bgp address-family ipv4-unicast route-target vpn export '65035:1011'
    set vrf name BLUE_SPOKE protocols bgp address-family ipv4-unicast route-target vpn import '65035:1030'
-   set vrf name BLUE_SPOKE protocols bgp system-as '65001'
    set vrf name BLUE_SPOKE protocols bgp neighbor 10.60.60.2 address-family ipv4-unicast as-override
    set vrf name BLUE_SPOKE protocols bgp neighbor 10.60.60.2 remote-as '65035'
    


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Originating from the bug in [T7665](https://vyos.dev/T7665). To avoid potential issues down the line - and given that there's no compelling technical reason to retain the system-as CLI node under per-VRF BGP configuration, which cannot be achieved through alternative means - the maintainers have collectively decided to deprecate the following command:

`set vrf name <name> protocols bgp system-as <asn>`

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T7760

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
* https://github.com/vyos/vyos-1x/pull/4684

## Backport
<!-- optional: the PR should backport to this documentation branch -->

sagitta


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document