### PR TITLE
remote: T4732: add VRF option for commit-archive

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1000,6 +1000,11 @@ be ``config.boot-hostname.YYYYMMDD_HHMMSS``.
 
     vyos@vyos# ssh-keyscan <host> >> ~/.ssh/known_hosts
 
+.. cfgcmd:: set system config-management commit-archive vrf <name>
+
+  Specify name of the :abbr:`VRF (Virtual Routing and Forwarding)` instance
+  used to upload the configuration to the remote system.
+
 Saving and loading manually
 ---------------------------
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add new CLI option to make transfers to the commit-archive working using a dedicated (e.g. management) VRF.

`set system config-management commit-archive vrf MGMT`

All transfers using vyos.remote module will now run through the VRF defined on the CLI.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T4732

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
* https://github.com/vyos/vyos-1x/pull/5115

## Backport
<!-- optional: the PR should backport to this documentation branch -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document