### PR TITLE
vpp: T7805: Delete 'default-hugepage-size' from memory section

### DIFF
--- a/docs/vpp/configuration/dataplane/memory.rst
+++ b/docs/vpp/configuration/dataplane/memory.rst
@@ -18,10 +18,6 @@ Before configuring memory in VPP dataplane settings, you need to ensure that hug
 
 To configure memory settings for VPP, you can use the following commands in the VPP CLI:
 
-.. cfgcmd:: set vpp settings memory default-hugepage-size <size>
-
-Sets the default hugepage size for VPP.
-
 VPP uses a main heap as a central memory pool for FIB data structures entries allocations.
 
 Efficient memory management is crucial for VPP's performance, and the main heap plays a significant role in this.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T7805

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-1x/pull/4729
## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document