### PR TITLE
vpp: T8266: Add global `interface-rx-mode` setting and remove per-interface commands

### DIFF
--- a/docs/vpp/configuration/dataplane/interface.rst
+++ b/docs/vpp/configuration/dataplane/interface.rst
@@ -20,21 +20,6 @@ Interfaces connected to the VPP dataplane use the DPDK driver by default, provid
 
 Some network interface cards (NICs) may not be compatible with the DPDK driver.
 
-.. _vpp_config_dataplane_interface_rx_mode:
-
-rx-mode
--------
-
-The rx-mode parameter defines how VPP handles incoming packets on the interface. There are several modes available, each with its own advantages and use cases:
-
-- ``interrupt``: In this mode, VPP relies on hardware interrupts to notify it of incoming packets. This mode is suitable for low to moderate traffic loads and can help reduce CPU usage during idle periods. It is not recommended if low-latency processing is required. May not be supported by some NICs.
-- ``polling``: In polling mode, VPP continuously checks the interface for incoming packets. This mode is ideal for high-throughput scenarios where low latency is critical, as it minimizes the time packets spend waiting to be processed. However, it can lead to higher CPU usage, especially during periods of low traffic, because the polling process is always active.
-- ``adaptive``: Adaptive mode combines the benefits of both interrupt and polling modes. VPP starts in interrupt mode and switches to polling mode when the traffic load increases.
-
-.. cfgcmd:: set vpp settings interface <interface-name> rx-mode <mode>
-
-The choice of rx-mode should be based on the expected traffic patterns and performance requirements of the network environment.
-
 dpdk-options
 ------------
 
@@ -52,6 +37,24 @@ DPDK options you can configure are:
 - ``num-rx-desc``: Defines the size of each receive queue. Larger queue sizes can help accommodate bursts of incoming traffic, reducing the likelihood of packet drops during high traffic periods.
 - ``num-tx-desc``: Defines the size of each transmit queue. Larger sizes can help manage bursts of outgoing traffic more effectively.
 - ``promisc``: Enables or disables promiscuous mode on the interface. When promiscuous mode is enabled, the interface will receive all packets on the network, regardless of type and destination of the packets. Some NICs need this feature to be enabled to avoid filtering out packets (for example to pass VLAN tagged packets).
+
+Global Interface Parameters
+===========================
+
+.. _vpp_config_dataplane_interface_rx_mode:
+
+interface-rx-mode
+-----------------
+
+The interface-rx-mode parameter defines how VPP handles incoming packets on interfaces. There are several modes available, each with its own advantages and use cases:
+
+- ``interrupt``: In this mode, VPP relies on hardware interrupts to notify it of incoming packets. This mode is suitable for low to moderate traffic loads and can help reduce CPU usage during idle periods. It is not recommended if low-latency processing is required. May not be supported by some NICs.
+- ``polling``: In polling mode, VPP continuously checks the interface for incoming packets. This mode is ideal for high-throughput scenarios where low latency is critical, as it minimizes the time packets spend waiting to be processed. However, it can lead to higher CPU usage, especially during periods of low traffic, because the polling process is always active.
+- ``adaptive``: Adaptive mode combines the benefits of both interrupt and polling modes. VPP starts in interrupt mode and switches to polling mode when the traffic load increases.
+
+.. cfgcmd:: set vpp settings interface-rx-mode <mode>
+
+The choice of rx-mode should be based on the expected traffic patterns and performance requirements of the network environment.
 
 Potential Issues and Troubleshooting
 ====================================

--- a/docs/vpp/configuration/interfaces/kernel.rst
+++ b/docs/vpp/configuration/interfaces/kernel.rst
@@ -117,30 +117,6 @@ MTU Configuration
 
    Ensure the MTU setting matches or is smaller than the MTU supported by the associated VPP interface to avoid issues.
 
-Receive Processing Mode
------------------------
-
-.. cfgcmd:: set vpp kernel-interfaces <interface-name> rx-mode <mode>
-
-   Configure how the interface processes received packets:
-
-   * **polling**: Constantly check for new data (highest performance, higher CPU usage)
-   * **interrupt**: Interrupt-driven processing (balanced performance and CPU usage)
-   * **adaptive**: Automatically switch between polling and interrupt based on traffic load
-
-**Examples:**
-
-.. code-block:: none
-
-   # High-performance mode (default)
-   set vpp kernel-interfaces vpptap1 rx-mode polling
-   
-   # Balanced mode
-   set vpp kernel-interfaces vpptap1 rx-mode interrupt
-   
-   # Adaptive mode
-   set vpp kernel-interfaces vpptap1 rx-mode adaptive
-
 VLAN Configuration
 ------------------
 
@@ -198,7 +174,7 @@ Basic Kernel Interface
    set vpp kernel-interfaces vpptap1 description "VPP-Kernel bridge"
    set vpp kernel-interfaces vpptap1 address 192.168.1.10/24
    set vpp kernel-interfaces vpptap1 mtu 1500
-   set vpp kernel-interfaces vpptap1 rx-mode adaptive
+   set vpp settings interface-rx-mode adaptive
 
 High-Performance Interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -210,7 +186,7 @@ High-Performance Interface
    set vpp kernel-interfaces vpptap2 description "High-performance bridge"
    set vpp kernel-interfaces vpptap2 address 10.0.0.10/8
    set vpp kernel-interfaces vpptap2 mtu 9000
-   set vpp kernel-interfaces vpptap2 rx-mode polling
+   set vpp settings interface-rx-mode polling
 
 Multi-VLAN Setup
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Change Summary
Add `set vpp settings interface-rx-mode <polling|interrupt|adaptive>` to configure RX mode for all interfaces.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T8266

## Related PR(s)
* https://github.com/vyos/vyos-1x/pull/4995


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document