### PR TITLE
vpp ipfix: fix configuration example

### DIFF
--- a/docs/vpp/configuration/ipfix.rst
+++ b/docs/vpp/configuration/ipfix.rst
@@ -46,5 +46,6 @@ Example Configuration
     set vpp ipfix flowprobe-record 'l3'
     set vpp ipfix flowprobe-record 'l4'
     set vpp ipfix interface eth0
-    set vpp ipfix interface eth1 direction 'both' flow-variant 'ipv4'
+    set vpp ipfix interface eth1 direction 'both'
+    set vpp ipfix interface eth1 flow-variant 'ipv4'
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
cli command syntax issue in ipfix documentation under Example Configuration - https://docs.vyos.io/en/latest/vpp/configuration/ipfix.html
```
vyos@vyos# set vpp ipfix interface eth1 direction 'both' flow-variant 'ipv4'

  Configuration path: vpp ipfix interface eth1 direction both [flow-variant] is not valid
  Set failed
```
I was able to apply it as two commands:
```
set vpp ipfix interface eth1 direction 'both'
set vpp ipfix interface eth1 flow-variant ipv4
```
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->


## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document