### PR TITLE
Update wireguard.rst

### DIFF
--- a/docs/configuration/interfaces/wireguard.rst
+++ b/docs/configuration/interfaces/wireguard.rst
@@ -288,13 +288,13 @@ value needs to be lower than the UDP timeout.
             allowed-ips 10.172.24.30/32
             allowed-ips 2001:db8:470:22::30/128
             persistent-keepalive 15
-            pubkey F5MbW7ye7DsoxdOaixjdrudshjjxN5UdNV+pGFHqehc=
+            public-key F5MbW7ye7DsoxdOaixjdrudshjjxN5UdNV+pGFHqehc=
         }
         peer iPhone {
             allowed-ips 10.172.24.20/32
             allowed-ips 2001:db8:470:22::20/128
             persistent-keepalive 15
-            pubkey BknHcLFo8nOo8Dwq2CjaC/TedchKQ0ebxC7GYn7Al00=
+            public-key BknHcLFo8nOo8Dwq2CjaC/TedchKQ0ebxC7GYn7Al00=
         }
         port 2224
         private-key OLTQY3HuK5qWDgVs6fJR093SwPgOmCKkDI1+vJLGoFU=
@@ -354,7 +354,7 @@ Status
       private key: (hidden)
       listening port: 51820
 
-    peer: <peer pubkey>
+    peer: <peer public-key>
       endpoint: <peer public IP>
       allowed ips: 10.69.69.2/32
       latest handshake: 23 hours, 45 minutes, 26 seconds ago


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
VyOS 1.3 uses `pubkey`, VyOS 1.4  uses `public-key`. Update examples to reflect that change.

## Related Task(s)
none

## Related PR(s)
none

## Backport
I guess this should be applied to 1.5 and forward as well.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document