### PR TITLE
vrf: fix typo

### DIFF
--- a/docs/configuration/vrf/index.rst
+++ b/docs/configuration/vrf/index.rst
@@ -78,7 +78,7 @@ you do not want to e.g. allow BGP to peer across the default route.
 
 .. cfgcmd:: set vrf name <name> ipv6 nht no-resolve-via-default
 
-   Do not allow IPv4 nexthop tracking to resolve via the default route. This
+   Do not allow IPv6 nexthop tracking to resolve via the default route. This
    parameter is configured per-VRF, so the command is also available in the VRF
    subnode.
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
There was a typo changing the meaning in a way indicating that an IPv6 option applies to IPv4.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->


## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document