### PR TITLE
vpp: T8202: Remove XDP driver from documentation

### DIFF
--- a/docs/vpp/configuration/dataplane/buffers.rst
+++ b/docs/vpp/configuration/dataplane/buffers.rst
@@ -34,7 +34,7 @@ Usually it needs to be tuned if:
 - there are a lot of queues in NICs
 - there are big descriptors size configured for NICs
 
-The value should be set responsibly, overprovisioning can lead to issues with NICs configured with XDP driver.
+The value should be set responsibly.
 
 .. cfgcmd:: set vpp settings buffers buffers-per-numa <value>
 

--- a/docs/vpp/configuration/dataplane/interface.rst
+++ b/docs/vpp/configuration/dataplane/interface.rst
@@ -14,14 +14,11 @@ Only Ethernet interfaces (physical or virtual) can be connected to the VPP datap
 Interface Configuration Parameters
 ==================================
 
-driver
-------
+Interfaces connected to the VPP dataplane use the DPDK driver by default, providing high performance and low latency.
 
-The driver parameter specifies the type of driver used for the network interface. VPP supports two types of drivers that can be used for this: DPDK and XDP. The choice of driver depends on the specific use case, hardware capabilities, and performance requirements. Some NICs may support only one of these drivers.
+.. cfgcmd:: set vpp settings interface <interface-name>
 
-.. cfgcmd:: set vpp settings interface <interface-name> driver <driver-type>
-
-The DPDK driver is generally preferred for high-performance scenarios, while the XDP driver may be suitable for NICs that do not support DPDK.
+Some network interface cards (NICs) may not be compatible with the DPDK driver.
 
 .. _vpp_config_dataplane_interface_rx_mode:
 
@@ -55,21 +52,6 @@ DPDK options you can configure are:
 - ``num-rx-desc``: Defines the size of each receive queue. Larger queue sizes can help accommodate bursts of incoming traffic, reducing the likelihood of packet drops during high traffic periods.
 - ``num-tx-desc``: Defines the size of each transmit queue. Larger sizes can help manage bursts of outgoing traffic more effectively.
 - ``promisc``: Enables or disables promiscuous mode on the interface. When promiscuous mode is enabled, the interface will receive all packets on the network, regardless of type and destination of the packets. Some NICs need this feature to be enabled to avoid filtering out packets (for example to pass VLAN tagged packets).
-
-xdp-options
------------
-
-The xdp-options section allows for the configuration of various XDP-specific settings for the interface.
-
-.. cfgcmd:: set vpp settings interface <interface-name> xdp-options <option> <value>
-
-XDP options you can configure are:
-
-- ``num-rx-queues``: Specifies the number of receive queues for the XDP interface. More queues can improve performance on multi-core systems by allowing parallel processing of incoming packets. Each queue will be assigned to a separate CPU core.
-- ``promisc``: Enables or disables promiscuous mode on the interface. When promiscuous mode is enabled, the interface will receive all packets on the network, regardless of type and destination of the packets. Some NICs need this feature to be enabled to avoid filtering out packets (for example to pass VLAN tagged packets).
-- ``rx-queue-size``: Defines the size of each receive queue. Larger queue sizes can help accommodate bursts of incoming traffic, reducing the likelihood of packet drops during high traffic periods.
-- ``tx-queue-size``: Defines the size of each transmit queue. Larger sizes can help manage bursts of outgoing traffic more effectively.
-- ``zero-copy``: Enables zero-copy mode for the XDP interface. This mode allows packets to be processed without copying them between kernel and user space, reducing latency and CPU usage.
 
 Potential Issues and Troubleshooting
 ====================================

--- a/docs/vpp/limitations.rst
+++ b/docs/vpp/limitations.rst
@@ -19,7 +19,7 @@ While VPP Dataplane offers significant performance advantages, there are some li
 
 * **NIC and Drivers Compatibility**
 
-  Some NICs may work with DPDK drivers but not with XDP, or vice versa.
+  VyOS currently supports only DPDK drivers for network interfaces. Not all NICs are compatible with DPDK drivers.
 
 * **Data Path Limitations**
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T8202

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-1x/pull/4955
## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document