### PR TITLE
vpp: T8255: Update logging command to use `default-level`

### DIFF
--- a/docs/vpp/configuration/dataplane/logging.rst
+++ b/docs/vpp/configuration/dataplane/logging.rst
@@ -17,7 +17,7 @@ VPP stores logs in two places:
 
 Logging detalization can be configured via the next command:
 
-.. cfgcmd:: set vpp settings logging default-log-level <level>
+.. cfgcmd:: set vpp settings logging default-level <level>
 
 Where ``<level>`` can be one of the following:
 


### PR DESCRIPTION
## Change Summary
Instead `vpp settings logging default-log-level` use `vpp settings logging default-level` command.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T8255

## Related PR(s)
* https://github.com/vyos/vyos-1x/pull/4983


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document