### PR TITLE
 haproxy: T7906: Probing of a port other than the one to which normal traffic is sent

### DIFF
--- a/docs/configuration/loadbalancing/haproxy.rst
+++ b/docs/configuration/loadbalancing/haproxy.rst
@@ -158,6 +158,12 @@ Backend
   Active health check backend server
 
 .. cfgcmd:: set load-balancing haproxy backend <name> server
+   <name> check port <port>
+
+  Set the alternative port number for health checks.
+  Overrides the default server port used for TCP/HTTP checks.
+
+.. cfgcmd:: set load-balancing haproxy backend <name> server
    <name> send-proxy
 
   Send a Proxy Protocol version 1 header (text format)
@@ -494,5 +500,5 @@ This configuration enables HTTP health checks on backend servers.
     set load-balancing haproxy backend bk-01 server srv01 check
     set load-balancing haproxy backend bk-01 server srv02 address '192.0.2.12'
     set load-balancing haproxy backend bk-01 server srv02 port '8882'
-    set load-balancing haproxy backend bk-01 server srv02 check
+    set load-balancing haproxy backend bk-01 server srv02 check port '8892'
 

--- a/docs/configuration/loadbalancing/haproxy.rst
+++ b/docs/configuration/loadbalancing/haproxy.rst
@@ -160,7 +160,7 @@ Backend
 .. cfgcmd:: set load-balancing haproxy backend <name> server
    <name> check port <port>
 
-  Set the alternative port number for health checks.
+  Set an alternative port number for health checks.
   Overrides the default server port used for TCP/HTTP checks.
 
 .. cfgcmd:: set load-balancing haproxy backend <name> server


### PR DESCRIPTION
## Change Summary
Add support for specifying a [custom health check port](https://www.haproxy.com/documentation/haproxy-configuration-tutorials/reliability/health-checks/#tcp-health-checks) for HAProxy backend servers. 

This allows health probes to target a dedicated endpoint - such as port 8080 - separate from normal traffic ports (e.g., 80 or 443).

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T7906

## Related PR(s)
* https://github.com/vyos/vyos-1x/pull/4806


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document