### PR TITLE
vpp: fix bonding interface examples

### DIFF
--- a/docs/vpp/configuration/interfaces/bonding.rst
+++ b/docs/vpp/configuration/interfaces/bonding.rst
@@ -141,7 +141,7 @@ For detailed information about kernel interface integration, see :doc:`kernel`.
 
 .. code-block:: none
 
-   set vpp interfaces bonding bond0 kernel-interface vpptap0
+   set vpp interfaces bonding bond0 kernel-interface vpptun0
 
 .. important::
 
@@ -169,10 +169,10 @@ Here's a complete example configuring a bonding interface with LACP:
    set vpp interfaces bonding bond0 member interface eth1
    
    # Create kernel interface for OS integration
-   set vpp interfaces bonding bond0 kernel-interface vpptap0
+   set vpp interfaces bonding bond0 kernel-interface vpptun0
    
    # Configure IP on kernel interface
-   set vpp kernel-interfaces vpptap0 address 192.168.1.10/24
+   set vpp kernel-interfaces vpptun0 address 192.168.1.10/24
 
 Best Practices
 --------------


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

fix bonding interface examples - https://docs.vyos.io/en/latest/vpp/configuration/interfaces/bonding.html

Current example leads to config error:

```
vyos@vyos# set vpp interfaces bonding bond0 kernel-interface vpptap0

  
  
  Kernel interface must start with vpptunN
  Value validation failed
  Set failed

[edit]
vyos@vyos#
```

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->


## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document