### PR TITLE
DOC: Remove outdated upstream package documentation

### DIFF
--- a/docs/contributing/upstream-packages.rst
+++ b/docs/contributing/upstream-packages.rst
@@ -7,9 +7,8 @@ Upstream Packages
 #################
 
 Many base system packages are pulled straight from Debian's ``main`` and
-``contrib`` repositories, but there are exceptions.
-
-If you only want to build a fresh ISO image, you can skip
+``contrib`` repositories, but there are exceptions. If you only want to build
+a fresh ISO image, you can skip
 this section. This information may be useful for a deeper dive into VyOS.
 
 
@@ -19,3 +18,140 @@ System packages that are not directly pulled from Debian are built through a
 separate build system, ``build.py`` in the `vyos-build <https://github.com/vyos/vyos-build/tree/current/scripts/package-build>`__ repository.
 
 .. start_vyoslinter
+
+
+Overview
+========
+
+Previously, VyOS used Jenkins for building upstream packages. With the move away 
+from Jenkins, the build system was replaced with a Python-based solution using 
+``build.py`` and ``package.toml`` configuration files.
+
+Each package directory contains:
+
+- A ``package.toml`` configuration file that defines how the package is built.
+- A symlink to the common ``build.py`` script in the build system.
+
+
+Building Packages
+=================
+
+To build a package, navigate to the package directory and execute the 
+build script:
+
+.. code-block:: console
+
+   cd package-build/<package-name>
+   ./build.py
+
+The script will:
+
+1. Check out the source code from the configured repository.
+2. Apply any patches defined in the configuration.
+3. Execute pre-build hooks (if configured).
+4. Build the package using the specified build command.
+5. Generate both binary (``.deb``) packages and source tarballs.
+
+
+Package Configuration (package.toml)
+====================================
+
+Each package directory contains a ``package.toml`` file that defines the build 
+parameters. The key configuration fields are:
+
+**name**
+   The package name (e.g., ``frr``)
+
+**commit_id**
+   The specific commit, tag, or branch to check out from the source repository
+   (e.g., ``stable/10.5``)
+
+**scm_url**
+   The Git URL of the upstream source repository
+   (e.g., ``https://github.com/FRRouting/frr.git``)
+
+**build_cmd**
+   The command to execute for building the package. This replaces what was 
+   previously defined in the Jenkins ``Jenkinsfile``.
+
+   Default if not specified: ``dpkg-buildpackage -uc -us -tc -F --source-option=--tar-ignore=.git --source-option=--tar-ignore=.github``
+
+   Example with custom build command:
+
+   .. code-block:: toml
+
+      build_cmd = "sudo dpkg -i ../*.deb; dpkg-buildpackage -us -uc -tc -b -Ppkg.frr.rtrlib,pkg.frr.lua"
+
+**pre_build_hook** (Optional)
+   A shell command or script that executes after the repository is checked out 
+   and before the build process begins. This allows you to perform preparatory 
+   tasks such as:
+
+   - Creating directories
+   - Copying files
+   - Running custom setup scripts
+   - Installing dependencies
+
+   Single command example:
+
+   .. code-block:: toml
+
+      pre_build_hook = "echo 'Preparing build environment'"
+
+   Multi-line commands example:
+
+   .. code-block:: toml
+
+      pre_build_hook = """
+        mkdir -p ../hello/vyos
+        mkdir -p ../vyos
+        cp example.txt ../vyos
+      """
+
+   Combined commands and scripts:
+
+   .. code-block:: toml
+
+      pre_build_hook = "ls -l; ./script.sh"
+
+**apply_patches** (Optional)
+   Boolean flag to control whether patches should be applied. Defaults to
+   ``true``.
+
+   .. code-block:: toml
+
+      apply_patches = false
+
+**prepare_package** (Optional)
+   Boolean flag to enable package preparation. When set to ``true``, the 
+   ``install_data`` configuration is used.
+
+**install_data** (Optional)
+   Data used for package preparation when ``prepare_package`` is enabled.
+
+
+Example ``package.toml``
+====================
+
+Here's an example configuration for the FRRouting (FRR) package:
+
+.. code-block:: toml
+
+   name = "frr"
+   commit_id = "stable/10.5"
+   scm_url = "https://github.com/FRRouting/frr.git"
+   build_cmd = "sudo dpkg -i ../*.deb; dpkg-buildpackage -us -uc -tc -b -Ppkg.frr.rtrlib,pkg.frr.lua"
+
+
+Build Output
+============
+
+After running ``./build.py``, the following artifacts are generated in the 
+package directory:
+
+- ``.deb`` files - Binary Debian packages ready for installation
+- ``.tar.gz`` files - Source tarballs of the checked-out repositories
+- Additional build artifacts as produced by the Debian build system
+
+The build script also creates build dependency packages (`*build-deps*.deb`), 
+which are automatically cleaned up after the build completes.

--- a/docs/contributing/upstream-packages.rst
+++ b/docs/contributing/upstream-packages.rst
@@ -9,82 +9,13 @@ Upstream Packages
 Many base system packages are pulled straight from Debian's ``main`` and
 ``contrib`` repositories, but there are exceptions.
 
-This page lists those exceptions and briefly describes changes made to
-these packages. If you only want to build a fresh ISO image, you can skip
+If you only want to build a fresh ISO image, you can skip
 this section. This information may be useful for a deeper dive into VyOS.
 
-``vyos-netplug``
-----------------
 
-VyOS uses a modified version because the upstream release sometimes causes
-network interfaces to go down.
+.. stop_vyoslinter
 
-Source: https://github.com/vyos/vyos-netplug.
+System packages that are not directly pulled from Debian are built through a 
+separate build system, ``build.py`` in the `vyos-build <https://github.com/vyos/vyos-build/tree/current/scripts/package-build>`__ repository.
 
-VyOS may switch to ``systemd`` in the future. Building the package does not
-require a special procedure.
-
-``keepalived``
---------------
-
-``keepalived`` is not updated to newer feature releases between Debian releases.
-VyoS builds it from source.
-
-Debian maintains the package in git, but the upstream tarball was imported
-without its original commit history. To allow merging new tags, we maintain
-a fork with packaging files imported from
-Debian: https://github.com/vyos/keepalived-upstream.
-
-``strongswan``
---------------
-
-VyOS's StrongSWAN build differs from upstream:
-
-- We disable the ``strongswan-nm`` package build because VyOS does not use
-  NetworkManager.
-- We merged patches for DMVPN.
-
-Source: https://github.com/vyos/vyos-strongswan
-
-DMVPN patches were added in this commit:
-https://github.com/vyos/vyos-strongswan/commit/1cf12b0f2f921bfc51affa3b81226
-
-VyOS's op-mode scripts use the ``python-vici`` module, which is not included
-in Debian's build and is difficult to integrate. VyOS debianizes the module
-manually:
-
-1. Install ``stdeb`` from PyPI (for example: ``pip3 install stdeb``).
-2. ``cd vyos-strongswan``
-3. ``./configure --enable-python-eggs``
-4. ``cd src/libcharon/plugins/vici/python``
-5. ``make``
-6. ``python3 setup.py --command-packages=stdeb.command bdist_deb``
-
-The package is created in the ``deb_dist`` directory.
-
-``mdns-repeater``
------------------
-
-This package does not exist in Debian. VyOS maintains a debianized fork at
-https://github.com/vyos/mdns-repeater.
-
-No special build procedure is required.
-
-``udp-broadcast-relay``
------------------------
-
-This package does not exist in Debian. VyOS maintain a debianized fork at
-https://github.com/vyos/udp-broadcast-relay.
-
-No special build procedure is required.
-
-``hvinfo``
-----------
-
-A fork with packaging changes for VyOS is available
-at https://github.com/vyos/hvinfo.
-
-The original repository is at https://github.com/dmbaturin/hvinfo.
-
-It is an Ada program and requires GNAT and ``gprbuild``. Dependencies are
-properly specified; follow the suggestions from ``debuild``.
+.. start_vyoslinter

--- a/docs/contributing/upstream-packages.rst
+++ b/docs/contributing/upstream-packages.rst
@@ -1,4 +1,4 @@
-:lastproofread: 2025-11-30
+:lastproofread: 2026-01-30
 
 .. _upstream_packages:
 
@@ -70,6 +70,7 @@ parameters. The key configuration fields are:
    The Git URL of the upstream source repository
    (e.g., ``https://github.com/FRRouting/frr.git``)
 
+.. stop_vyoslinter
 **build_cmd**
    The command to execute for building the package. This replaces what was 
    previously defined in the Jenkins ``Jenkinsfile``.
@@ -81,6 +82,7 @@ parameters. The key configuration fields are:
    .. code-block:: toml
 
       build_cmd = "sudo dpkg -i ../*.deb; dpkg-buildpackage -us -uc -tc -b -Ppkg.frr.rtrlib,pkg.frr.lua"
+.. start_vyoslinter
 
 **pre_build_hook** (Optional)
    A shell command or script that executes after the repository is checked out 
@@ -116,22 +118,22 @@ parameters. The key configuration fields are:
 
 **apply_patches** (Optional)
    Boolean flag to control whether patches should be applied. Defaults to
-   ``true``.
+   ``True``.
 
    .. code-block:: toml
 
       apply_patches = false
 
 **prepare_package** (Optional)
-   Boolean flag to enable package preparation. When set to ``true``, the 
+   Boolean flag to enable package preparation. When set to ``True``, the 
    ``install_data`` configuration is used.
 
 **install_data** (Optional)
    Data used for package preparation when ``prepare_package`` is enabled.
 
 
-Example ``package.toml``
-====================
+Example package.toml file
+===========================
 
 Here's an example configuration for the FRRouting (FRR) package:
 


### PR DESCRIPTION
Upstream packages are now built through a Python script, 'build.py' from the vyos-build repository:
https://github.com/vyos/vyos-build/tree/current/scripts/package-build/build.py

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

* Remove outdated upstream package build information.
* Adds information about the unified build system in [`build.py`](https://github.com/vyos/vyos-build/blob/current/scripts/package-build/build.py)

## Related Task(s)


## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document