### PR TITLE
vpp: fix ipsec interface config syntax

### DIFF
--- a/docs/vpp/configuration/ipsec.rst
+++ b/docs/vpp/configuration/ipsec.rst
@@ -153,8 +153,8 @@ On the VPP host:
     set vpn ipsec site-to-site peer peerB vti bind 'vti1'
     set vpn ipsec site-to-site peer peerB vti traffic-selector remote prefix '192.168.200.0/24'
 
-    set vpp settings interface eth1 driver 'dpdk'
-    set vpp settings interface eth2 driver 'dpdk'
+    set vpp settings interface eth1
+    set vpp settings interface eth2
     set vpp settings ipsec netlink rx-buffer-size '32000'
     set vpp settings lcp ignore-kernel-routes
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

Fixing ipsec configuration example, current config fails to apply due to recent change in vpp interface syntax

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->


## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document