### PR TITLE
VPP: Syntax fixes and improvements

### DIFF
--- a/docs/vpp/configuration/dataplane/buffers.rst
+++ b/docs/vpp/configuration/dataplane/buffers.rst
@@ -18,13 +18,16 @@ Buffer Configuration Parameters
 The following parameters can be configured for VPP buffers:
 
 buffers-per-numa
-^^^^^^^^^^^^^^^^
+----------------
 
 Number of buffers allocated per NUMA node. This setting helps in optimizing memory access patterns for multi-CPU systems.
+
 Usually it needs to be tuned if:
+
 - there are a lot of interfaces in the system
 - there are a lot of queues in NICs
 - there are big descriptors size configured for NICs
+
 The value should be set responsibly, overprovisioning can lead to issues with NICs configured with XDP driver.
 
 .. cfgcmd:: set vpp settings buffers buffers-per-numa <value>
@@ -40,7 +43,7 @@ This should be done for each NIC, and then sum the results for all NICs in the s
 Try to avoid setting this value too low to avoid packet drops.
 
 data-size
-^^^^^^^^^
+---------
 
 This value sets how much payload data can be stored in a single buffer allocated by VPP.
 Making it larger can reduce buffer chains for big packets, while a smaller value can save memory for environments handling mostly small packets.
@@ -50,7 +53,7 @@ Making it larger can reduce buffer chains for big packets, while a smaller value
 Optimal size depends on the typical packet size in your network. If you are not sure, use the value of biggest MTU in your network plus some overhead (e.g., 128 bytes).
 
 page-size
-^^^^^^^^^
+---------
 
 A memory pages type used for buffer allocation. Common values are 4K, 2M, or 1G.
 
@@ -59,7 +62,7 @@ Use pages that are configured in system settings.
 .. cfgcmd:: set vpp settings buffers page-size <value>
 
 Potential Issues and Troubleshooting
-------------------------------------
+====================================
 
 Improper buffer configuration can lead to various issues, including:
 

--- a/docs/vpp/configuration/dataplane/interface.rst
+++ b/docs/vpp/configuration/dataplane/interface.rst
@@ -15,7 +15,8 @@ Interface Configuration Parameters
 ==================================
 
 driver
-^^^^^^
+------
+
 The driver parameter specifies the type of driver used for the network interface. VPP supports two types of drivers that can be used for this: DPDK and XDP. The choice of driver depends on the specific use case, hardware capabilities, and performance requirements. Some NICs may support only one of these drivers.
 
 .. cfgcmd:: set vpp settings interface <interface-name> driver <driver-type>
@@ -25,7 +26,7 @@ The DPDK driver is generally preferred for high-performance scenarios, while the
 .. _vpp_config_dataplane_interface_rx_mode:
 
 rx-mode
-^^^^^^^
+-------
 
 The rx-mode parameter defines how VPP handles incoming packets on the interface. There are several modes available, each with its own advantages and use cases:
 
@@ -38,7 +39,7 @@ The rx-mode parameter defines how VPP handles incoming packets on the interface.
 The choice of rx-mode should be based on the expected traffic patterns and performance requirements of the network environment.
 
 dpdk-options
-^^^^^^^^^^^^
+------------
 
 The dpdk-options section allows for the configuration of various DPDK-specific settings for the interface.
 
@@ -47,16 +48,16 @@ The dpdk-options section allows for the configuration of various DPDK-specific s
 DPDK options you can configure are:
 
 - ``num-rx-queues``: Specifies the number of receive queues for the interface. More queues can improve performance on multi-core systems by allowing parallel processing of incoming packets. Each queue will be assigned to a separate CPU core.
+- ``num-tx-queues``: Specifies the number of transmit queues for the interface. Similar to receive queues, more transmit queues can enhance performance by enabling parallel processing of outgoing packets. By default, the VPP Dataplane has one TX queue per enabled CPU worker, or a single queue if no workers are configured.
 
 .. seealso:: :doc:`cpu`
 
-- ``num-tx-queues``: Specifies the number of transmit queues for the interface. Similar to receive queues, more transmit queues can enhance performance by enabling parallel processing of outgoing packets.
 - ``num-rx-desc``: Defines the size of each receive queue. Larger queue sizes can help accommodate bursts of incoming traffic, reducing the likelihood of packet drops during high traffic periods.
 - ``num-tx-desc``: Defines the size of each transmit queue. Larger sizes can help manage bursts of outgoing traffic more effectively.
 - ``promisc``: Enables or disables promiscuous mode on the interface. When promiscuous mode is enabled, the interface will receive all packets on the network, regardless of type and destination of the packets. Some NICs need this feature to be enabled to avoid filtering out packets (for example to pass VLAN tagged packets).
 
 xdp-options
-^^^^^^^^^^^
+-----------
 
 The xdp-options section allows for the configuration of various XDP-specific settings for the interface.
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
- Fixed syntax on vpp/dataplane/buffers.rst
- Expanded DPDK options description in interface settings

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document