### PR TITLE
T7664: FRR 10.5 remove unsupported ip protocols

### DIFF
--- a/docs/configuration/system/ip.rst
+++ b/docs/configuration/system/ip.rst
@@ -51,8 +51,7 @@ can be used to filter which routes zebra will install in the kernel.
 .. cfgcmd:: set system ip protocol <protocol> route-map <route-map>
 
    Apply a route-map filter to routes for the specified protocol. The following
-   protocols can be used: any, babel, bgp, connected, eigrp, isis, kernel,
-   ospf, rip, static, table
+   protocols can be used: any, babel, bgp, eigrp, isis, ospf, rip, static
 
    .. note:: If you choose any as the option that will cause all protocols that
       are sending routes to zebra.

--- a/docs/configuration/system/ipv6.rst
+++ b/docs/configuration/system/ipv6.rst
@@ -33,8 +33,7 @@ can be used to filter which routes zebra will install in the kernel.
 .. cfgcmd:: set system ipv6 protocol <protocol> route-map <route-map>
 
    Apply a route-map filter to routes for the specified protocol. The following
-   protocols can be used: any, babel, bgp, connected, isis, kernel, ospfv3,
-   ripng, static, table
+   protocols can be used: any, babel, bgp, isis, ospfv3, ripng, static
 
    .. note:: If you choose any as the option that will cause all protocols that
       are sending routes to zebra.

--- a/docs/configuration/vrf/index.rst
+++ b/docs/configuration/vrf/index.rst
@@ -47,8 +47,8 @@ can be used to filter which routes zebra will install in the kernel.
 
    Apply a route-map filter to routes for the specified protocol.
 
-   The following protocols can be used: any, babel, bgp, connected, eigrp,
-   isis, kernel, ospf, rip, static, table
+   The following protocols can be used: any, babel, bgp, eigrp,
+   isis, ospf, rip, static
 
    .. note:: If you choose any as the option that will cause all protocols that
       are sending routes to zebra.
@@ -57,8 +57,8 @@ can be used to filter which routes zebra will install in the kernel.
 
    Apply a route-map filter to routes for the specified protocol.
 
-   The following protocols can be used: any, babel, bgp, connected, isis,
-   kernel, ospfv3, ripng, static, table
+   The following protocols can be used: any, babel, bgp, isis,
+   ospfv3, ripng, static
 
    .. note:: If you choose any as the option that will cause all protocols that
       are sending routes to zebra.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Remove unsupported `ip protocol` options

FRR 10.5 removed support for `connected`, `kernel` and `table` protocols in `ip protocol`.

## Related Task(s)

* https://vyos.dev/T7664

## Related PR(s)

* https://github.com/vyos/vyos-build/pull/1090
* https://github.com/vyos/vyos-1x/pull/4921

## Backport
<!-- optional: the PR should backport to this documentation branch -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document