### PR TITLE
vpp: T8354: Move 'ignore-kernel-routes' option out of resource-allocation section

### DIFF
--- a/docs/vpp/configuration/dataplane/lcp.rst
+++ b/docs/vpp/configuration/dataplane/lcp.rst
@@ -34,7 +34,7 @@ behavior using the following command:
 
 .. _vpp_config_dataplane_lcp_ignore-kernel-routes:
 
-.. cfgcmd:: set vpp settings resource-allocation ignore-kernel-routes
+.. cfgcmd:: set vpp settings ignore-kernel-routes
 
 Pay attention that disabling this option leads to loss of connectivity to
 destinations if there are no direct routes in VPP routing table.


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T83564

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-1x/pull/5034
## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document