### PR TITLE
vpp: T8258: Move `poll-sleep-usec` out of `unix` section

### DIFF
--- a/docs/vpp/configuration/dataplane/unix.rst
+++ b/docs/vpp/configuration/dataplane/unix.rst
@@ -16,7 +16,7 @@ To mitigate this, VPP provides a configurable polling delay that allows to reduc
 
 You can configure the polling delay using the following command in the VyOS CLI:
 
-.. cfgcmd:: set vpp settings unix poll-sleep-usec <delay>
+.. cfgcmd:: set vpp settings poll-sleep-usec <delay>
 
 Sets the polling delay in microseconds. A value of 0 means no delay (default), while higher values introduce a delay between polling cycles.
 


### PR DESCRIPTION
## Change Summary
Instead of `vpp settings unix poll-sleep-usec` use `vpp settings poll-sleep-usec` command to configure the parameter.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T8258

## Related PR(s)
* https://github.com/vyos/vyos-1x/pull/4986

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document