### PR TITLE
bgp: T7984: add CLI support for "neighbor <N> remote-as auto"

### DIFF
--- a/docs/configuration/protocols/bgp.rst
+++ b/docs/configuration/protocols/bgp.rst
@@ -186,9 +186,9 @@ Defining Peers
 ^^^^^^^^^^^^^^
 
 .. cfgcmd:: set protocols bgp neighbor <address|interface> remote-as
-   <nasn>
+   <asn>
 
-   This command creates a new neighbor whose remote-as is <nasn>. The neighbor
+   This command creates a new neighbor whose remote-as is <asn>. The neighbor
    address can be an IPv4 address or an IPv6 address or an interface to use
    for the connection. The command is applicable for peer and peer group.
 
@@ -205,6 +205,12 @@ Defining Peers
    Create a peer as you would when you specify an ASN, except that if the
    peers ASN is the same as mine as specified under the :cfgcmd:`protocols
    bgp <asn>` command the connection will be denied.
+
+.. cfgcmd:: set protocols bgp neighbor <address|interface> remote-as
+   auto
+
+   Create a peer as you would when you specify an ASN, except that the peers
+   remote ASN is detected automatically from the OPEN message.
 
 .. cfgcmd:: set protocols bgp neighbor <address|interface> local-role
    <role> [strict]


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

FRR implemented a new know to learn the peers remote ASN from the BGP OPEN message

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T7984

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
* https://github.com/vyos/vyos-1x/pull/4988



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document