### PR TITLE
router-advert: T8140: add captive-portal documentation

### DIFF
--- a/docs/configuration/service/router-advert.rst
+++ b/docs/configuration/service/router-advert.rst
@@ -47,6 +47,7 @@ Configuration
    "DNSSL", "dnssl", "DNS search list to advertise"
    "Name Server", "name-server", "Advertise DNS server per https://tools.ietf.org/html/rfc6106"
    "Auto Ignore Prefix", "auto-ignore", "Exclude a prefix from being advertised when the wildcard ::/64 prefix is used"
+   "Captive Portal", "captive-portal", "Advertise a URL pointing to an RFC 8908-compliant API to tell hosts that they are behind a captive portal"
 
 .. start_vyoslinter
 


### PR DESCRIPTION
## Change Summary
Documentation for the captive portal router-advert option as implemented in pull request vyos/vyos-1x#4929.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T8140

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
* https://github.com/vyos/vyos-1x/pull/4929

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document