### PR TITLE
docs: Fix typos and a few grammar issues

### DIFF
--- a/docs/_static/js/codecopier.js
+++ b/docs/_static/js/codecopier.js
@@ -40,7 +40,7 @@ $(document).ready(async function () {
     try {
       await navigator.clipboard.writeText(currentTarget.offsetParent.innerText)
     } catch (error) {
-      console.log('Copiing text failed, please try again', {
+      console.log('Copying text failed, please try again', {
         error
       })
     }

--- a/docs/automation/cloud-init.rst
+++ b/docs/automation/cloud-init.rst
@@ -328,9 +328,9 @@ vyos-commands. For example:
      - set interfaces ethernet eth0 address '198.51.100.2/30'
      - set interfaces ethernet eth0 description 'WAN - ISP01'
      - set interfaces ethernet eth1 address '192.168.25.1/24'
-     - set interfaces ethernet eth1 description 'Comming through VLAN 25'
+     - set interfaces ethernet eth1 description 'Coming through VLAN 25'
      - set interfaces ethernet eth2 address '192.168.26.1/24'
-     - set interfaces ethernet eth2 description 'Comming through VLAN 26'
+     - set interfaces ethernet eth2 description 'Coming through VLAN 26'
      - set protocols static route 0.0.0.0/0 next-hop '198.51.100.1'
 
 **network-config** file only has configuration that disables the automatic
@@ -403,7 +403,7 @@ On proxmox server:
    ## Import seed.iso for cloud init
    qm set 555 --ide2 media=cdrom,file=local:iso/seed.iso
    
-   ## Since this server has 1 nic, lets add network intefaces (vlan 25 and 26)
+   ## Since this server has 1 nic, lets add network interfaces (vlan 25 and 26)
    qm set 555 --net1 virtio,bridge=vmbr0,firewall=1,tag=25
    qm set 555 --net2 virtio,bridge=vmbr0,firewall=1,tag=26
    

--- a/docs/automation/terraform/terraformAWS.rst
+++ b/docs/automation/terraform/terraformAWS.rst
@@ -290,7 +290,7 @@ Structure of files Terrafom for AWS
  ├── vyos.tf				# The main script
  ├── var.tf					# The file of all variables in "vyos.tf"
  ├── versions.tf			# File for the changing version of Terraform.
- └── terraform.tfvars		# The value of all variables (passwords, login, ip adresses and so on)
+ └── terraform.tfvars		# The value of all variables (passwords, login, ip addresses and so on)
  
 
  
@@ -304,7 +304,7 @@ vyos.tf
 
   ##############################################################################
   # Build an VyOS VM from the Marketplace
-  # To finde nessesery AMI image_ in AWS
+  # To find necessary AMI image_ in AWS
   #
   # In the script vyos.tf we'll use default values (you can chang it as you need)
   # AWS Region = "us-east-1"
@@ -533,7 +533,7 @@ group_vars/all
   ansible_network_os: vyos.vyos.vyos
   ansible_user: vyos
 
-Sourse files for AWS from GIT
+Source files for AWS from GIT
 -----------------------------
 
 All files about the article can be found here_

--- a/docs/automation/terraform/terraformAZ.rst
+++ b/docs/automation/terraform/terraformAZ.rst
@@ -87,7 +87,7 @@ Structure of files Terrafom for Azure
  .
  ├── vyos.tf				# The main script
  ├── var.tf					# File for the changing version of Terraform.
- └── terraform.tfvars		# The value of all variables (passwords, login, ip adresses and so on)
+ └── terraform.tfvars		# The value of all variables (passwords, login, ip addresses and so on)
 
 File contents of Terrafom for Azure
 -----------------------------------
@@ -138,7 +138,7 @@ vyos.tf
   
   ##############################################################################
   # Build an VyOS VM from the Marketplace
-  # To finde nessesery image use the command:
+  # To find necessary image use the command:
   #
   # az vm image list --offer vyos --all
   #
@@ -205,7 +205,7 @@ vyos.tf
     network_interface_ids         = ["${azurerm_network_interface.vyos-nic.id}"]
     delete_os_disk_on_termination = "true"
   
-  # To finde an information about the plan use the command:
+  # To find an information about the plan use the command:
   # az vm image list --offer vyos --all
   
     plan {
@@ -478,7 +478,7 @@ group_vars/all
   ansible_user: vyos
   ansible_ssh_pass: Vyos0!
 
-Sourse files for Azure from GIT
+Source files for Azure from GIT
 -------------------------------
 
 All files about the article can be found here_

--- a/docs/automation/terraform/terraformGoogle.rst
+++ b/docs/automation/terraform/terraformGoogle.rst
@@ -38,7 +38,7 @@ Google Cloud
    :align: center
    :alt: Network Topology Diagram
 
-The .JSON file download automaticly after creating and will look like:
+The .JSON file download automatically after creating and will look like:
 
 .. image:: /_static/images/json.png
    :width: 50%
@@ -699,7 +699,7 @@ group_vars/all
   ansible_user: vyos
   ansible_ssh_pass: vyos
 
-Sourse files for Google Cloud from GIT
+Source files for Google Cloud from GIT
 --------------------------------------
 
 All files about the article can be found here_

--- a/docs/automation/terraform/terraformvSphere.rst
+++ b/docs/automation/terraform/terraformvSphere.rst
@@ -89,7 +89,7 @@ Structure of files Terrafom for vSphere
  ├── vyos.tf				# The main script
  ├── versions.tf			# File for the changing version of Terraform.
  ├── var.tf					# File for the changing version of Terraform.
- └── terraform.tfvars		# The value of all variables (passwords, login, ip adresses and so on)
+ └── terraform.tfvars		# The value of all variables (passwords, login, ip addresses and so on)
 
 
 File contents of Terrafom for vSphere
@@ -280,7 +280,7 @@ var.tf
   }
   
   variable "host" {
-    description = "name if yor host"
+    description = "name of your host"
     type        = string
   }
   
@@ -290,7 +290,7 @@ var.tf
   }
   
   variable "url_ova" {
-    description = "the URL to .OVA file or cloude store"
+    description = "the URL to .OVA file or cloud store"
     type        = string
   }
   
@@ -391,7 +391,7 @@ group_vars/all
   ansible_ssh_pass: 12345678
 
 
-Sourse files for vSphere from GIT
+Source files for vSphere from GIT
 ---------------------------------
 
 All files about the article can be found here_

--- a/docs/automation/terraform/terraformvyos.rst
+++ b/docs/automation/terraform/terraformvyos.rst
@@ -20,7 +20,7 @@ Structure of files in the standard Terraform project:
  ├── main.tf             # The main script
  ├── version.tf          # File for the changing version of Terraform.
  ├── variables.tf        # The file of all variables in "main.tf"
- └── terraform.tfvars    # The value of all variables (passwords, login, ip adresses and so on)
+ └── terraform.tfvars    # The value of all variables (passwords, login, ip addresses and so on)
 
 
 General commands that we will use for running Terraform scripts

--- a/docs/automation/vyos-api.rst
+++ b/docs/automation/vyos-api.rst
@@ -554,7 +554,7 @@ Commit-confirm
 **************
 
 For the previous two endpoints discussed, a ``commit`` command is implicit
-following a succesful request operation (``set | delete | load | merge``, or
+following a successful request operation (``set | delete | load | merge``, or
 a list of ``set`` and ``delete`` operations).  One can instead request a
 ``commit-confirm`` command by including the field ``confirm_time`` of type
 int > 0. An example follows, in the alternative JSON format, for brevity,

--- a/docs/changelog/1.2.3.rst
+++ b/docs/changelog/1.2.3.rst
@@ -10,7 +10,7 @@ New features
 * :vytask:`T1524` "set service dns forwarding allow-from <IPv4 net|IPv6 net>"
   option for limiting queries to specific client networks
 * :vytask:`T1503` Functions for checking if a commit is in progress
-* :vytask:`T1543` "set system contig-mangement commit-archive source-address"
+* :vytask:`T1543` "set system contig-management commit-archive source-address"
   option
 * :vytask:`T1554` Intel NIC drivers now support receive side scaling and
   multiqueue

--- a/docs/changelog/1.2.4.rst
+++ b/docs/changelog/1.2.4.rst
@@ -15,7 +15,7 @@ Resolved issues
 * :vytask:`T1351` accel-pppoe adding CIDR based IP pool option
 * :vytask:`T1391` In route-map set community additive
 * :vytask:`T1394` syslog systemd and host_name.py race condition
-* :vytask:`T1401` Copying files with the FTP protocol fails if the passwor
+* :vytask:`T1401` Copying files with the FTP protocol fails if the password
   contains special characters
 * :vytask:`T1421` OpenVPN client push-route stopped working, needs added quotes
   to fix
@@ -63,7 +63,7 @@ Resolved issues
 * :vytask:`T1809` Wireless: SSID scan does not work in AP mode
 * :vytask:`T1811` Upgrade from 1.1.8: Config file migratio
   failed: module=l2tp
-* :vytask:`T1812` DHCP: hostnames of clients not resolving afte
+* :vytask:`T1812` DHCP: hostnames of clients not resolving after
   update v1.2.3 -> 1.2-rolling
 * :vytask:`T1819` Reboot kills SNMPv3 configuration
 * :vytask:`T1822` Priority inversion wireless interface dhcpv6
@@ -71,7 +71,7 @@ Resolved issues
 * :vytask:`T1836` import-conf-mode-commands in vyos-1x/scripts fails
   to create an xml
 * :vytask:`T1839` LLDP shows "VyOS unknown" instead of "VyOS"
-* :vytask:`T1841` PPP ipv6-up.d direcotry missing
+* :vytask:`T1841` PPP ipv6-up.d directory missing
 * :vytask:`T1893` igmp-proxy: Do not allow adding unknown interface
 * :vytask:`T1903` Implementation udev predefined interface naming
 * :vytask:`T1904` update eth1 and eth2 link files for the vep4600

--- a/docs/changelog/1.2.5.rst
+++ b/docs/changelog/1.2.5.rst
@@ -29,7 +29,7 @@ Resolved issues
 * :vytask:`T1837` PPPoE unrecognized option 'replacedefaultroute'
 * :vytask:`T1851` wireguard - changing the pubkey on an existing peer seems to
   destroy the running config.
-* :vytask:`T1858` l2tp: Delete depricated outside-nexthop and add gateway-address
+* :vytask:`T1858` l2tp: Delete deprecated outside-nexthop and add gateway-address
 * :vytask:`T1864` Lower IPSec DPD timeout lower limit from 10s -> 2s
 * :vytask:`T1879` Extend Dynamic DNS XML definition value help strings and
   validators
@@ -61,7 +61,7 @@ Resolved issues
 * :vytask:`T2077` ISO build from crux branch is failing
 * :vytask:`T2079` Update Linux Kernel to v4.19.106
 * :vytask:`T2087` Add maxfail 0 option to pppoe configuration.
-* :vytask:`T2100` BGP route adverisement wih checks rib
+* :vytask:`T2100` BGP route adverisement with checks rib
 * :vytask:`T2120` "reset vpn ipsec-peer" doesn't work with named peers
 * :vytask:`T2197` Cant add vif-s interface into a bridge
 * :vytask:`T2228` WireGuard does not allow ports < 1024 to be used

--- a/docs/changelog/1.2.6.rst
+++ b/docs/changelog/1.2.6.rst
@@ -6,7 +6,7 @@
 Resolved issues
 ---------------
 
-VyOS 1.2.6 release was found to be suspectible to CVE-2020-10995. It's a low-
+VyOS 1.2.6 release was found to be susceptible to CVE-2020-10995. It's a low-
 impact vulnerability in the PowerDNS recursor that allows an attacker to cause
 performance degradation via a specially crafted authoritative DNS server reply.
 
@@ -83,7 +83,7 @@ Resolved issues
 * :vytask:`T2482` Update PowerDNS recursor to 4.3.1 for CVE-2020-10995
 * :vytask:`T2517` vyos-container: link_filter: No such file or directory
 * :vytask:`T2526` Wake-On-Lan CLI implementation
-* :vytask:`T2528` "update dns dynamic" throws FileNotFoundError excepton
+* :vytask:`T2528` "update dns dynamic" throws FileNotFoundError exception
 * :vytask:`T2536` "show log dns forwarding" still refers to dnsmasq
 * :vytask:`T2538` Update Intel NIC drivers to recent release (preparation for
   Kernel >=5.4)

--- a/docs/changelog/1.3.rst
+++ b/docs/changelog/1.3.rst
@@ -229,7 +229,7 @@
 * :vytask:`T2051`  ``Throughput anomalies``
 * :vytask:`T2250`  ``vyos-build "make iso" error if configure was ran outside of the docker container``
 * :vytask:`T3020`  ``The "scp" example is wrong in the bash-completion for "set system config-management commit-archive location"``
-* :vytask:`T3045`  ``Changes to Conntrack-Sync don't apply correctly (Mutlicast->UDP)``
+* :vytask:`T3045`  ``Changes to Conntrack-Sync don't apply correctly (Multicast->UDP)``
 * :vytask:`T3940`  ``DHCP client does not remove IP address when stopped by the 02-vyos-stopdhclient hook``
 * :vytask:`T4146`  ``Nginx should not listen on port 80``
 * :vytask:`T4328`  ``Large MTU on 1.3.1-S1``
@@ -382,7 +382,7 @@
 * :vytask:`T2189`  ``Adding a large port-range will take ~ 20 minutes to commit``
 * :vytask:`T2516`  ``vyos-container: cannot configure ethernet interface``
 * :vytask:`T2838`  ``Ethernet device names changing, multiple hw-id being added``
-* :vytask:`T3852`  ``DHCP client issue - interface has two dhclient processes when link is unpluged and then plug again``
+* :vytask:`T3852`  ``DHCP client issue - interface has two dhclient processes when link is unplugged and then plug again``
 * :vytask:`T4117`  ``Does not possible to configure PoD/CoA for L2TP vpn``
 * :vytask:`T4153`  ``Monitor bandwidth-test initiate not working``
 * :vytask:`T4177`  ``Strip-private doesn't work for service monitoring``
@@ -590,7 +590,7 @@
 * :vytask:`T4093`  ``SNMPv3 snmpd.conf generation bug``
 * :vytask:`T4101`  ``commit-archive: Use of uninitialized value $source_address in concatenation``
 * :vytask:`T4104`  ``RAID1: "add raid md0 member sda1" does not restore boot sector``
-* :vytask:`T4110`  ``[IPV6-SSH/DNS}  enable IPv6 link local adresses as listen-address %eth0``
+* :vytask:`T4110`  ``[IPV6-SSH/DNS}  enable IPv6 link local addresses as listen-address %eth0``
 * :vytask:`T4141`  ``Set high-availability vrrp sync-group without members error``
 * :vytask:`T4142`  ``Input ifbX interfaces not displayed in op-mode``
 * :vytask:`T4152`  ``NHRP shortcut-target holding-time does not work``
@@ -608,7 +608,7 @@
 * :vytask:`T4234`  ``Show firewall partly broken in 1.3.x``
 * :vytask:`T4237`  ``Conntrack-sync error - error adding listen-address command``
 * :vytask:`T4240`  ``Cannot add wlan0 to bridge via configure``
-* :vytask:`T4241`  ``ocserv openconnect looks broken in recent bulds of 1.3 Equuleus``
+* :vytask:`T4241`  ``ocserv openconnect looks broken in recent builds of 1.3 Equuleus``
 * :vytask:`T4242`  ``ethernet speed/duplex can never be switched back to auto/auto``
 * :vytask:`T4258`  ``[DHCP-SERVER]  error parameter on Failover``
 * :vytask:`T4259`  ``The conntrackd daemon can be started wrongly``
@@ -646,7 +646,7 @@
 **New features and improvements**
 
 
-* :vytask:`T3704`  ``Add ability to interact with Areca RAID adapers``
+* :vytask:`T3704`  ``Add ability to interact with Areca RAID adapters``
 * :vytask:`T3745`  ``op-mode IPSec show vpn ipse sa sorting``
 * :vytask:`T3912`  ``Use a more informative default post-login banner``
 * :vytask:`T3945`  ``Add route-map for bgp aggregate-address``
@@ -899,7 +899,7 @@
 * :vytask:`T3786`  ``GRE tunnel source address 0.0.0.0 error``
 * :vytask:`T3788`  ``Keys are not allowed with ipip and sit tunnels``
 * :vytask:`T3790`  ``Does not possible to configure PPTP static ip-address to users``
-* :vytask:`T3792`  ``login: A hypen present in a username from "system login user" is replaced by an underscore``
+* :vytask:`T3792`  ``login: A hyphen present in a username from "system login user" is replaced by an underscore``
 * :vytask:`T3797`  ``show interface errors with vrrp configuration``
 * :vytask:`T3802`  ``Commit fails if ethernet interface doesn't support flow control``
 * :vytask:`T3805`  ``OpenVPN insufficient privileges for rtnetlink when closing TUN/TAP interface``

--- a/docs/changelog/1.4.rst
+++ b/docs/changelog/1.4.rst
@@ -24,7 +24,7 @@
 
 * :vytask:`T5878`  ``Make the list of SSH server ciphers configurable``
 * :vytask:`T5949`  ``Disable USB autosuspend``
-* :vytask:`T6320`  ``WiFi: Enable support for 6GHz AccesPoints``
+* :vytask:`T6320`  ``WiFi: Enable support for 6GHz AccessPoints``
 * :vytask:`T6423`  ``Require command definition nodes that have an owner to also have a priority``
 * :vytask:`T6424`  ``ipsec: op-mode command to generate client profiles should honor common name of the CA node that signed the server certificate``
 * :vytask:`T6454`  ``Explicitly set the default reverse proxy mode to HTTP``
@@ -60,7 +60,7 @@
 * :vytask:`T6484`  ``Smoketest fails: fastnetmon killed due to OOM``
 * :vytask:`T6503`  ``Command 'restart ssh' not working``
 * :vytask:`T6519`  ``interfaces: 20-to-21 -> migration fails if new system has less ethernet interfaces``
-* :vytask:`T6523`  ``Error: "nft table ip vyos_filter not found" when commiting prometheus-client``
+* :vytask:`T6523`  ``Error: "nft table ip vyos_filter not found" when committing prometheus-client``
 * :vytask:`T6559`  ``vyos-configd should return commit error on config dependency error``
 * :vytask:`T6584`  ``Revert addition of Linux Kernel MT7921 driver``
 * :vytask:`T6593`  ``Release DHCP interface does not work``
@@ -83,7 +83,7 @@
 * :vytask:`T6524`  ``Rewrite "release dhcp interface <interface>" to Python to drop remaining Perl dependencies``
 * :vytask:`T6592`  ``Changing VRF on interface fails``
 * :vytask:`T6594`  ``IPoE-server extended-scripts do not work``
-* :vytask:`T6597`  ``wireless: hostapd occationly gets deactivated via systemd and causes loss in connectivity``
+* :vytask:`T6597`  ``wireless: hostapd occasionally gets deactivated via systemd and causes loss in connectivity``
 * :vytask:`T6598`  ``Unexpected podman version 4.3.1``
 
 1.4.0 (4th June 2024)
@@ -98,7 +98,7 @@
 * :vytask:`T3202`  ``Enable wireguard debug messages by default``
 * :vytask:`T4022`  ``Add package nat-rtsp-dkms``
 * :vytask:`T4393`  ``sstp: add support for configuring host-name (SNI)``
-* :vytask:`T5386`  ``Execute VRRP transition script when `set high-availability disable` is commited``
+* :vytask:`T5386`  ``Execute VRRP transition script when `set high-availability disable` is committed``
 * :vytask:`T5752`  ``Check compatibility of new image tools with XCP-NG images``
 * :vytask:`T6293`  ``add Mediatek MT7921 to defconfig``
 * :vytask:`T6339`  ``Display the flavor name and build comment in "show version"``
@@ -318,7 +318,7 @@
 * :vytask:`T6073`  ``Conntrack/NAT not being disabled when VRFs are defined``
 * :vytask:`T6074`  ``container: do not allow deleting images which have a container running``
 * :vytask:`T6079`  ``dhcp: migration fails for duplicate static-mapping``
-* :vytask:`T6081`  ``QoS policy shaper target and interval wrong calcuations``
+* :vytask:`T6081`  ``QoS policy shaper target and interval wrong calculations``
 * :vytask:`T6084`  ``OpenNHRP DMVPN configuration file clean after reboot if we have any IPSec configuration``
 * :vytask:`T6086`  ``NAT does not work with network-groups``
 * :vytask:`T6093`  ``Incorrect dhcp-options vendor-class-id regex``

--- a/docs/changelog/1.5.rst
+++ b/docs/changelog/1.5.rst
@@ -73,7 +73,7 @@
 
 * :vytask:`T6168` ``(bug): add system image does not set default boot to current console type in compatibility mode``
 * :vytask:`T6243` ``(bug): Update vyos-http-api-tools for package idna security advisory``
-* :vytask:`T6154` ``(enhancment): Installer should ask for password twice``
+* :vytask:`T6154` ``(enhancement): Installer should ask for password twice``
 * :vytask:`T5966` ``(default): Adjust dynamic dns configuration address subpath to be more intuitive and other op-mode adjustments``
 * :vytask:`T5723` ``(default): mdns repeater: Always reload systemd daemon before applying changes``
 * :vytask:`T5722` ``(bug): Failing to add route in failover if gateway not in the same interface network``
@@ -166,7 +166,7 @@
 2024-04-06
 ==========
 
-* :vytask:`T6203` ``(enhancment): Remove obsoleted xml lib``
+* :vytask:`T6203` ``(enhancement): Remove obsoleted xml lib``
 * :vytask:`T6202` ``(bug): Multi-Protocol BGP is broken by 6PE patch in upstream FRR 9.1``
 
 
@@ -366,7 +366,7 @@
 2024-03-02
 ==========
 
-* :vytask:`T6081` ``(bug): QoS policy shaper target and interval wrong calcuations``
+* :vytask:`T6081` ``(bug): QoS policy shaper target and interval wrong calculations``
 
 
 2024-02-29
@@ -554,7 +554,7 @@
 
 * :vytask:`T5995` ``(bug): Kernel NIC-drivers for Huawei NICs are not properly enabled``
 * :vytask:`T5978` ``(bug): ethernet: hw-tc-offload does not actually get enabled on the NIC``
-* :vytask:`T5979` ``(enhancment): Add configurable kernel boot parameters``
+* :vytask:`T5979` ``(enhancement): Add configurable kernel boot parameters``
 * :vytask:`T5973` ``(bug): vrf: RTNETLINK answers: File exists``
 * :vytask:`T5967` ``(bug): Multi-hop BFD connections can't be established; please add minimum-ttl option.``
 * :vytask:`T5619` ``(default): Update the Intel ixgbe driver due to issues with Intel X533``
@@ -611,7 +611,7 @@
 * :vytask:`T5799` ``(bug): vyos unbootable after 1.4-rolling-202308240020 to 1.5-rolling-202312010026 upgrade``
 * :vytask:`T5787` ``(bug): dhcp-server allows duplicate static-mapping for the same IP address``
 * :vytask:`T5912` ``(bug): DHCP Static mapping don't work on every first lease``
-* :vytask:`T5692` ``(enhancment): NTP leap smear``
+* :vytask:`T5692` ``(enhancement): NTP leap smear``
 * :vytask:`T5954` ``(feature): Enable nvme_hwmon and drivetemp in KERNEL``
 
 
@@ -838,7 +838,7 @@
 ==========
 
 * :vytask:`T5823` ``(feature): Protocol BGP add default values for config dictionary``
-* :vytask:`T5798` ``(enhancment): reverse-proxy load-balancing service should support multiple certificates for frontend``
+* :vytask:`T5798` ``(enhancement): reverse-proxy load-balancing service should support multiple certificates for frontend``
 
 
 2023-12-19
@@ -889,7 +889,7 @@
 2023-12-12
 ==========
 
-* :vytask:`T5815` ``(enhancment): Add load_config module``
+* :vytask:`T5815` ``(enhancement): Add load_config module``
 
 
 2023-12-11
@@ -916,8 +916,8 @@
 2023-12-08
 ==========
 
-* :vytask:`T5782` ``(enhancment): Use a single config mode script for https and http-api``
-* :vytask:`T5768` ``(enhancment): Remove auxiliary http-api.conf for simplification of http-api config mode script``
+* :vytask:`T5782` ``(enhancement): Use a single config mode script for https and http-api``
+* :vytask:`T5768` ``(enhancement): Remove auxiliary http-api.conf for simplification of http-api config mode script``
 
 
 2023-12-04
@@ -950,7 +950,7 @@
 2023-11-25
 ==========
 
-* :vytask:`T5655` ``(bug): commit-archive: Ctrl+C should not eror out with stack trace, signal should be cought``
+* :vytask:`T5655` ``(bug): commit-archive: Ctrl+C should not error out with stack trace, signal should be cought``
 
 
 2023-11-24
@@ -1007,7 +1007,7 @@
 * :vytask:`T5677` ``(bug): show lldp neighbors generates TypeError when neighbor has no `descr```
 * :vytask:`T5728` ``(bug): Improve compatibility between OpenVPN on VyOS 1.5 and OpenVPN Connect Client``
 * :vytask:`T5732` ``(bug): generate firewall rule-resequence drops geoip country-code from output``
-* :vytask:`T5661` ``(enhancment): Add show show ssh dynamic-protection attacker and show log ssh dynamic-protection``
+* :vytask:`T5661` ``(enhancement): Add show show ssh dynamic-protection attacker and show log ssh dynamic-protection``
 
 
 2023-11-13
@@ -1225,8 +1225,8 @@
 ==========
 
 * :vytask:`T5602` ``(feature): For reverse-proxy type of load-balancing feature, support "backup" option in backends configuration``
-* :vytask:`T5609` ``(enhancment): Add util to get drive device name from id``
-* :vytask:`T5608` ``(enhancment): Rewrite add/delete raid member to Python and remove from vyatta-op``
+* :vytask:`T5609` ``(enhancement): Add util to get drive device name from id``
+* :vytask:`T5608` ``(enhancement): Rewrite add/delete raid member to Python and remove from vyatta-op``
 * :vytask:`T5607` ``(bug): Adjust RAID smoketest for non-deterministic SCSI device probing``
 
 
@@ -1253,7 +1253,7 @@
 2023-09-15
 ==========
 
-* :vytask:`T5587` ``(bug): Firwall can not pass the smoketest``
+* :vytask:`T5587` ``(bug): Firewall can not pass the smoketest``
 * :vytask:`T5581` ``(feature): Add "show ip nht" op-mode command (IPv4 nexthop tracking table)``
 
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -141,7 +141,7 @@ perform by itself at a later point.
 Examples:
 
 -  ``force arp request interface eth1 address 10.3.0.2`` — send a
-   gratuitious ARP request.
+   gratuitous ARP request.
 -  ``force root-partition-auto-resize`` — grow the root filesystem to
    the size of the system partition (this is also done on startup, but
    this command can do it without a reboot).
@@ -149,7 +149,7 @@ Examples:
 execute
 '''''''
 
-"Execute" commands are for executing various diagnostic and auxilliary
+"Execute" commands are for executing various diagnostic and auxiliary
 actions that the system would never perform by itself.
 
 Examples:

--- a/docs/configexamples/autotest/OpenVPN_with_LDAP/OpenVPN_with_LDAP.log
+++ b/docs/configexamples/autotest/OpenVPN_with_LDAP/OpenVPN_with_LDAP.log
@@ -373,7 +373,7 @@ See the timeout setting options in the Network Debug and Troubleshooting Guide.
 2023-05-11 14:39:54,941 p=69617 u=rob n=ansible | [WARNING]: To ensure idempotency and correct diff the input configuration lines should be similar to how they appear if present in the running configuration on device including the indentation
 
 2023-05-11 14:39:54,943 p=69617 u=rob n=ansible | changed: [ovpn-server]
-2023-05-11 14:39:54,954 p=69617 u=rob n=ansible | TASK [eve-ng-lab-test : generate openvpn client conifg] *************************************************************************************************************************************************************************
+2023-05-11 14:39:54,954 p=69617 u=rob n=ansible | TASK [eve-ng-lab-test : generate openvpn client config] *************************************************************************************************************************************************************************
 2023-05-11 14:39:54,977 p=69617 u=rob n=ansible | skipping: [eveng]
 2023-05-11 14:39:54,985 p=69617 u=rob n=ansible | skipping: [vyos-oobm]
 2023-05-11 14:39:54,996 p=69617 u=rob n=ansible | skipping: [client]

--- a/docs/configexamples/fwall-and-bridge.rst
+++ b/docs/configexamples/fwall-and-bridge.rst
@@ -14,7 +14,7 @@ own requirements.
 
 * Bridge br0:
    * Isolated layer 2 bridge.
-   * Accept only IPv6 communication whithin the bridge.
+   * Accept only IPv6 communication within the bridge.
 
 * Bridge br1:
    * Drop all DHCP discover packets.
@@ -46,7 +46,7 @@ First, we need to configure the interfaces and bridges:
 
 .. code-block:: none
 
-  # Brige br0
+  # Bridge br0
   set interfaces bridge br0 description 'Isolated L2 bridge'
   set interfaces bridge br0 member interface eth1
   set interfaces bridge br0 member interface eth2
@@ -217,7 +217,7 @@ And the content of the custom rulesets:
   set firewall bridge name br1-fwd rule 20 action 'accept'
   set firewall bridge name br1-fwd rule 20 source address '10.1.1.102'
   set firewall bridge name br1-fwd rule 20 state 'new'
-    # Drop everythin else within the bridge:
+    # Drop everything else within the bridge:
   set firewall bridge name br1-fwd default-action 'drop'
 
   ### br2 - br2-fwd
@@ -264,7 +264,7 @@ router itself, to other local networks, and to the Internet.
 
 As a reminder, here's a link to the :doc:`firewall documentation
 </configuration/firewall/index>`, where you can find more information about
-the packet flow for traffic that comes from bridge layer and should be analized
+the packet flow for traffic that comes from bridge layer and should be analyzed
 by the IP firewall.
 
 Access to the router itself is controlled by the base chain ``input``, and

--- a/docs/configexamples/inter-vrf-routing-vrf-lite.rst
+++ b/docs/configexamples/inter-vrf-routing-vrf-lite.rst
@@ -128,7 +128,7 @@ in our topology.
    set interface eth eth<N> address <IP ADDRESS/CIDR>
 
    # Static default route back to Core
-   set procotols static route 0.0.0.0/0 next-hop <CORE IP ADDRESS>
+   set protocols static route 0.0.0.0/0 next-hop <CORE IP ADDRESS>
 
 Core Router
 ===========
@@ -832,7 +832,7 @@ the import statement in the vrf we need to filter.
    S>* 172.16.0.0/24 [1/0] via 172.16.2.2, eth1, weight 1, 00:45:32
    C>* 172.16.2.0/30 is directly connected, eth1, 00:45:39
    B>* 192.0.2.0/24 [20/0] via 10.2.2.2, eth3 (vrf Internet), weight 1, 00:45:24
-   B>* 192.168.0.0/24 [20/0] via 192.168.3.2, eth2 (vrf Managment), weight 1, 00:45:27
+   B>* 192.168.0.0/24 [20/0] via 192.168.3.2, eth2 (vrf Management), weight 1, 00:45:27
    B>* 198.51.100.0/24 [20/0] via 10.2.2.2, eth3 (vrf Internet), weight 1, 00:45:24
 
    # show ipv6 route vrf LAN2
@@ -840,7 +840,7 @@ the import statement in the vrf we need to filter.
    C>* 2001:db8::2/127 is directly connected, eth1, 00:46:26
    B>* 2001:db8:0:1::/64 [20/0] via 2001:db8::1, eth0 (vrf LAN1), weight 1, 00:46:17
    S>* 2001:db8:0:2::/64 [1/0] via 2001:db8::3, eth1, weight 1, 00:46:21
-   B>* 2001:db8:0:3::/64 [20/0] via 2001:db8::5, eth2 (vrf Managment), weight 1, 00:46:16
+   B>* 2001:db8:0:3::/64 [20/0] via 2001:db8::5, eth2 (vrf Management), weight 1, 00:46:16
    B>* 2001:db8:1::/48 [20/0] via fe80::5200:ff:fe02:3, eth3 (vrf Internet), weight 1, 00:46:13
    B>* 2001:db8:2::/48 [20/0] via fe80::5200:ff:fe02:3, eth3 (vrf Internet), weight 1, 00:46:13
    C>* fe80::/64 is directly connected, eth1, 00:46:27

--- a/docs/configuration/firewall/bridge.rst
+++ b/docs/configuration/firewall/bridge.rst
@@ -84,7 +84,7 @@ Actions
 =======
 
 If a rule is defined, then an action must be defined for it. This tells the
-firewall what to do if all matching criterea in the rule are met.
+firewall what to do if all matching criteria in the rule are met.
 
 In firewall bridge rules, the action can be:
 
@@ -390,7 +390,7 @@ Packet Modifications
 ====================
 
 Starting from **VyOS-1.5-rolling-202410060007**, the firewall can modify
-packets before they are sent out. This feaure provides more flexibility in
+packets before they are sent out. This feature provides more flexibility in
 packet handling.
 
 .. cfgcmd:: set firewall bridge [prerouting | forward | output] filter

--- a/docs/configuration/firewall/groups.rst
+++ b/docs/configuration/firewall/groups.rst
@@ -40,7 +40,7 @@ In an **address group** a single IP address or IP address range is defined.
 Remote Groups
 ==============
 
-A **remote-group** takes an argument of a URL hosting a linebreak-deliminated
+A **remote-group** takes an argument of a URL hosting a linebreak-delimited
 list of IPv4 and/or IPv6 addresses, CIDRs and ranges. VyOS will pull this list periodicity
 according to the frequency defined in the firewall **resolver-interval** and load
 matching entries into the group for use in rules. The list will be cached in

--- a/docs/configuration/firewall/ipv4.rst
+++ b/docs/configuration/firewall/ipv4.rst
@@ -851,8 +851,8 @@ geoip) to keep database and rules updated.
 
    .. code-block:: none
 
-      set firewall ipv4 forward fitler rule 10 protocol tcp_udp
-      set firewall ipv4 forward fitler rule 11 protocol !tcp_udp
+      set firewall ipv4 forward filter rule 10 protocol tcp_udp
+      set firewall ipv4 forward filter rule 11 protocol !tcp_udp
 
 .. cfgcmd:: set firewall ipv4 forward filter rule <1-999999>
    recent count <1-255>
@@ -984,7 +984,7 @@ Packet Modifications
 ====================
 
 Starting from **VyOS-1.5-rolling-202410060007**, the firewall can modify
-packets before they are sent out. This feaure provides more flexibility in
+packets before they are sent out. This feature provides more flexibility in
 packet handling.
 
 .. cfgcmd:: set firewall ipv4 prerouting raw rule <1-999999>
@@ -1179,7 +1179,7 @@ Rule-set overview
       SUPPORT                  address_group       VyOS_MANAGEMENT-20       192.168.1.2
                                                    WAN_IN-20
       PHONE_VPN_SERVERS        address_group       WAN_IN-160               10.6.32.2
-      PINGABLE_ADRESSES        address_group       WAN_IN-170               192.168.5.2
+      PINGABLE_ADDRESSES        address_group       WAN_IN-170               192.168.5.2
                                                    WAN_IN-171
       PBX                      ipv6_address_group  IPV6-WAN_IN-100          2001:db8::1
       SERVERS                  ipv6_address_group  IPV6-WAN_IN-110          2001:db8::2

--- a/docs/configuration/firewall/ipv6.rst
+++ b/docs/configuration/firewall/ipv6.rst
@@ -974,7 +974,7 @@ Packet Modifications
 ====================
 
 Starting from **VyOS-1.5-rolling-202410060007**, the firewall can modify
-packets before they are sent out. This feaure provides more flexibility in
+packets before they are sent out. This feature provides more flexibility in
 packet handling.
 
 .. cfgcmd:: set firewall ipv6 prerouting raw rule <1-999999>
@@ -1178,7 +1178,7 @@ Rule-set overview
       SUPPORT                  address_group       VyOS_MANAGEMENT-20       192.168.1.2
                                                    WAN_IN-20
       PHONE_VPN_SERVERS        address_group       WAN_IN-160               10.6.32.2
-      PINGABLE_ADRESSES        address_group       WAN_IN-170               192.168.5.2
+      PINGABLE_ADDRESSES        address_group       WAN_IN-170               192.168.5.2
                                                    WAN_IN-171
       PBX                      ipv6_address_group  IPV6-WAN_IN-100          2001:db8::1
       SERVERS                  ipv6_address_group  IPV6-WAN_IN-110          2001:db8::2

--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -2,7 +2,7 @@
 Configuration Guide
 ###################
 
-The following structure respresent the cli structure.
+The following structure represent the cli structure.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/configuration/loadbalancing/wan.rst
+++ b/docs/configuration/loadbalancing/wan.rst
@@ -28,7 +28,7 @@ Let's assume we have two DHCP WAN interfaces and one LAN (eth2):
 
 .. note::
 
-    WAN Load Balacing should not be used when dynamic routing protocol is
+    WAN Load Balancing should not be used when dynamic routing protocol is
     used/needed. This feature creates customized routing tables and firewall
     rules, that makes it incompatible to use with routing protocols.
 

--- a/docs/configuration/nat/nat44.rst
+++ b/docs/configuration/nat/nat44.rst
@@ -654,7 +654,7 @@ Load Balance
 ------------
 Here we provide two examples on how to apply NAT Load Balance.
 
-First scenario: apply destination NAT for all HTTP traffic comming through
+First scenario: apply destination NAT for all HTTP traffic coming through
 interface eth0, and user 4 backends. First backend should received 30% of
 the request, second backend should get 20%, third 15% and the fourth 35%
 We will use source and destination address for hash generation.

--- a/docs/configuration/policy/examples.rst
+++ b/docs/configuration/policy/examples.rst
@@ -158,8 +158,8 @@ ISP's and VyOS router will respond from the same interface that the packet was
 received. Also, it used, if we want that one VPN tunnel to be through one
 provider, and the second through another.
 
-* ``203.0.113.254`` IP addreess on VyOS eth1 from ISP1
-* ``192.168.2.254`` IP addreess on VyOS eth2 from ISP2
+* ``203.0.113.254`` IP address on VyOS eth1 from ISP1
+* ``192.168.2.254`` IP address on VyOS eth2 from ISP2
 * ``table 10`` Routing table used for ISP1
 * ``table 11`` Routing table used for ISP2
 

--- a/docs/configuration/policy/route-map.rst
+++ b/docs/configuration/policy/route-map.rst
@@ -2,7 +2,7 @@
 Route Map Policy
 ################
 
-Route map is a powerfull command, that gives network administrators a very
+Route map is a powerful command, that gives network administrators a very
 useful and flexible tool for traffic manipulation.
 
 *************

--- a/docs/configuration/policy/route.rst
+++ b/docs/configuration/policy/route.rst
@@ -168,7 +168,7 @@ And for ipv6:
 .. cfgcmd:: set policy route <name> rule <n> limit burst <0-4294967295>
 .. cfgcmd:: set policy route6 <name> rule <n> limit burst <0-4294967295>
 
-   Set maximum number of packets to alow in excess of rate.
+   Set maximum number of packets to allow in excess of rate.
 
 .. cfgcmd:: set policy route <name> rule <n> limit rate <text>
 .. cfgcmd:: set policy route6 <name> rule <n> limit rate <text>
@@ -256,8 +256,8 @@ And for ipv6:
 Actions
 =======
 
-When mathcing all patterns defined in a rule, then different actions can
-be made. This includes droping the packet, modifying certain data, or
+When matching all patterns defined in a rule, then different actions can
+be made. This includes dropping the packet, modifying certain data, or
 setting a different routing table.
 
 .. cfgcmd:: set policy route <name> rule <n> action drop

--- a/docs/configuration/protocols/bfd.rst
+++ b/docs/configuration/protocols/bfd.rst
@@ -159,7 +159,7 @@ Configuration
    bfd multi-hop source <address> profile <profile>
    
    Configure a static route for <subnet> using gateway <address> 
-   , use source address to indentify the peer when is multi-hop session 
+   , use source address to identify the peer when is multi-hop session
    and the gateway address as BFD peer destination address.
 
 .. cfgcmd::  set protocols static route6 <subnet> next-hop <address> 
@@ -172,7 +172,7 @@ Configuration
    bfd multi-hop source <address> profile <profile>
    
    Configure a static route for <subnet> using gateway <address> 
-   , use source address to indentify the peer when is multi-hop session 
+   , use source address to identify the peer when is multi-hop session
    and the gateway address as BFD peer destination address.
 
 

--- a/docs/configuration/protocols/bgp.rst
+++ b/docs/configuration/protocols/bgp.rst
@@ -335,7 +335,7 @@ Peer Parameters
    but you can’t connect them directly.
 
    The number parameter (1-10) configures the amount of accepted
-   occurences of the system AS number in AS path.
+   occurrences of the system AS number in AS path.
 
    This command is only allowed for eBGP peers. It is not applicable
    for peer groups.

--- a/docs/configuration/protocols/segment-routing.rst
+++ b/docs/configuration/protocols/segment-routing.rst
@@ -90,7 +90,7 @@ devices, below configuration shows how to enable SR on IS-IS:
    
   A segment ID that contains an IP address prefix calculated by an IGP in the
   service provider core network. Prefix SIDs are globally unique, this value
-  indentify it 
+  identify it
 
 .. cfgcmd:: set protocols isis segment-routing prefix <address> index
    <no-php-flag | explicit-null| n-flag-clear>
@@ -168,7 +168,7 @@ devices, below configuration shows how to enable SR on OSPF:
    
   A segment ID that contains an IP address prefix calculated by an IGP in the
   service provider core network. Prefix SIDs are globally unique, this value
-  indentify it 
+  identify it
 
 .. cfgcmd:: set protocols ospf segment-routing prefix <address> index
    <no-php-flag | explicit-null| n-flag-clear>

--- a/docs/configuration/service/conntrack-sync.rst
+++ b/docs/configuration/service/conntrack-sync.rst
@@ -29,7 +29,7 @@ will be mandatorily defragmented.
 
 It is possible to use either Multicast or Unicast to sync conntrack traffic.
 Most examples below show Multicast, but unicast can be specified by using the
-"peer" keywork after the specified interface, as in the following example:
+"peer" keyword after the specified interface, as in the following example:
 
 :cfgcmd:`set service conntrack-sync interface eth0 peer 192.168.0.250`
 
@@ -86,7 +86,7 @@ Configuration
 
 .. cfgcmd:: set service conntrack-sync interface <name> peer <address>
 
-    Peer to send unicast UDP conntrack sync entires to, if not using Multicast
+    Peer to send unicast UDP conntrack sync entries to, if not using Multicast
     configuration from above above.
 
 .. cfgcmd:: set service conntrack-sync sync-queue-size <size>
@@ -95,7 +95,7 @@ Configuration
 
 .. cfgcmd:: set service conntrack-sync disable-external-cache
 
-   This diable the external cache and directly injects the flow-states into the
+   This disable the external cache and directly injects the flow-states into the
    in-kernel Connection Tracking System of the backup firewall.
 
 .. cfgcmd:: set service conntrack-sync disable-syslog

--- a/docs/configuration/service/console-server.rst
+++ b/docs/configuration/service/console-server.rst
@@ -66,7 +66,7 @@ port.
 .. cfgcmd:: set service console-server device <device> ssh port <port>
 
   Accept SSH connections for the given `<device>` on TCP port `<port>`.
-  After successfull authentication the user will be directly dropped to
+  After successful authentication the user will be directly dropped to
   the connected serial device.
 
   .. hint:: Multiple users can connect to the same serial device but only

--- a/docs/configuration/service/dhcp-server.rst
+++ b/docs/configuration/service/dhcp-server.rst
@@ -191,7 +191,7 @@ level, i.e. for individual shared networks or subnets. See examples below.
 
    If set to ``enable`` on global level, updates for all scopes will be enabled,
    except if explicitly set to ``disable`` on the scope level. If set to ``disable``,
-   updates will only be sent for scopes, where ``send-updates`` is explicity
+   updates will only be sent for scopes, where ``send-updates`` is explicitly
    set to ``enable``.
 
    This model is followed for a few behavioral settings below: if the option is
@@ -519,7 +519,7 @@ NB: Kea (the DHCP server used by VyOS) is programmed to offer as many
 alternatives as it can to repeated DHCP Discover requests. Some operating
 systems (Notably Microsoft Windows) make multiple DHCP Discover requests before
 settling on an address. This particularly seems to happen when the DHCP server
-isn't set to authorative. This may explain why the address you espect isn't
+isn't set to authoritative. This may explain why the address you espect isn't
 being chosen. Wireshark is helpful in these situations.
 
 **Example:**
@@ -913,13 +913,13 @@ used:
 
 
 .. cfgcmd:: set service dhcpv6-server shared-network-name <name> subnet
-   <prefix> prefix-delegation prefix <pd-prefix> prefix-length <lenght>
+   <prefix> prefix-delegation prefix <pd-prefix> prefix-length <length>
 
    Delegate prefixes from `<pd-prefix>` to clients in subnet `<prefix>`. Range
-   is defined by `<lenght>` in bits, 32 to 64.
+   is defined by `<length>` in bits, 32 to 64.
 
 .. cfgcmd:: set service dhcpv6-server shared-network-name <name> subnet
-   <prefix> prefix-delegation prefix <pd-prefix> delegated-length <lenght>
+   <prefix> prefix-delegation prefix <pd-prefix> delegated-length <length>
 
    Hand out prefixes of size `<length>` in bits from `<pd-prefix>` to clients
    in subnet `<prefix>` when the request for prefix delegation.
@@ -933,7 +933,7 @@ used:
 .. cfgcmd:: set service dhcpv6-server shared-network-name <name> subnet
    <prefix> prefix-delegation prefix <pd-prefix> excluded-prefix-length <length>
 
-   Define lenght of exclude prefix in `<pd-prefix>`.
+   Define length of exclude prefix in `<pd-prefix>`.
 
 **Example:**
 

--- a/docs/configuration/service/eventhandler.rst
+++ b/docs/configuration/service/eventhandler.rst
@@ -75,7 +75,7 @@ Event Handler Configuration Steps
 
     This is an optional command. Adds arguments to the script. Arguments must be separated by spaces.
 
-    .. note:: We don't recomend to use arguments. Using environments is more preffereble.
+    .. note:: We don't recommend using arguments. Using environments is more preferable.
     
 
 *******

--- a/docs/configuration/service/ipoe-server.rst
+++ b/docs/configuration/service/ipoe-server.rst
@@ -148,7 +148,7 @@ to a single source IP e.g. the loopback interface.
 
 .. cfgcmd:: set service ipoe-server authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. note:: The ``source-address`` must be configured on one of VyOS interface.
    Best practice would be a loopback or dummy interface.
@@ -205,7 +205,7 @@ RADIUS advanced options
 
 .. cfgcmd:: set service ipoe-server authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. cfgcmd:: set service ipoe-server authentication radius rate-limit attribute <attribute>
 
@@ -241,7 +241,7 @@ If the RADIUS server sends the attribute ``Stateful-IPv6-Address-Pool``, IPv6 ad
 will be allocated from a predefined IPv6 pool ``prefix`` whose name equals the attribute value.
 
 If the RADIUS server sends the attribute ``Delegated-IPv6-Prefix-Pool``, IPv6
-delegation pefix will be allocated from a predefined IPv6 pool ``delegate``
+delegation prefix will be allocated from a predefined IPv6 pool ``delegate``
 whose name equals the attribute value.
 
 .. note:: ``Stateful-IPv6-Address-Pool`` and ``Delegated-IPv6-Prefix-Pool`` are defined in
@@ -258,7 +258,7 @@ IPv6
 .. cfgcmd:: set service ipoe-server client-ipv6-pool <IPv6-POOL-NAME> prefix <address>
    mask <number-of-bits>
 
-  Use this comand to set the IPv6 address pool from which an IPoE client
+  Use this command to set the IPv6 address pool from which an IPoE client
   will get an IPv6 prefix of your defined length (mask) to terminate the
   IPoE endpoint at their side. The mask length can be set from 48 to 128
   bit long, the default value is 64.
@@ -429,7 +429,7 @@ Monitoring
       delayed: 0
 
 **************
-Toubleshooting
+Troubleshooting
 **************
 
 .. code-block:: none

--- a/docs/configuration/service/monitoring.rst
+++ b/docs/configuration/service/monitoring.rst
@@ -81,7 +81,7 @@ for Prometheus native metrics through exporters see section below.
 
 .. cfgcmd:: set service monitoring telegraf prometheus-client metric-version <1 | 2>
 
-   Metris version, the default is ``2``
+   Metrics version, the default is ``2``
 
 .. cfgcmd:: set service monitoring telegraf prometheus-client port <port>
 

--- a/docs/configuration/service/pppoe-server.rst
+++ b/docs/configuration/service/pppoe-server.rst
@@ -113,7 +113,7 @@ to a single source IP e.g. the loopback interface.
 .. cfgcmd:: set service pppoe-server authentication radius
    source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. note:: The ``source-address`` must be configured on one of VyOS interface.
    Best practice would be a loopback or dummy interface.
@@ -182,7 +182,7 @@ RADIUS advanced options
 .. cfgcmd:: set service pppoe-server authentication radius
    source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. cfgcmd:: set service pppoe-server authentication radius
    rate-limit attribute <attribute>
@@ -222,7 +222,7 @@ IPv6 address will be allocated from a predefined IPv6 pool ``prefix``
 whose name equals the attribute value.
 
 If the RADIUS server sends the attribute ``Delegated-IPv6-Prefix-Pool``,
-IPv6 delegation pefix will be allocated from a predefined IPv6 pool ``delegate``
+IPv6 delegation prefix will be allocated from a predefined IPv6 pool ``delegate``
 whose name equals the attribute value.
 
 .. note:: ``Stateful-IPv6-Address-Pool`` and ``Delegated-IPv6-Prefix-Pool``
@@ -373,7 +373,7 @@ IPv6
 .. cfgcmd:: set service pppoe-server client-ipv6-pool <IPv6-POOL-NAME>
    prefix <address> mask <number-of-bits>
 
-  Use this comand to set the IPv6 address pool from which an PPPoE client
+  Use this command to set the IPv6 address pool from which an PPPoE client
   will get an IPv6 prefix of your defined length (mask) to terminate the
   PPPoE endpoint at their side. The mask length can be set from 48 to 128
   bit long, the default value is 64.

--- a/docs/configuration/service/salt-minion.rst
+++ b/docs/configuration/service/salt-minion.rst
@@ -45,7 +45,7 @@ Configuration
     URL with signature of master for auth reply verification
 
 
-Please take a look in the Automation section to find some usefull
+Please take a look in the Automation section to find some useful
 Examples.
 
 

--- a/docs/configuration/system/conntrack.rst
+++ b/docs/configuration/system/conntrack.rst
@@ -43,7 +43,7 @@ Configure
     Configure the connection tracking protocol helper modules.
     All modules are enable by default.
 
-    | Use `delete system conntrack modules` to deactive all modules.
+    | Use `delete system conntrack modules` to deactivate all modules.
     | Or, for example ftp, `delete system conntrack modules ftp`.
 
 .. cfgcmd:: set system conntrack tcp half-open-connections <1-21474836>

--- a/docs/configuration/system/frr.rst
+++ b/docs/configuration/system/frr.rst
@@ -12,7 +12,7 @@ but requires either a restart of the routing daemon, or a reboot of the system.
 
    Enable :abbr:`BMP (BGP Monitoring Protocol)` support.
 
-.. cfgcmd:: set system frr descriptors <numer>
+.. cfgcmd:: set system frr descriptors <number>
 
    This allows the operator to control the number of open file descriptors
    each daemon is allowed to start with. If the operator plans to run bgp with

--- a/docs/configuration/system/option.rst
+++ b/docs/configuration/system/option.rst
@@ -142,7 +142,7 @@ the used keyboard layout on the system console.
 Performance
 ***********
 
-As more and more routers run on Hypervisors, expecially with a :abbr:`NOS
+As more and more routers run on Hypervisors, especially with a :abbr:`NOS
 (Network Operating System)` as VyOS, it makes fewer and fewer sense to use
 static resource bindings like ``smp-affinity`` as present in VyOS 1.2 and
 earlier to pin certain interrupt handlers to specific CPUs.

--- a/docs/configuration/system/proxy.rst
+++ b/docs/configuration/system/proxy.rst
@@ -19,10 +19,10 @@ using the :opcmd:`add system image` command (:ref:`update_vyos`).
 
 .. cfgcmd:: set system proxy username <username>
 
-   Some proxys require/support the "basic" HTTP authentication scheme as per
+   Some proxies require/support the "basic" HTTP authentication scheme as per
    :rfc:`7617`, thus a username can be configured.
 
 .. cfgcmd:: set system proxy password <password>
 
-   Some proxys require/support the "basic" HTTP authentication scheme as per
+   Some proxies require/support the "basic" HTTP authentication scheme as per
    :rfc:`7617`, thus a password can be configured.

--- a/docs/configuration/trafficpolicy/index.rst
+++ b/docs/configuration/trafficpolicy/index.rst
@@ -1104,7 +1104,7 @@ the higher the priority.
    <bytes>
 
    Use this command to configure a Shaper policy, set its name, define
-   a class and set the size of the `tocken bucket`_ in bytes, which will
+   a class and set the size of the `token bucket`_ in bytes, which will
    be available to be sent at ceiling speed (default: 15Kb).
 
 .. cfgcmd:: set qos policy shaper <policy-name> class <class-ID> ceiling
@@ -1335,7 +1335,7 @@ That is how it is possible to do the so-called "ingress shaping".
 
 .. _that can give you a great deal of flexibility: https://blog.vyos.io/using-the-policy-route-and-packet-marking-for-custom-qos-matches
 .. _tc: https://en.wikipedia.org/wiki/Tc_(Linux)
-.. _tocken bucket: https://en.wikipedia.org/wiki/Token_bucket
+.. _token bucket: https://en.wikipedia.org/wiki/Token_bucket
 .. _HFSC: https://en.wikipedia.org/wiki/Hierarchical_fair-service_curve
 .. _Intermediate Functional Block: https://www.linuxfoundation.org/collaborate/workgroups/networking/ifb
 .. _Common Applications Kept Enhanced: https://www.bufferbloat.net/projects/codel/wiki/Cake/

--- a/docs/configuration/vpn/ipsec/ipsec_general.rst
+++ b/docs/configuration/vpn/ipsec/ipsec_general.rst
@@ -118,7 +118,7 @@ available. The use of PPKs in IKEv2 is described in :rfc:`8784`.
 
 .. cfgmod:: edit vpn authentication ppk <name>
 
-PPKs can be configued within VyOS under the `vpn ipsec authentication ppk`
+PPKs can be configured within VyOS under the `vpn ipsec authentication ppk`
 config.
 
 .. cfgmod:: set vpn authentication ppk <name> secret-type <plaintext|hex|base64>
@@ -143,7 +143,7 @@ You can view the PPK column for information on if PPK is configured, and
 if it is in use. The output is in the format of ``<configured> / <in use>``. 
 The options for configured are none if not conifugred, opt if configured 
 but optional, and req is configured and required. The in use will show yes 
-Possible values of the ``configured`` field are ``none`` if not conifgured, ``opt`` if configured 
+Possible values of the ``configured`` field are ``none`` if not configured, ``opt`` if configured
 but optional, and ``req`` is configured and required. The in use will show yes 
 
 

--- a/docs/configuration/vpn/l2tp.rst
+++ b/docs/configuration/vpn/l2tp.rst
@@ -154,7 +154,7 @@ e.g. the loopback interface.
 
 .. cfgcmd:: set vpn l2tp remote-access authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. note:: The ``source-address`` must be configured to that of an interface.
    Best practice would be a loopback or dummy interface.
@@ -211,7 +211,7 @@ RADIUS advanced options
 
 .. cfgcmd:: set vpn l2tp remote-access authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. cfgcmd:: set vpn l2tp remote-access authentication radius rate-limit attribute <attribute>
 
@@ -300,7 +300,7 @@ IPv6
 .. cfgcmd:: set vpn l2tp remote-access client-ipv6-pool <IPv6-POOL-NAME> prefix <address>
    mask <number-of-bits>
 
-  Use this comand to set the IPv6 address pool from which an l2tp client will
+  Use this command to set the IPv6 address pool from which an l2tp client will
   get an IPv6 prefix of your defined length (mask) to terminate the l2tp 
   endpoint at their side. The mask length can be set between 48 and 128 bits
   long, the default value is 64.

--- a/docs/configuration/vpn/openconnect.rst
+++ b/docs/configuration/vpn/openconnect.rst
@@ -151,7 +151,7 @@ Follow the instructions to generate server cert (in configuration mode):
   2 value(s) installed. Use "compare" to see the pending changes, and "commit" to apply.
   [edit]
 
-Each of the install command should be applied to the configuration and commited
+Each of the install command should be applied to the configuration and committed
 before using under the openconnect configuration:
 
 .. code-block:: none

--- a/docs/configuration/vpn/pptp.rst
+++ b/docs/configuration/vpn/pptp.rst
@@ -94,7 +94,7 @@ to a single source IP e.g. the loopback interface.
 
 .. cfgcmd:: set vpn pptp remote-access authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. note:: The ``source-address`` must be configured on one of VyOS interface.
    Best practice would be a loopback or dummy interface.
@@ -151,7 +151,7 @@ RADIUS advanced options
 
 .. cfgcmd:: set vpn pptp remote-access authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. cfgcmd:: set vpn pptp remote-access authentication radius rate-limit attribute <attribute>
 
@@ -187,7 +187,7 @@ If the RADIUS server sends the attribute ``Stateful-IPv6-Address-Pool``, IPv6 ad
 will be allocated from a predefined IPv6 pool ``prefix`` whose name equals the attribute value.
 
 If the RADIUS server sends the attribute ``Delegated-IPv6-Prefix-Pool``, IPv6
-delegation pefix will be allocated from a predefined IPv6 pool ``delegate``
+delegation prefix will be allocated from a predefined IPv6 pool ``delegate``
 whose name equals the attribute value.
 
 .. note:: ``Stateful-IPv6-Address-Pool`` and ``Delegated-IPv6-Prefix-Pool`` are defined in
@@ -221,7 +221,7 @@ IPv6
 .. cfgcmd:: set vpn pptp remote-access client-ipv6-pool <IPv6-POOL-NAME> prefix <address>
    mask <number-of-bits>
 
-  Use this comand to set the IPv6 address pool from which an PPTP client
+  Use this command to set the IPv6 address pool from which an PPTP client
   will get an IPv6 prefix of your defined length (mask) to terminate the
   PPTP endpoint at their side. The mask length can be set from 48 to 128
   bit long, the default value is 64.

--- a/docs/configuration/vpn/rsa-keys.rst
+++ b/docs/configuration/vpn/rsa-keys.rst
@@ -7,7 +7,7 @@ To make IPSec work with dynamic address on one/both sides, we will have to use
 RSA keys for authentication. They are very fast and easy to setup.
 
 First, on both routers run the operational command "generate pki key-pair 
-install <key-pair nam>>". You may choose different length than 2048 of course.
+install <key-pair name>". You may choose different length than 2048 of course.
 
 .. code-block:: none
 

--- a/docs/configuration/vpn/sstp.rst
+++ b/docs/configuration/vpn/sstp.rst
@@ -127,7 +127,7 @@ e.g. the loopback interface.
 
 .. cfgcmd:: set vpn sstp authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. note:: The ``source-address`` must be configured to that of an interface.
    Best practice would be a loopback or dummy interface.
@@ -184,7 +184,7 @@ RADIUS advanced options
 
 .. cfgcmd:: set vpn sstp authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. cfgcmd:: set vpn sstp authentication radius rate-limit attribute <attribute>
 
@@ -258,7 +258,7 @@ IPv6
 .. cfgcmd:: set vpn sstp client-ipv6-pool <IPv6-POOL-NAME> prefix <address>
    mask <number-of-bits>
 
-  Use this comand to set the IPv6 address pool from which an SSTP client will
+  Use this command to set the IPv6 address pool from which an SSTP client will
   get an IPv6 prefix of your defined length (mask) to terminate the SSTP
   endpoint at their side. The mask length can be set between 48 and 128 bits
   long, the default value is 64.
@@ -513,7 +513,7 @@ The following PPP configuration tests MSCHAP-v2:
   debug
 
 
-You can now "dial" the peer with the follwoing command: ``sstpc --log-level 4
+You can now "dial" the peer with the following command: ``sstpc --log-level 4
 --log-stderr --user vyos --password vyos vpn.example.com -- call vyos``.
 
 A connection attempt will be shown as:

--- a/docs/configuration/vrf/index.rst
+++ b/docs/configuration/vrf/index.rst
@@ -450,7 +450,7 @@ BGP routes may be leaked (i.e. copied) between a unicast VRF RIB and the VPN
 SAFI RIB of the default VRF for use in MPLS-based L3VPNs. Unicast routes may
 also be leaked between any VRFs (including the unicast RIB of the default BGP
 instance). A shortcut syntax is also available for specifying leaking from
-one VRF to another VRF using the default instance’s VPN RIB as the intemediary
+one VRF to another VRF using the default instance’s VPN RIB as the intermediary
 . A common application of the VRF-VRF feature is to connect a customer’s
 private routing domain to a provider’s VPN service. Leaking is configured from
 the point of view of an individual VRF: import refers to routes leaked from VPN

--- a/docs/installation/bare-metal.rst
+++ b/docs/installation/bare-metal.rst
@@ -416,7 +416,7 @@ Cooling
 
 The device itself is passivly cooled, whereas the power supply has an active fan.
 Even if the main processor is powered off, the power supply fan is operating and
-the entire chassis draws 7.5W. During operation the chassis drew arround 38W.
+the entire chassis draws 7.5W. During operation the chassis drew around 38W.
 
 BIOS Settings
 -------------


### PR DESCRIPTION
Majority of these were identified with the [typos-cli][], but with manual review and editing due to lots of false positives.

Adding the tool to CI after tuning out common false positives might be a good idea to help prevent new typos from slipping in.

I'm not sure if you want the release notes edited, or if those should be frozen in time. An advantage to editing them is it makes searching (e.g. CTRL + F) easier if the words are spelled correctly.

[typos-cli]: https://github.com/crate-ci/typos

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Fix typos and minor grammar issues in documentation


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document