### PR TITLE
vpp: T7897: Delete 'no-syscall-lock' option from xdp-options

### DIFF
--- a/docs/vpp/configuration/dataplane/interface.rst
+++ b/docs/vpp/configuration/dataplane/interface.rst
@@ -65,7 +65,6 @@ The xdp-options section allows for the configuration of various XDP-specific set
 
 XDP options you can configure are:
 
-- ``no-syscall-lock``: Disables the syscall lock for the XDP interface. This can improve performance by allowing multiple threads to access the interface concurrently.
 - ``num-rx-queues``: Specifies the number of receive queues for the XDP interface. More queues can improve performance on multi-core systems by allowing parallel processing of incoming packets. Each queue will be assigned to a separate CPU core.
 - ``promisc``: Enables or disables promiscuous mode on the interface. When promiscuous mode is enabled, the interface will receive all packets on the network, regardless of type and destination of the packets. Some NICs need this feature to be enabled to avoid filtering out packets (for example to pass VLAN tagged packets).
 - ``rx-queue-size``: Defines the size of each receive queue. Larger queue sizes can help accommodate bursts of incoming traffic, reducing the likelihood of packet drops during high traffic periods.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T7897

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-1x/pull/4781
## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document