### PR TITLE
Fix blackbox-exporter examples

### DIFF
--- a/docs/configuration/service/monitoring.rst
+++ b/docs/configuration/service/monitoring.rst
@@ -272,7 +272,7 @@ DNS module example:
 
 .. code-block:: none
 
-  set service monitoring prometheus blackbox-exporter modules dns name dns4 preferred-ip-protocol ip4
+  set service monitoring prometheus blackbox-exporter modules dns name dns4 preferred-ip-protocol ipv4
   set service monitoring prometheus blackbox-exporter modules dns name dns4 query-name vyos.io
   set service monitoring prometheus blackbox-exporter modules dns name dns4 query-type A
 
@@ -280,7 +280,7 @@ ICMP module example:
 
 .. code-block:: none
 
-  set service monitoring prometheus blackbox-exporter modules icmp name ping6 preferred-ip-protocol ip6
+  set service monitoring prometheus blackbox-exporter modules icmp name ping6 preferred-ip-protocol ipv6
   set service monitoring prometheus blackbox-exporter modules icmp name ping6 ip-protocol-fallback
   set service monitoring prometheus blackbox-exporter modules icmp name ping6 timeout 3
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Update prometheus blackbox-exporter examples to use the correct values for `preferred-ip-protocol` according to [interface definition](https://github.com/vyos/vyos-1x/blob/current/interface-definitions/include/monitoring/blackbox-exporter-module-commons.xml.i#L28).

## Related Task(s)
-

## Related PR(s)
-

## Backport
-



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document