### PR TITLE
docs: reformat wireless.rst for readability

### DIFF
--- a/docs/configuration/interfaces/wireless.rst
+++ b/docs/configuration/interfaces/wireless.rst
@@ -1,31 +1,29 @@
-:lastproofread: 2026-03-23
+:lastproofread: 2024-07-04
 
 .. _wireless-interface:
 
 ########################
-Wireless LAN / Wi-Fi
+WLAN/WIFI - Wireless LAN
 ########################
 
-:abbr:`WLAN (Wireless LAN)` interfaces provide 802.11 (a/b/g/n/ac) wireless 
-connectivity, referred to as Wi-Fi, and operate in one of the following modes:
+The :abbr:`WLAN (Wireless LAN)` interface provides 802.11 (a/b/g/n/ac) wireless
+support (commonly referred to as Wi-Fi) by means of compatible hardware. If
+your hardware supports it, VyOS supports multiple logical wireless interfaces
+per physical device.
 
-* ``access-point``: Provide network access to connecting stations.
+There are three modes of operation for a wireless interface:
 
-* ``station:`` Operate as Wi-Fi clients, connecting to the network via an 
-  available :abbr:`AP (Access Point)`.
+* :abbr:`WAP (Wireless Access-Point)` mode provides network access to connecting
+  stations if the physical hardware supports acting as a WAP
 
-* ``monitor:`` Passively monitor wireless traffic.
+* Station mode acts as a Wi-Fi client accessing the network through an available
+  WAP
 
-If the system detects an unconfigured wireless device, it automatically adds 
-the device to the configuration tree with the detected settings, such as the 
-MAC address, and sets it to ``monitor`` mode.
+* Monitor mode lets the system passively monitor wireless traffic
 
-.. note:: VyOS supports creating **multiple** WLAN interfaces on a single 
-   physical device. 
-
-.. note:: Wi-Fi connectivity, support for multiple WLAN interfaces on a single 
-   physical device, and access point capabilities strictly depend on the 
-   underlying hardware.
+If the system detects an unconfigured wireless device, it will be automatically
+added to the configuration tree, specifying any detected settings (for example,
+its MAC address) and configured to run in monitor mode.
 
 *************
 Configuration
@@ -38,122 +36,110 @@ Common interface configuration
    :var0: wireless
    :var1: wlan0
 
-System-wide configuration
+System Wide configuration
 =========================
 
 .. cfgcmd:: set system wireless country-code <cc>
 
-  **Configure the system's ISO/IEC 3166-1 country code.**
+  Country code (ISO/IEC 3166-1). Used to set regulatory domain. Set as needed
+  to indicate country in which device is operating. This can limit available
+  channels and transmit power.
 
-  The country code indicates the region in which the device operates. This may 
-  restrict available channels and transmit power.
-
-  .. note:: This option is mandatory in ``access-point`` mode.
+  .. note:: This option is mandatory in Access-Point mode.
 
 Wireless options
 ================
 
 .. cfgcmd:: set interfaces wireless <interface> channel <number>
 
-  **Configure the IEEE 802.11 wireless radio channel for the interface.** 
-
-  Channel allocation depends on the frequency band:
-
-  * **2.4 GHz** (802.11b/g/n/ax): Channels range from 1 to 14.
-  * **5 GHz** (802.11a/h/j/n/ac/ax): Channels range from 34 to 177.
-  * **6 GHz** (802.11ax): Channels range from 1 to 233.
-  * **Automatic channel selection:** 0.
+  Channel number (IEEE 802.11), for 2.4 GHz (802.11 b/g/n/ax) channels
+  range from 1-14. On 5 GHz (802.11 a/h/j/n/ac) channels available are
+  0, 34 to 177. 
+  On 6GHz (802.11 ax) channels range from 1 to 233.
 
 .. cfgcmd:: set interfaces wireless <interface> disable-broadcast-ssid
 
-  **Configure the interface to broadcast an empty SSID in beacons and to ignore 
-  probe requests that do not include the full SSID.** 
-
-  This requires client stations to be configured with the correct SSID to connect.
+  Send empty SSID in beacons and ignore probe request frames that do not specify
+  full SSID, i.e., require stations to know the SSID.
 
 .. cfgcmd:: set interfaces wireless <interface> expunge-failing-stations
 
-  **Configure the interface to disconnect client stations upon excessive 
-  transmission failures or connection loss.**
+  Disassociate stations based on excessive transmission failures or other
+  indications of connection loss.
 
-  This feature depends on driver capabilities and may not work with some drivers.
+  This depends on the driver capabilities and may not be available with all
+  drivers.
 
 .. cfgcmd:: set interfaces wireless <interface> isolate-stations
 
-  **Enable client isolation on the interface.**
-
-  This prevents low-level frame bridging between associated stations within the 
-  BSS. 
+  Client isolation can be used to prevent low-level bridging of frames between
+  associated stations in the BSS.
 
   By default, this bridging is allowed.
 
-.. cfgcmd:: set interfaces wireless <interface> max-stations <number>
+.. cfgcmd:: set interfaces wireless <interface> max-stations <count>
 
-  **Configure the number of allowed connecting clients for the interface.** 
+  Maximum number of stations allowed in station table. New stations will be
+  rejected after the station table is full. IEEE 802.11 has a limit of 2007
+  different association IDs, so this number should not be larger than that.
 
-  When this limit is reached, new client association requests are rejected. The 
-  IEEE 802.11 standard allows up to 2007 distinct association IDs. Therefore, 
-  this value should not exceed 2007.
-
-  Default: 2007.
+  This defaults to 2007.
 
 .. cfgcmd:: set interfaces wireless <interface> mgmt-frame-protection
 
-  Enable :abbr:`MFP (Management Frame Protection)` on the interface according to 
-  IEEE 802.11w.
+  Management Frame Protection (MFP) according to IEEE 802.11w
 
   .. note:: :abbr:`MFP (Management Frame Protection)` is required for WPA3.
 
 .. cfgcmd:: set interfaces wireless <interface> enable-bf-protection
 
-  Enable :abbr:`BF (Beacon Frame)` protection on the interface.
+  Beacon Protection: management frame protection for Beacon frames.
 
   .. note:: This option requires :abbr:`MFP (Management Frame Protection)` 
     to be enabled.
 
 .. cfgcmd:: set interfaces wireless <interface> mode <a | b | g | n | ac | ax>
 
-  Configure wireless radio mode for the interface. 
+  Operation mode of wireless radio.
 
-  * ``a``: 802.11a (up to 54 Mbps).
-  * ``b``: 802.11b (up to 11 Mbps).
-  * ``g`` (default): 802.11g (up to 54 Mbps).
-  * ``n``: 802.11n (up to 600 Mbps).
-  * ``ac``: 802.11ac (up to 1300 Mbps).
-  * ``ax``: 802.11ax (exceeds 1 Gbps).
+  * ``a`` - 802.11a - 54 Mbits/sec
+  * ``b`` - 802.11b - 11 Mbits/sec
+  * ``g`` - 802.11g - 54 Mbits/sec (default)
+  * ``n`` - 802.11n - 600 Mbits/sec
+  * ``ac`` - 802.11ac - 1300 Mbits/sec
+  * ``ax`` - 802.11ax - exceeds 1GBit/sec
 
-  .. note:: In VyOS, 802.11ax is only implemented for 2.4 GHz and 6 GHz.
+  .. note:: In VyOS, 802.11ax is only implemented for 2.4GHz and 6GHz.
 
 .. cfgcmd:: set interfaces wireless <interface> physical-device <device>
 
-  **Configure the underlying wireless physical device for the interface.**
+  Wireless hardware device used as underlay radio.
 
-  Default: ``phy0``.
+  This defaults to phy0.
 
 .. cfgcmd:: set interfaces wireless <interface> reduce-transmit-power <number>
 
-  **Configure the interface to add the Power Constraint** :abbr:`IE (Information 
-  Element)` **to Beacon and Probe Response frames.** 
+  Adds the Power Constraint information element to Beacon and Probe Response
+  frames.
 
-  The Power Constraint :abbr:`IE (Information Element)` is required by :abbr:`TPC 
-  (Transmit Power Control)`.
+  This option adds the Power Constraint information element when applicable
+  and the Country information element is configured. The Power Constraint 
+  element is required by Transmit Power Control.
 
-  Valid values: 0 to 255.
-
-  .. note:: You must configure the country code to use this option.
+  Valid values are 0..255.
 
 .. cfgcmd:: set interfaces wireless <interface> ssid <ssid>
 
-  Configure the SSID to be used in IEEE 802.11 management frames.
+  SSID to be used in IEEE 802.11 management frames
 
 .. cfgcmd:: set interfaces wireless <interface> type
    <access-point | station | monitor>
 
-  **Configure the wireless device type for the interface.**
+  Wireless device type for this interface
 
-  * ``access-point``: Forwards packets between other nodes.
-  * ``station``: Connects to another :abbr:`AP (Access Point)`.
-  * ``monitor``: Passively monitors all packets on the frequency/channel.
+  * ``access-point`` - Access-point forwards packets between other nodes
+  * ``station`` - Connects to another access point
+  * ``monitor`` - Passively monitor all packets on the frequency/channel
 
 .. cmdinclude:: /_include/interface-per-client-thread.txt
    :var0: wireless
@@ -171,215 +157,180 @@ PPDU
 HT (High Throughput) capabilities (802.11n)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Configure **HT mode options** if you use 802.11n or 802.11ax at 2.4 GHz.
+  Configuring HT mode options is required when using 802.11n or
+  802.11ax at 2.4GHz.
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities ht 40mhz-incapable
 
-  **Configure the interface to operate at 20 MHz.**
-
-  The command sets the ``[40-INTOLERANT]`` flag.
+  Device is incapable of 40 MHz, do not advertise. This sets ``[40-INTOLERANT]``
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities ht auto-powersave
 
-  Enable :abbr:`WMM-PS (Wi-Fi Multimedia Power Save)` (:abbr:`U-APSD (Unscheduled 
-  Automatic Power Save Delivery)`) for the interface.
+  WMM-PS Unscheduled Automatic Power Save Delivery [U-APSD]
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities ht
    channel-set-width <ht20 | ht40+ | ht40->
 
-  **Configure the supported channel width set for the interface.**
+  Supported channel width set.
 
-  * ``ht20``: Allows a 20 MHz channel width.
-  * ``ht40-``: Allows both 20 MHz and 40 MHz channel widths, with the secondary 
-    channel **below** the primary channel.
-  * ``ht40+``: Allows both 20 MHz and 40 MHz channel widths, with the secondary 
-    channel **above** the primary channel.
-  
-  .. note:: Channel availability for HT40- and HT40+ is limited. The following 
-     table lists channels permitted for HT40- and HT40+ according to IEEE 802.11n 
-     Annex J. Channel availability may vary by location.
+  * ``ht20`` - 20 MHz channel width
+  * ``ht40-`` - Both 20 MHz and 40 MHz with secondary channel below the primary
+    channel
+  * ``ht40+`` - Both 20 MHz and 40 MHz with secondary channel above the primary
+    channel
 
-     .. code-block:: none
+  .. note:: There are limits on which channels can be used with HT40- and HT40+.
+    Following table shows the channels that may be available for HT40- and HT40+
+    use per IEEE 802.11n Annex J:
 
-       freq		HT40-		HT40+
-       2.4 GHz		5-13		1-7 (1-9 in Europe/Japan)
-       5 GHz		40,48,56,64	36,44,52,60
+    Depending on the location, not all of these channels may be available for
+    use!
 
-  .. note:: 40 MHz channels may automatically switch their primary and secondary 
-     assignments, or the creation of a 40 MHz channel may be rejected due to 
-     :abbr:`OBSSs (Overlapping Basic Service Sets)`. ``hostapd`` performs these 
-     adjustments automatically when setting up the channel.
+    .. code-block:: none
+
+      freq		HT40-		HT40+
+      2.4 GHz		5-13		1-7 (1-9 in Europe/Japan)
+      5 GHz		40,48,56,64	36,44,52,60
+
+  .. note:: 40 MHz channels may switch their primary and secondary channels if
+    needed or creation of 40 MHz channel maybe rejected based on overlapping
+    BSSes. These changes are done automatically when hostapd is setting up the
+    40 MHz channel.
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities ht
    delayed-block-ack
 
-  **Enable HT-delayed** :abbr:`Block Ack (Block Acknowledgement)` **on the 
-  interface.** 
-
-  This sets the ``[DELAYED-BA]`` flag.
+  Enable HT-delayed Block Ack ``[DELAYED-BA]``
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities ht dsss-cck-40
 
-  **Enable** :abbr:`DSSS (Direct Sequence Spread Spectrum)`/:abbr:`CCK 
-  (Complementary Code Keying)` **mode in 40 MHz channels.** 
-
-  This sets the ``[DSSS_CCK-40]`` flag.
+  DSSS/CCK Mode in 40 MHz, this sets ``[DSSS_CCK-40]``
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities ht greenfield
 
-  **Enable HT Greenfield mode on the interface.** 
-
-  This sets the ``[GF]`` flag.
+  This enables the greenfield option which sets the ``[GF]`` option
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities ht ldpc
 
-  Enable :abbr:`LDPC (Low-Density Parity-Check)` coding on the interface.
+  Enable LDPC coding capability
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities ht lsig-protection
 
-  Enable :abbr:`L-SIG TXOP (Legacy Signal Transmission Opportunity)` protection 
-  on the interface.
+  Enable L-SIG TXOP protection capability
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities ht max-amsdu
    <3839 | 7935>
 
-  Configure the maximum :abbr:`A-MSDU (Aggregate MAC Service Data Unit)` length 
-  to either 3839 octets (default) or 7935 octets.
+  Maximum A-MSDU length 3839 (default) or 7935 octets
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities ht
    short-gi <20 | 40>
 
-  **Configure** :abbr:`Short GI (Short Guard Interval)` **capabilities for 20 MHz 
-  or 40 MHz channels.**
-
-  * ``20``: Enables Short GI for 20 MHz channels. 
-  * ``40``: Enables Short GI for 40 MHz channels. 
+  Short GI capabilities for 20 and 40 MHz
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities ht
    smps <static | dynamic>
 
-  **Configure** :abbr:`SMPS (Spatial Multiplexing Power Save)` **mode for the 
-  interface.**
-
-  * ``static``: Enables static SMPS mode. 
-  * ``dynamic``: Enables dynamic SMPS mode. 
+  Spatial Multiplexing Power Save (SMPS) settings
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities ht stbc rx <num>
 
-  Enable receiving :abbr:`PPDUs (PLCP Protocol Data Units)` using :abbr:`STBC 
-  (Space-Time Block Coding)`.
+  Enable receiving PPDU using STBC (Space Time Block Coding)
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities ht stbc tx
 
-  Enable transmitting :abbr:`PPDUs (PLCP Protocol Data Units)` using :abbr:`STBC 
-  (Space-Time Block Coding)`.
-
+  Enable sending PPDU using STBC (Space Time Block Coding)
 
 VHT (Very High Throughput) capabilities (802.11ac)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. cfgcmd:: set interfaces wireless <interface> capabilities vht antenna-count <num>
+.. stop_vyoslinter
 
-  **Configure the number of antennas for the interface.**
+.. cfgcmd:: set interfaces wireless <interface> capabilities vht antenna-count <count>
 
-  Valid values: 1 to 8.
+.. start_vyoslinter
+
+  Number of antennas on this card
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities vht
    antenna-pattern-fixed
 
-  **Enable the fixed antenna pattern capability on the interface.**
-
-  Use this option if the antenna pattern does not change during the lifetime of 
-  an association.
+  Set if antenna pattern does not change during the lifetime of an association
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities vht beamform
   <single-user-beamformer | single-user-beamformee | multi-user-beamformer |
   multi-user-beamformee>
 
-  Configure VHT beamforming capabilities for the interface.
+  Beamforming capabilities:
 
-  * ``single-user-beamformer``: Supports operation as a Single-User (SU) 
-    beamformer.
-  * ``single-user-beamformee``: Supports operation as a Single-User (SU) 
-    beamformee.
-  * ``multi-user-beamformer``: Supports operation as a Multi-User (MU) beamformer.
-  * ``multi-user-beamformee``: Supports operation as a Multi-User (MU) beamformee.
+  * ``single-user-beamformer`` - Support for operation as 
+    single user beamformer
+  * ``single-user-beamformee`` - Support for operation as 
+    single user beamformee
+  * ``multi-user-beamformer`` - Support for operation as 
+    multi user beamformer
+  * ``multi-user-beamformee`` - Support for operation as 
+    multi user beamformee
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities vht
    center-channel-freq <freq-1 | freq-2> <number>
 
-  **Configure the VHT operating channel center frequency for the interface.**
+  VHT operating channel center frequency - center freq 1
+  (for use with 80, 80+80 and 160 modes)
 
-  * ``freq-1``: Specifies the center frequency for 80 MHz, 160 MHz, and 80+80 MHz 
-    channels.
+  VHT operating channel center frequency - center freq 2
+  (for use with the 80+80 mode)
 
-  * ``freq-2:`` Specifies the center frequency for 80+80 MHz channels.
-
-  * ``<number>``: Ranges from 34 to 173. For 80 MHz channels, the center 
-    frequency is typically the channel number plus 6. 
+  <number> must be from 34 - 173. For 80 MHz channels it should be channel + 6.
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities vht
    channel-set-width <0 | 1 | 2 | 3>
 
-  **Configure the VHT operating channel width for the interface.**
-
-  * ``0`` (default): 20 MHz or 40 MHz channel width.
-  * ``1``: 80 MHz channel width.
-  * ``2``: 160 MHz channel width.
-  * ``3``: 80+80 MHz channel width.
+   * ``0`` - 20 or 40 MHz channel width (default)
+   * ``1`` - 80 MHz channel width
+   * ``2`` - 160 MHz channel width
+   * ``3`` - 80+80 MHz channel width
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities vht ldpc
 
-  Enable :abbr:`LDPC (Low-Density Parity Check)` coding for the interface.
+  Enable LDPC (Low Density Parity Check) coding capability
 
 .. cfgcmd:: set interfaces wireless <interface> 
   capabilities vht link-adaptation
 
-  Enable VHT link adaptation on the interface.
+  VHT link adaptation capabilities
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities vht
    max-mpdu <value>
 
-  **Increase the maximum** :abbr:`MPDU (MAC Protocol Data Unit)` **length to 
-  7991 or 11454 octets.** 
-
-  Default: 3895 octets.
+  Increase Maximum MPDU length to 7991 or 11454 octets (default 3895 octets)
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities vht
    max-mpdu-exp <value>
 
-  Configure the maximum length of :abbr:`A-MPDU (Aggregated MAC Protocol Data 
-  Unit)` :abbr:`pre-EOF (pre-End of Frame)` padding that the interface can 
-  receive.
+  Set the maximum length of A-MPDU pre-EOF padding that the station can 
+  receive
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities vht
    short-gi <80 | 160>
 
-  **Configure** :abbr:`Short GI (Short Guard Interval)` **capabilities for 80 MHz 
-  or 160 MHz channels.**
-
-  * ``80``: Enables Short GI for 80 MHz channels. 
-  * ``160``: Enables Short GI for 160 MHz channels. 
-
+  Short GI capabilities
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities vht stbc rx <num>
 
-  Enable receiving :abbr:`PPDUs (PLCP Protocol Data Units)` using :abbr:`STBC 
-  (Space-Time Block Coding)`.
+  Enable receiving PPDU using STBC (Space Time Block Coding)
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities vht stbc tx
 
-  Enable transmitting :abbr:`PPDUs (PLCP Protocol Data Units)` using :abbr:`STBC 
-  (Space-Time Block Coding)`.
+  Enable sending PPDU using STBC (Space Time Block Coding)
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities vht tx-powersave
 
-  Enable VHT :abbr:`TXOP (Transmit Opportunity)` Power Save mode for the 
-  interface.
+  Enable VHT TXOP Power Save Mode
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities vht vht-cf
 
-  Enable receiving the VHT variant HT Control field on the interface.
+  Station supports receiving VHT variant HT Control field
 
 HE (High Efficiency) capabilities (802.11ax)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -387,92 +338,87 @@ HE (High Efficiency) capabilities (802.11ax)
 .. cfgcmd:: set interfaces wireless <interface> 
   capabilities he antenna-pattern-fixed
 
-  Notify the :abbr:`AP (Access Point)` that antenna positions are fixed and do not change during the lifetime of an association.
+  Tell the AP that antenna positions are fixed and will not change
+  during the lifetime of an association.
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities he beamform 
   <single-user-beamformer | single-user-beamformee | multi-user-beamformer>
 
-  **Configure HE beamforming capabilities for the interface.**
+  Beamforming capabilities:
 
-  * ``single-user-beamformer``: Supports operation as a Single-User (SU) 
-    beamformer.
-  * ``single-user-beamformee``: Supports operation as a Single-User (SU) 
-    beamformee.
-  * ``multi-user-beamformer``: Supports operation as a Multi-User (MU) beamformer.
+  * ``single-user-beamformer`` - Support for operation as 
+    single user beamformer
+  * ``single-user-beamformee`` - Support for operation as 
+    single user beamformee
+  * ``multi-user-beamformer`` - Support for operation as multi
+    user beamformer
 
 .. cfgcmd:: set interfaces wireless <interface> 
   capabilities he bss-color <number>
 
-  **Configure the** :abbr:`BSS (Basic Service Set)` **color for the interface.** 
-  
-  BSS coloring helps prevent channel jamming when multiple :abbr:`APs (Access 
-  Points)` use the same channels.
+  BSS coloring helps to prevent channel jamming when multiple APs use 
+  the same channels.
 
   Valid values are 1..63
 
 .. cfgcmd:: set interfaces wireless <interface> capabilities he 
   center-channel-freq <freq-1 | freq-2> <number>
 
-  **Configure the HE operating channel center frequency for the interface.**
+  HE operating channel center frequency - center freq 1
+  (for use with 80, 80+80 and 160 modes)
 
-  * ``freq-1``: Specifies the center frequency for 80 MHz, 160 MHz, and 80+80 MHz 
-    channels.
+  HE operating channel center frequency - center freq 2
+  (for use with the 80+80 mode)
 
-  * ``freq-2``: Specifies the center frequency for 80+80 MHz channels.
-
-  * ``<number>``: Ranges from 34 to 173. For 80 MHz channels, the center 
-    frequency is typically the primary channel number plus 6. 
+  <number> must be within 1..233. For 80 MHz channels it should be 
+  channel + 6 and for 160 MHz channels, it should be channel + 14.
 
 .. cfgcmd:: set interfaces wireless <interface> 
   capabilities he channel-set-width <number>
 
-  **Configure the HE operating channel width for the interface.**
+  <number> must be one of:
 
-  For the 2.4 GHz band:
-
-  * ``81``: 20 MHz channel width.
-  * ``83``: 40 MHz channel width, secondary 20 MHz channel above primary.
-  * ``84``: 40 MHz channel width, secondary 20 MHz channel below primary.
-
-  For the 6 GHz band: 
-
-  * ``131``: 20 MHz channel width.
-  * ``132``: 40 MHz channel width.
-  * ``133``: 80 MHz channel width.
-  * ``134``: 160 MHz channel width.
-  * ``135``: 80+80 MHz channel width.
+  * ``81`` - 20 MHz channel width (2.4GHz)
+  * ``83`` - 40 MHz channel width, secondary 20MHz channel above primary 
+    channel (2.4GHz)
+  * ``84`` - 40 MHz channel width, secondary 20MHz channel below primary 
+    channel (2.4GHz)
+  * ``131`` - 20 MHz channel width (6GHz)
+  * ``132`` - 40 MHz channel width (6GHz)
+  * ``133`` - 80 MHz channel width (6GHz)
+  * ``134`` - 160 MHz channel width (6GHz)
+  * ``135`` - 80+80 MHz channel width (6GHz)
 
 .. cfgcmd:: set interfaces wireless <interface> 
   capabilities he coding-scheme <number>
-  
-  **Configure** :abbr:`SS (Spatial Stream)` **and** :abbr:`HE-MCS (High 
-  Efficiency Modulation and Coding Scheme)` **settings for the interface.** 
 
-  Explicit configuration of these settings is typically unnecessary.
+  This setting configures Spatial Stream and Modulation Coding Scheme 
+  settings for HE mode (HE-MCS). It is usually not needed to set this 
+  explicitly, but it might help with some WiFi adapters.
 
-  The ``<number>`` defines the supported MCS range and must be one of the following:
+  <number> must be one of:
 
-  * ``0``: Allows HE-MCS 0-7.
-  * ``1``: Allows HE-MCS 0-9.
-  * ``2``: Allows HE-MCS 0-11.
-  * ``3``: Disables HE-MCS.
+  * ``0`` - HE-MCS 0-7
+  * ``1`` - HE-MCS 0-9
+  * ``2`` - HE-MCS 0-11
+  * ``3`` - HE-MCS is not supported
 
-Wireless options (station/client)
+Wireless options (Station/Client)
 =================================
 
-The following example configures a wireless station (Wi-Fi client) that 
-connects to the network through an :abbr:`AP (Access Point)`, using the default 
-physical interface ``phy0``.
+The example creates a wireless station (commonly referred to as Wi-Fi client)
+that accesses the network through the WAP defined in the above example. The
+default physical device (``phy0``) is used.
 
 .. code-block:: none
 
   set system wireless country-code de
   set interfaces wireless wlan0 type station
   set interfaces wireless wlan0 address dhcp
-  set interfaces wireless wlan0 ssid Test
+  set interfaces wireless wlan0 ssid 'TEST'
   set interfaces wireless wlan0 security wpa passphrase '12345678'
 
-Resulting configuration:
+Resulting in
 
 .. code-block:: none
 
@@ -493,32 +439,28 @@ Resulting configuration:
       type station
     }
 
-Wireless security
-=================
+Security
+========
 
-:abbr:`WPA (Wi-Fi Protected Access)`, WPA2, and WPA3 Enterprise, combined with 
-802.1X-based authentication, enable user or computer authentication within a 
-domain.
+:abbr:`WPA (Wi-Fi Protected Access)`, WPA2 Enterprise and WPA3 Enterprise in 
+combination with 802.1x based authentication can be used to authenticate 
+users or computers in a domain.
 
-The authentication process involves the following three participants:
+The wireless client (supplicant) authenticates against the RADIUS server
+(authentication server) using an :abbr:`EAP (Extensible Authentication
+Protocol)` method configured on the RADIUS server. The WAP (also referred
+to as authenticator) role is to send all authentication messages between the
+supplicant and the configured authentication server, thus the RADIUS server
+is responsible for authenticating the users.
 
-* **Supplicant**: The wireless client authenticates against the RADIUS server 
-  using an EAP method.
-* **Authenticator**: The Access Point (AP) sends authentication messages 
-  between the supplicant and the RADIUS server.
-* **Authentication server**: The RADIUS server authenticates users.
+The WAP in this example has the following characteristics:
 
-The following example configures an :abbr:`AP (Access Point)` to use WPA2 
-Enterprise security and authenticate connecting clients against an external 
-RADIUS server.
-
-Configuration parameters:
-
-* **IP address:** ``192.168.2.1/24``
-* **Network ID (SSID):** ``Enterprise-TEST``
-* **Protocol:** 802.11n
-* **Wireless channel:** ``1``
-* **RADIUS server:** ``192.168.3.10`` with shared-secret ``VyOSPassword``
+* IP address ``192.168.2.1/24``
+* Network ID (SSID) ``Enterprise-TEST``
+* WPA passphrase ``12345678``
+* Use 802.11n protocol
+* Wireless channel ``1``
+* RADIUS server at ``192.168.3.10`` with shared-secret ``VyOSPassword``
 
 .. stop_vyoslinter
 .. code-block:: none
@@ -586,13 +528,13 @@ QinQ (802.1ad)
    :var1: wlan0
 
 *********
-Operation 
+Operation
 *********
 
 .. opcmd:: show interfaces wireless info
 
-Show the operational status and wireless-specific information about all 
-wireless interfaces.
+Use this command to view operational status and wireless-specific information
+about all wireless interfaces.
 
 .. code-block:: none
 
@@ -602,8 +544,8 @@ wireless interfaces.
 
 .. opcmd:: show interfaces wireless detail
 
-Show the operational status and detailed wireless-specific information about 
-all wireless interfaces.
+Use this command to view operational status and details wireless-specific
+information about all wireless interfaces.
 
 .. stop_vyoslinter
 .. code-block:: none
@@ -637,8 +579,8 @@ all wireless interfaces.
 
 .. opcmd:: show interfaces wireless <wlanX>
 
-Show the operational status and statistics for the specified wireless 
-interface. Interface identifiers range from ``wlan0`` to ``wlan999``.
+This command shows both status and statistics on the specified wireless
+interface. The wireless interface identifier can range from wlan0 to wlan999.
 
 .. stop_vyoslinter
 .. code-block:: none
@@ -661,8 +603,8 @@ interface. Interface identifiers range from ``wlan0`` to ``wlan999``.
 
 .. opcmd:: show interfaces wireless <wlanX> brief
 
-Show a brief operational status summary for the specified wireless interface. 
-Interface identifiers range from ``wlan0`` to ``wlan999``.
+This command gives a brief status overview of a specified wireless interface.
+The wireless interface identifier can range from wlan0 to wlan999.
 
 .. code-block:: none
 
@@ -675,8 +617,8 @@ Interface identifiers range from ``wlan0`` to ``wlan999``.
 
 .. opcmd:: show interfaces wireless <wlanX> queue
 
-Show queue information for the specified wireless interface. Interface 
-identifiers range from ``wlan0`` to ``wlan999``.
+Use this command to view wireless interface queue information.
+The wireless interface identifier can range from wlan0 to wlan999.
 
 .. code-block:: none
 
@@ -688,12 +630,13 @@ identifiers range from ``wlan0`` to ``wlan999``.
 
 .. opcmd:: show interfaces wireless <wlanX> scan
 
-Show information about :abbr:`APs (Access Points)` within the range of the 
-specified wireless interface. You can use this data when configuring wireless 
-interfaces in ``station`` mode.
+This command is used to retrieve information about WAP within the range of your
+wireless interface. This command is useful on wireless interfaces configured
+in station mode.
 
-.. note:: Some wireless drivers or hardware may not support such scanning. 
-   Refer to your driver and hardware documentation for more information.
+.. note:: Scanning is not supported on all wireless drivers and wireless
+   hardware. Refer to your driver and wireless hardware documentation for
+   further details.
 
 .. code-block:: none
 
@@ -719,17 +662,17 @@ interfaces in ``station`` mode.
 Examples
 ********
 
-The following example configures an :abbr:`AP (Access Point)` with the 
-following parameters:
+The following example creates a WAP. When configuring multiple WAP interfaces,
+you must specify unique IP addresses, channels, Network IDs commonly referred
+to as :abbr:`SSID (Service Set Identifier)`, and MAC addresses.
 
-* IP address: ``192.168.2.1/24``
-* Network ID (SSID): ``TEST``
-* WPA passphrase: ``12345678``
-* Protocol: 802.11n
-* Wireless channel: ``1``
+The WAP in this example has the following characteristics:
 
-.. note:: When setting up multiple WAP interfaces, ensure each has a unique IP 
-   address, channel, network ID (SSID), and MAC address.
+* IP address ``192.168.2.1/24``
+* Network ID (SSID) ``TEST``
+* WPA passphrase ``12345678``
+* Use 802.11n protocol
+* Wireless channel ``1``
 
 .. code-block:: none
 
@@ -743,7 +686,7 @@ following parameters:
   set interfaces wireless wlan0 security wpa cipher CCMP
   set interfaces wireless wlan0 security wpa passphrase '12345678'
 
-Resulting configuration:
+Resulting in
 
 .. code-block:: none
 
@@ -770,27 +713,30 @@ Resulting configuration:
       }
   }
 
-To enable access point functionality, configure a DHCP server for this 
-interface's network, or add the interface to an existing local bridge.
-(see :ref:`bridge-interface` for details).
+To get it to work as an access point with this configuration you will need
+to set up a DHCP server to work with that network. You can - of course - also
+bridge the Wireless interface with any configured bridge
+(:ref:`bridge-interface`) on the system.
 
-Wi-Fi 6/6E (802.11ax)
-=====================
+WiFi-6(e) - 802.11ax
+====================
 
-The following examples configure Wi-Fi 6 (2.4 GHz) and Wi-Fi 6E (6 GHz) 
-:abbr:`APs (Access Points)` with the following parameters:
+The following examples will show valid configurations for WiFi-6 (2.4GHz) 
+and WiFi-6e (6GHz) Access-Points with the following characteristics:
 
-* Network ID (SSID): ``test.ax``
-* WPA passphrase: ``super-dooper-secure-passphrase``
-* Protocol: 802.11ax
-* Wireless channel for 2.4 GHz: ``11`` 
-* Wireless channel for 6 GHz: ``5`` 
+* Network ID (SSID) ``test.ax``
+* WPA passphrase ``super-dooper-secure-passphrase``
+* Use 802.11ax protocol
+* Wireless channel ``11`` for 2.4GHz
+* Wireless channel ``5`` for 6GHz 
 
 
-Example configuration: Wi-Fi 6 at 2.4 GHz
------------------------------------------
+Example Configuration: WiFi-6 at 2.4GHz
+---------------------------------------
 
-You may expect real throughput around 10 MB/s or higher in crowded areas.
+You may expect real throughputs around 10MBytes/s or higher in crowded areas.
+
+.. stop_vyoslinter
 
 .. code-block:: none
 
@@ -822,7 +768,9 @@ You may expect real throughput around 10 MB/s or higher in crowded areas.
   set interfaces wireless wlan0 type access-point
   commit
 
-Resulting configuration:
+.. start_vyoslinter
+
+Resulting in
 
 .. code-block:: none
 
@@ -878,14 +826,15 @@ Resulting configuration:
       }
   }
 
-Example configuration: Wi-Fi 6E at 6 GHz
-----------------------------------------
+Example Configuration: WiFi-6e at 6GHz
+--------------------------------------
 
-You may expect real throughput between 50 MB/s and 150 MB/s, depending on 
-obstructions from walls, water, metal, or other materials with high 
-electromagnetic damping at 6 GHz. 
+You may expect real throughputs around 50MBytes/s to 150MBytes/s,
+depending on obstructions by walls, water, metal or other materials
+with high electro-magnetic dampening at 6GHz. Best results are achieved
+with the AP being in the same room and in line-of-sight.
 
-Best results are achieved when the AP is in the same room and in line of sight.
+.. stop_vyoslinter
 
 .. code-block:: none
 
@@ -913,7 +862,9 @@ Best results are achieved when the AP is in the same room and in line of sight.
   set interfaces wireless wlan0 stationary-ap
   commit
 
-Resulting configuration:
+.. start_vyoslinter
+
+Resulting in
 
 .. code-block:: none
 
@@ -968,10 +919,8 @@ Resulting configuration:
 Intel AX200
 ===========
 
-The Intel AX200 card does not operate out of the box in ``access-point`` mode. 
-
-You can still enable :abbr:`AP (Access Point)` functionality on this hardware 
-by applying the following configuration:
+The Intel AX200 card does not work out of the box in AP mode. You can
+still put this card into AP mode using the following configuration:
 
 .. stop_vyoslinter
 .. code-block:: none

--- a/docs/configuration/interfaces/wireless.rst
+++ b/docs/configuration/interfaces/wireless.rst
@@ -1,10 +1,10 @@
-:lastproofread: 2024-07-04
+:lastproofread: 2026-03-23
 
 .. _wireless-interface:
 
-########################
-WLAN/WIFI - Wireless LAN
-########################
+####################
+Wireless LAN / Wi-Fi
+####################
 
 The :abbr:`WLAN (Wireless LAN)` interface provides 802.11 (a/b/g/n/ac) wireless
 support (commonly referred to as Wi-Fi) by means of compatible hardware. If
@@ -36,7 +36,7 @@ Common interface configuration
    :var0: wireless
    :var1: wlan0
 
-System Wide configuration
+System-wide configuration
 =========================
 
 .. cfgcmd:: set system wireless country-code <cc>
@@ -52,10 +52,13 @@ Wireless options
 
 .. cfgcmd:: set interfaces wireless <interface> channel <number>
 
-  Channel number (IEEE 802.11), for 2.4 GHz (802.11 b/g/n/ax) channels
-  range from 1-14. On 5 GHz (802.11 a/h/j/n/ac) channels available are
-  0, 34 to 177. 
-  On 6GHz (802.11 ax) channels range from 1 to 233.
+  Configure the IEEE 802.11 wireless radio channel for the interface.
+  Channel allocation depends on the frequency band:
+
+  * **2.4 GHz** (802.11b/g/n/ax): Channels range from 1 to 14.
+  * **5 GHz** (802.11a/h/j/n/ac/ax): Channels range from 34 to 177.
+  * **6 GHz** (802.11ax): Channels range from 1 to 233.
+  * **Automatic channel selection:** 0.
 
 .. cfgcmd:: set interfaces wireless <interface> disable-broadcast-ssid
 
@@ -193,7 +196,7 @@ HT (High Throughput) capabilities (802.11n)
       5 GHz		40,48,56,64	36,44,52,60
 
   .. note:: 40 MHz channels may switch their primary and secondary channels if
-    needed or creation of 40 MHz channel maybe rejected based on overlapping
+    needed or creation of 40 MHz channel may be rejected based on overlapping
     BSSes. These changes are done automatically when hostapd is setting up the
     40 MHz channel.
 
@@ -443,7 +446,7 @@ Security
 ========
 
 :abbr:`WPA (Wi-Fi Protected Access)`, WPA2 Enterprise and WPA3 Enterprise in 
-combination with 802.1x based authentication can be used to authenticate 
+combination with 802.1X based authentication can be used to authenticate 
 users or computers in a domain.
 
 The wireless client (supplicant) authenticates against the RADIUS server
@@ -544,7 +547,7 @@ about all wireless interfaces.
 
 .. opcmd:: show interfaces wireless detail
 
-Use this command to view operational status and details wireless-specific
+Show the operational status and detailed wireless-specific
 information about all wireless interfaces.
 
 .. stop_vyoslinter
@@ -734,7 +737,7 @@ and WiFi-6e (6GHz) Access-Points with the following characteristics:
 Example Configuration: WiFi-6 at 2.4GHz
 ---------------------------------------
 
-You may expect real throughputs around 10MBytes/s or higher in crowded areas.
+You may expect real throughput around 10 MB/s or higher in crowded areas.
 
 .. stop_vyoslinter
 
@@ -829,9 +832,9 @@ Resulting in
 Example Configuration: WiFi-6e at 6GHz
 --------------------------------------
 
-You may expect real throughputs around 50MBytes/s to 150MBytes/s,
-depending on obstructions by walls, water, metal or other materials
-with high electro-magnetic dampening at 6GHz. Best results are achieved
+You may expect real throughput between 50 MB/s and 150 MB/s, depending on
+obstructions from walls, water, metal, or other materials
+with high electromagnetic damping at 6 GHz. Best results are achieved
 with the AP being in the same room and in line-of-sight.
 
 .. stop_vyoslinter

--- a/docs/configuration/interfaces/wireless.rst
+++ b/docs/configuration/interfaces/wireless.rst
@@ -42,7 +42,7 @@ System-wide configuration
   to indicate country in which device is operating. This can limit available
   channels and transmit power.
 
-  .. note:: This option is mandatory in Access-Point mode.
+  .. note:: This option is mandatory in ``access-point`` mode.
 
 Wireless options
 ================
@@ -137,9 +137,9 @@ Wireless options
 
   Wireless device type for this interface
 
-  * ``access-point`` - Access-point forwards packets between other nodes
-  * ``station`` - Connects to another access point
-  * ``monitor`` - Passively monitor all packets on the frequency/channel
+  * ``access-point``: Forwards packets between other nodes.
+  * ``station``: Connects to another :abbr:`AP (Access Point)`.
+  * ``monitor``: Passively monitors all packets on the frequency/channel.
 
 .. cmdinclude:: /_include/interface-per-client-thread.txt
    :var0: wireless
@@ -179,12 +179,9 @@ HT (High Throughput) capabilities (802.11n)
   * ``ht40+`` - Both 20 MHz and 40 MHz with secondary channel above the primary
     channel
 
-  .. note:: There are limits on which channels can be used with HT40- and HT40+.
-    Following table shows the channels that may be available for HT40- and HT40+
-    use per IEEE 802.11n Annex J:
-
-    Depending on the location, not all of these channels may be available for
-    use!
+  .. note:: Channel availability for HT40- and HT40+ is limited. The following
+     table lists channels permitted for HT40- and HT40+ according to IEEE
+     802.11n Annex J. Channel availability may vary by location.
 
     .. code-block:: none
 

--- a/docs/configuration/interfaces/wireless.rst
+++ b/docs/configuration/interfaces/wireless.rst
@@ -6,12 +6,9 @@
 Wireless LAN / Wi-Fi
 ####################
 
-The :abbr:`WLAN (Wireless LAN)` interface provides 802.11 (a/b/g/n/ac) wireless
-support (commonly referred to as Wi-Fi) by means of compatible hardware. If
-your hardware supports it, VyOS supports multiple logical wireless interfaces
-per physical device.
-
-There are three modes of operation for a wireless interface:
+:abbr:`WLAN (Wireless LAN)` interfaces provide 802.11 (a/b/g/n/ac) wireless
+connectivity, referred to as Wi-Fi, and operate in one of the following
+modes:
 
 * :abbr:`WAP (Wireless Access-Point)` mode provides network access to connecting
   stations if the physical hardware supports acting as a WAP
@@ -421,7 +418,7 @@ default physical device (``phy0``) is used.
   set interfaces wireless wlan0 ssid 'TEST'
   set interfaces wireless wlan0 security wpa passphrase '12345678'
 
-Resulting in
+Resulting configuration:
 
 .. code-block:: none
 
@@ -689,7 +686,7 @@ The WAP in this example has the following characteristics:
   set interfaces wireless wlan0 security wpa cipher CCMP
   set interfaces wireless wlan0 security wpa passphrase '12345678'
 
-Resulting in
+Resulting configuration:
 
 .. code-block:: none
 
@@ -716,26 +713,25 @@ Resulting in
       }
   }
 
-To get it to work as an access point with this configuration you will need
-to set up a DHCP server to work with that network. You can - of course - also
-bridge the Wireless interface with any configured bridge
-(:ref:`bridge-interface`) on the system.
+To enable access point functionality, configure a DHCP server for this
+interface's network, or add the interface to an existing local bridge
+(see :ref:`bridge-interface` for details).
 
-WiFi-6(e) - 802.11ax
-====================
+Wi-Fi 6/6E (802.11ax)
+=====================
 
-The following examples will show valid configurations for WiFi-6 (2.4GHz) 
-and WiFi-6e (6GHz) Access-Points with the following characteristics:
+The following examples configure Wi-Fi 6 (2.4 GHz) and Wi-Fi 6E (6 GHz)
+:abbr:`APs (Access Points)` with the following parameters:
 
-* Network ID (SSID) ``test.ax``
-* WPA passphrase ``super-dooper-secure-passphrase``
-* Use 802.11ax protocol
-* Wireless channel ``11`` for 2.4GHz
-* Wireless channel ``5`` for 6GHz 
+* Network ID (SSID): ``test.ax``
+* WPA passphrase: ``super-dooper-secure-passphrase``
+* Protocol: 802.11ax
+* Wireless channel for 2.4 GHz: ``11``
+* Wireless channel for 6 GHz: ``5``
 
 
-Example Configuration: WiFi-6 at 2.4GHz
----------------------------------------
+Example configuration: Wi-Fi 6 at 2.4 GHz
+------------------------------------------
 
 You may expect real throughput around 10 MB/s or higher in crowded areas.
 
@@ -773,7 +769,7 @@ You may expect real throughput around 10 MB/s or higher in crowded areas.
 
 .. start_vyoslinter
 
-Resulting in
+Resulting configuration:
 
 .. code-block:: none
 
@@ -829,8 +825,8 @@ Resulting in
       }
   }
 
-Example Configuration: WiFi-6e at 6GHz
---------------------------------------
+Example configuration: Wi-Fi 6E at 6 GHz
+-----------------------------------------
 
 You may expect real throughput between 50 MB/s and 150 MB/s, depending on
 obstructions from walls, water, metal, or other materials
@@ -867,7 +863,7 @@ with the AP being in the same room and in line-of-sight.
 
 .. start_vyoslinter
 
-Resulting in
+Resulting configuration:
 
 .. code-block:: none
 


### PR DESCRIPTION
## Summary
- Reformat `docs/configuration/interfaces/wireless.rst` (549 lines changed)
- Standardize heading hierarchy, rewrap long prose lines, fix code-block indentation
- Reword some command descriptions for conciseness
- Improve overall document structure and readability

**Note:** This PR includes prose rewording alongside formatting changes.

Split from #1816 for focused review.

## Test plan
- [ ] Sphinx build passes without warnings
- [ ] All wireless page sections render correctly
- [ ] Cross-references to wireless page still work