### PR TITLE
ssh: T8098: rename "ciphers" to "cipher"

### DIFF
--- a/docs/configuration/service/ssh.rst
+++ b/docs/configuration/service/ssh.rst
@@ -45,7 +45,7 @@ Configuration
   Specify IPv4/IPv6 listen address of SSH server. Multiple addresses can be
   defined.
 
-.. cfgcmd:: set service ssh ciphers <cipher>
+.. cfgcmd:: set service ssh cipher <cipher>
 
   Define allowed ciphers used for the SSH connection. A number of allowed
   ciphers can be specified, use multiple occurrences to allow multiple ciphers.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

rename "ciphers" to "cipher"

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T8098

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

* https://github.com/vyos/vyos-1x/pull/4896

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document