### PR TITLE
Correction of syslog and isis cli commands as per the latest version

### DIFF
--- a/docs/configuration/protocols/isis.rst
+++ b/docs/configuration/protocols/isis.rst
@@ -118,12 +118,12 @@ IS-IS Global Configuration
   This command sets overload bit to avoid any transit traffic through this
   router. It is described in :rfc:`3787`.
 
-.. cfgcmd:: set protocols isis name default-information originate <ipv4|ipv6>
+.. cfgcmd:: set protocols isis default-information originate <ipv4|ipv6>
   level-1
 
   This command will generate a default-route in L1 database.
 
-.. cfgcmd:: set protocols isis name default-information originate <ipv4|ipv6>
+.. cfgcmd:: set protocols isis default-information originate <ipv4|ipv6>
   level-2
 
   This command will generate a default-route in L2 database.
@@ -224,23 +224,31 @@ Interface Configuration
   during convergence/interface flap events, but for this interface only.
 
 .. cfgcmd:: set protocols isis interface <interface> fast-reroute lfa [level-1 | level-2] enable
+
   This command enables per-prefix local LFA fast reroute link protection.
 
 .. cfgcmd:: set protocols isis interface <interface> fast-reroute lfa [level-1 | level-2] exclude
-  This command excludes an interface from the local LFA backup nexthop computation.
+
+  This command excludes an interface from the local LFA backup nexthop 
+  computation.
 
 .. cfgcmd:: set protocols isis interface <interface> fast-reroute remote-lfa [level-1 | level-2] tunnel mpls-ldp
+
   This command enables per-prefix Remote LFA fast reroute link protection.
   Note that other routers in the network need to be configured to accept LDP
   targeted hello messages in order for RLFA to work.
 
 .. cfgcmd:: set protocols isis interface <interface> fast-reroute remote-lfa [level-1 | level-2] maximum-metric <metric>
-  This command limits Remote LFA PQ node selection within the specified metric. Metric value range (1-16777215).
+
+  This command limits Remote LFA PQ node selection within the specified 
+  metric. Metric value range (1-16777215).
 
 .. cfgcmd:: set protocols isis interface <interface> fast-reroute ti-lfa [level-1|level-2] [node-protection [link-fallback]]
+
   This command enables per-prefix TI-LFA fast reroute link or node protection.
-  When node protection is used, option link-fallback enables the computation and
-  use of link-protecting LFAs for destinations unprotected by node protection.
+  When node protection is used, option link-fallback enables the computation 
+  and use of link-protecting LFAs for destinations unprotected by node 
+  protection.
 
 Route Redistribution
 --------------------

--- a/docs/configuration/system/syslog.rst
+++ b/docs/configuration/system/syslog.rst
@@ -51,22 +51,16 @@ Configure the general behavior of the syslog service.
    If configured, the device includes its :abbr:`FQDN (Fully Qualified Domain 
    Name)` in log messages, even if the syslog server is in the same domain.
 
-.. cfgcmd:: set system syslog source-address <address>
-
-   Configure the source IP address for log transmission to a remote server.
 
 Local logging
 -------------
 
 Configure which log messages to save to a local log file.
 
-.. cfgcmd:: set system syslog file <filename> facility <keyword> level <keyword>
+.. cfgcmd:: set system syslog local <filename> facility <keyword> level <keyword>
 
    **Configure syslog to save log messages for a specific facility and 
-   severity level to a local log file.** 
-
-   Logs matching the specified facility and severity level are saved to the 
-   local file at ``/var/log/messages``. 
+   severity level to ``/var/log/messages``.**
    
    Refer to the tables below for valid facility and severity options.
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Correction of syslog and isis cli commands as per the latest version:
- There is no option for syslog file only local option exists.
- Corrected syntax
set protocols isis default-information originate <ipv4|ipv6> level-1
## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/Txxxx

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document