### PR TITLE
firewall: fix inbound-interface name syntax

### DIFF
--- a/docs/configexamples/policy-based-ipsec-and-firewall.rst
+++ b/docs/configexamples/policy-based-ipsec-and-firewall.rst
@@ -166,10 +166,10 @@ Firewall Configuration:
     # Input traffic: add rules needed for ipsec connection
     set firewall ipv4 input filter rule 10 action 'accept'
     set firewall ipv4 input filter rule 10 destination port '500,4500'
-    set firewall ipv4 input filter rule 10 inbound-interface interface-name 'eth0'
+    set firewall ipv4 input filter rule 10 inbound-interface name 'eth0'
     set firewall ipv4 input filter rule 10 protocol 'udp'
     set firewall ipv4 input filter rule 15 action 'accept'
-    set firewall ipv4 input filter rule 15 inbound-interface interface-name 'eth0'
+    set firewall ipv4 input filter rule 15 inbound-interface name 'eth0'
     set firewall ipv4 input filter rule 15 protocol 'esp'
 
     # Input traffic: accept ssh connection from trusted ips


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->



## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Config example uses wrong syntax for firewall inbound-interface name, fix replaces 'interface-name' with 'name'

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document