### PR TITLE
ssh: fix fido2 examples indentation

### DIFF
--- a/docs/configuration/service/ssh.rst
+++ b/docs/configuration/service/ssh.rst
@@ -72,22 +72,30 @@ Configuration
   Two FIDO2 key types are supported by OpenSSH: ``ed25519-sk``, ``ecdsa-sk``
 
   Generic FIDO2-backed SSH key generation example:
+
   .. code-block:: none
+
     ssh-keygen -t ecdsa-sk -O verify-required -C "fido2-ssh-key"
+    
   During key generation, OpenSSH will:
-   * Request user presence (for example, a physical touch or confirmation)
-   * Optionally request user verification (PIN), if supported by the authenticator
-   * Create a local key handle file and a corresponding public key (``.pub``)
-   The private key material never leaves the authenticator device.
+    * Request user presence (for example, a physical touch or confirmation)
+    * Optionally request user verification (PIN), if supported by the authenticator
+    * Create a local key handle file and a corresponding public key (``.pub``)
+
+  The private key material never leaves the authenticator device.
 
   VyOS configuration example:
+
   .. code-block:: none
+
     # Generate a FIDO2 SSH key on the client system
     # Copy the public key to the VyOS instance
     set system login user vyos authentication public-keys fido key '<public-key>'
     set system login user vyos authentication public-keys fido type 'sk-ecdsa-sha2-nistp256@openssh.com'
     set service ssh fido touch-required
+
   You can now log into the system using: ``ssh -i ~/.ssh/id_fido_key vyos@192.0.2.1``
+
 .. cfgcmd:: set service ssh disable-host-validation
 
   Disable the host validation through reverse DNS lookups - can speedup login


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

fix wrong indentation of code-blocks in fido2 examples - https://docs.vyos.io/en/latest/configuration/service/ssh.html

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document