### PR TITLE
DOC: Copyedit policy local-route, correct and add missing params

### DIFF
--- a/docs/configuration/policy/examples.rst
+++ b/docs/configuration/policy/examples.rst
@@ -167,9 +167,9 @@ provider, and the second through another.
 .. code-block:: none
 
   set policy local-route rule 101 set table '10'
-  set policy local-route rule 101 source '203.0.113.254'
+  set policy local-route rule 101 source address '203.0.113.254'
   set policy local-route rule 102 set table '11'
-  set policy local-route rule 102 source '192.0.2.254'
+  set policy local-route rule 102 source address '192.0.2.254'
   set protocols static table 10 route 0.0.0.0/0 next-hop '203.0.113.1'
   set protocols static table 11 route 0.0.0.0/0 next-hop '192.0.2.2'
 
@@ -178,9 +178,9 @@ Add multiple source IP in one rule with same priority
 .. code-block:: none
 
   set policy local-route rule 101 set table '10'
-  set policy local-route rule 101 source '203.0.113.254'
-  set policy local-route rule 101 source '203.0.113.253'
-  set policy local-route rule 101 source '198.51.100.0/24'
+  set policy local-route rule 101 source address '203.0.113.254'
+  set policy local-route rule 101 source address '203.0.113.253'
+  set policy local-route rule 101 source address '198.51.100.0/24'
 
 ###########################
 Clamp MSS for a specific IP

--- a/docs/configuration/policy/local-route.rst
+++ b/docs/configuration/policy/local-route.rst
@@ -13,35 +13,75 @@ Local Route IPv4
 
 .. cfgcmd:: set policy local-route rule <1-32765> set table <1-200|main>
 
-   Set routing table to forward packet to.
+   Set the routing table to use for forwarding matching packets.
 
-.. cfgcmd:: set policy local-route rule <1-32765> source <x.x.x.x|x.x.x.x/x>
+.. cfgcmd:: set policy local-route rule <1-32765> set vrf <vrf|default>
 
-   Set source address or prefix to match.
+   Set the VRF to use for forwarding matching packets.
 
-.. cfgcmd:: set policy local-route rule <1-32765> destination <x.x.x.x|x.x.x.x/x>
+.. cfgcmd:: set policy local-route rule <1-32765> protocol <protocol>
 
-   Set destination address or prefix to match.
+   Match specified protocol (name or number).
+
+.. cfgcmd:: set policy local-route rule <1-32765> fwmark <1-2147483647>
+
+   Match specified firewall mark (fwmark).
+
+.. cfgcmd:: set policy local-route rule <1-32765> source address <x.x.x.x|x.x.x.x/x>
+
+   Match specified source address or prefix.
+
+.. cfgcmd:: set policy local-route rule <1-32765> source port <1-65535>
+
+   Match specified source port.
+
+.. cfgcmd:: set policy local-route rule <1-32765> destination address <x.x.x.x|x.x.x.x/x>
+
+   Match specified destination address or prefix.
+
+.. cfgcmd:: set policy local-route rule <1-32765> destination port <1-65535>
+
+   Match specified destination port.
 
 .. cfgcmd:: set policy local-route rule <1-32765> inbound-interface <interface>
 
-   Set inbound interface to match.
-   
+   Match specified inbound interface.
+
 Local Route IPv6
 ================
 
 .. cfgcmd:: set policy local-route6 rule <1-32765> set table <1-200|main>
 
-   Set routing table to forward packet to.
+   Set the routing table to use for forwarding matching packets.
 
-.. cfgcmd:: set policy local-route6 rule <1-32765> source <h:h:h:h:h:h:h:h | h:h:h:h:h:h:h:h/x>
+.. cfgcmd:: set policy local-route6 rule <1-32765> set vrf <vrf|default>
 
-   Set source address or prefix to match.
+   Set the VRF to use for forwarding matching packets.
 
-.. cfgcmd:: set policy local-route6 rule <1-32765> destination <h:h:h:h:h:h:h:h | h:h:h:h:h:h:h:h/x>
+.. cfgcmd:: set policy local-route6 rule <1-32765> protocol <protocol>
 
-   Set destination address or prefix to match.
+   Match specified protocol (name or number).
+
+.. cfgcmd:: set policy local-route6 rule <1-32765> fwmark <1-2147483647>
+
+   Match specified firewall mark (fwmark).
+
+.. cfgcmd:: set policy local-route6 rule <1-32765> source address <h:h:h:h:h:h:h:h|h:h:h:h:h:h:h:h/x>
+
+   Match specified source address or prefix.
+
+.. cfgcmd:: set policy local-route6 rule <1-32765> source port <1-65535>
+
+   Match specified source port.
+
+.. cfgcmd:: set policy local-route6 rule <1-32765> destination address <h:h:h:h:h:h:h:h|h:h:h:h:h:h:h:h/x>
+
+   Match specified destination address or prefix.
+
+.. cfgcmd:: set policy local-route6 rule <1-32765> destination port <1-65535>
+
+   Match specified destination port.
 
 .. cfgcmd:: set policy local-route6 rule <1-32765> inbound-interface <interface>
 
-   Set inbound interface to match.
+   Match specified inbound interface.


### PR DESCRIPTION
## Change Summary
The documentation has incorrect details for policy local-route for destination, source and is missing a few options as described below:

* Fix: destination -> destination address
* Fix: source -> source address
* Add: destination port
* Add: source port
* Add: protocol
* Add: fwmark
* Improve wording for clarity

## Related Task(s)

## Related PR(s)

## Backport

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document