### PR TITLE
Update examples.rst

### DIFF
--- a/docs/configuration/policy/examples.rst
+++ b/docs/configuration/policy/examples.rst
@@ -167,9 +167,9 @@ provider, and the second through another.
 .. code-block:: none
 
   set policy local-route rule 101 set table '10'
-  set policy local-route rule 101 source '203.0.113.254'
+  set policy local-route rule 101 source address '203.0.113.254'
   set policy local-route rule 102 set table '11'
-  set policy local-route rule 102 source '192.0.2.254'
+  set policy local-route rule 102 source address '192.0.2.254'
   set protocols static table 10 route 0.0.0.0/0 next-hop '203.0.113.1'
   set protocols static table 11 route 0.0.0.0/0 next-hop '192.0.2.2'
 
@@ -178,9 +178,9 @@ Add multiple source IP in one rule with same priority
 .. code-block:: none
 
   set policy local-route rule 101 set table '10'
-  set policy local-route rule 101 source '203.0.113.254'
-  set policy local-route rule 101 source '203.0.113.253'
-  set policy local-route rule 101 source '198.51.100.0/24'
+  set policy local-route rule 101 source address '203.0.113.254'
+  set policy local-route rule 101 source address '203.0.113.253'
+  set policy local-route rule 101 source address '198.51.100.0/24'
 
 ###########################
 Clamp MSS for a specific IP


### PR DESCRIPTION
Examples using `set policy local-route rule 101 source '203.0.113.254'` should include the `address` statement. 

Tested on: VyOS 1.4.4

This is again the result of VyOS devs merging without updating the documentation: https://github.com/vyos/vyos-1x/pull/2342 :(

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T5165

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document