### PR TITLE
vpp: fix vxlan interface example

### DIFF
--- a/docs/vpp/configuration/interfaces/vxlan.rst
+++ b/docs/vpp/configuration/interfaces/vxlan.rst
@@ -100,8 +100,8 @@ VXLAN with Kernel Interface
    set vpp interfaces vxlan vxlan3 vni 3000
    set vpp interfaces vxlan vxlan3 remote 203.0.113.30
    set vpp interfaces vxlan vxlan3 source-address 192.168.1.1
-   set vpp interfaces vxlan vxlan3 kernel-interface vpptun3
-   set vpp kernel-interfaces vpptun3 address 10.0.3.1/24
+   set vpp interfaces vxlan vxlan3 kernel-interface vpptap3
+   set vpp kernel-interfaces vpptap3 address 10.0.3.1/24
 
 Bridge Integration
 ------------------


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->
Fixing VXLAN vpp example, current version leads to config error:

```
vyos@vyos# set vpp interfaces vxlan vxlan3 kernel-interface vpptun3

  Kernel interface must start with vpptapN
  Value validation failed
  Set failed

[edit]
```

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document