### PR TITLE
console: T8375: document "set system console device <device> kernel" command

### DIFF
--- a/docs/configuration/system/console.rst
+++ b/docs/configuration/system/console.rst
@@ -22,8 +22,19 @@ Major upgrades to the installed distribution may also require console access.
    can be (see completion helper):
 
    * ``ttySN`` - Serial device name
+   * ``ttyAMAN``- Serial device name for some arm64 systems
    * ``ttyUSBX`` - USB Serial device name
    * ``hvc0`` - Xen console
+
+.. cfgcmd:: set system console device <device> kernel
+
+   When set, the selected serial console is used as the kernel boot console.
+   When removed, the kernel boot console falls back to tty0.
+
+   .. note:: Only one serial console can carry the ``kernel`` option.
+     When VyOS is installed via serial console, this option is set automatically
+     for the serial interface used during installation; usually ``ttyS0`` or
+     ``ttyAMA0``.
 
 .. cfgcmd:: set system console device <device> speed <speed>
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

When set, the selected serial console is used as the kernel boot console.
When removed, the kernel boot console falls back to `tty0`.

Only one serial console can carry the `kernel` option. When VyOS is installed via serial console, this option is set automatically for the serial interface used during installation; usually `ttyS0` or `ttyAMA0`.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T8375

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

* https://github.com/vyos/vyos-build/pull/1152
* https://github.com/vyos/vyos-build/pull/1155
* https://github.com/vyos/vyos-1x/pull/5092

## Backport
<!-- optional: the PR should backport to this documentation branch -->

@MergifyIo backport circinus


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document