### PR TITLE
docs: Correct title for rolling-release "latest" docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,6 +130,11 @@ html_logo = '_static/images/vyos-logo.png'
 # pixels large.
 html_favicon = '_static/images/vyos-logo-icon.png'
 
+# The "title" for HTML documentation generated with Sphinx's own templates.
+# This is appended to the `<title>` tag of individual pages, and used
+# in the navigation bar as the "topmost" element.
+html_title = f'{project} rolling release (current)'
+
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.


### PR DESCRIPTION
## Change Summary

The page title for the "latest" version of [docs.vyos.io](http://docs.vyos.io/) says `VyOS 1.5.x (circinus) documentation`. In reality, the "latest" is built from the main branch and refers to the rolling release. We need to adjust it so that it says `VyOS User Guide — VyOS rolling release (current)`.

I added "VyOS" before "rolling release (current)" because it improves readability and avoids awkward phrasing in contexts where the prefix isn't obvious (About page).

https://vyos--1713.org.readthedocs.build/en/1713/


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document
