### PR TITLE
config-sync: add missing config line

### DIFF
--- a/docs/configuration/service/config-sync.rst
+++ b/docs/configuration/service/config-sync.rst
@@ -70,6 +70,7 @@ Configure the HTTP API service on Router B
     set service https listen-address '10.0.20.112'
     set service https port '8443'
     set service https api keys id KID key 'foo'
+    set service https api rest
 
 Configure the config-sync service on Router A
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add missing config line in config-sync example. In VyOS 1.5+, the rest api settings live under the 'service https api rest' node.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/Txxxx

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document