### PR TITLE
ci: add CLAUDE.md and Copilot custom instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,10 @@
 
 This is VyOS user documentation written in reStructuredText (RST) and built with Sphinx.
 
+### Review Scope
+
+When reviewing pull requests, only flag issues **introduced by the PR's changes**. Do not flag pre-existing issues in unchanged lines. Compare against the base branch to determine what was actually changed.
+
 ### RST Heading Hierarchy
 
 All files must use this heading order:
@@ -17,13 +21,46 @@ All files must use this heading order:
 
 ### Line Length
 
-Maximum 80 characters per line. Exception: content inside `.. code-block::` directives is exempt because it renders with `<pre>` tags.
+Maximum 80 characters per line. Exception: content inside `.. code-block::` directives is **exempt** — they render with `<pre>` tags and preserve source formatting. Do not flag long lines inside code blocks.
+
+### Linter Suppression Markers
+
+`.. stop_vyoslinter` and `.. start_vyoslinter` are RST comments used to suppress CI linter checks. Key conventions:
+
+- **Always placed at column 0**, even when inside indented directives (`.. opcmd::`, `.. cfgcmd::`, numbered lists). This is the established repo convention. Do not flag column-0 placement as incorrect.
+- They are RST comments and do not break directive structure or nesting.
+- They must always appear in pairs (stop then start). A missing `start_vyoslinter` is a real issue.
+- A `stop_vyoslinter` that covers a large section is acceptable when the content requires it (e.g., files full of real debug output with production IPs).
+
+### IP Address Rules
+
+The CI linter checks IP addresses. These are **allowed without suppression** — do not flag them:
+
+- RFC 5737 documentation addresses: `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`
+- RFC 3849 documentation IPv6: `2001:db8::/32`
+- RFC 1918 private ranges: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+- Loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16`), `0.0.0.0/0`
+
+Real public IPs (e.g., `8.8.8.8`) require `stop/start_vyoslinter` suppression. Do not suggest replacing them with documentation addresses if the example intentionally uses real IPs.
+
+### TODO Markers
+
+`.. TODO::` directives serve two purposes in this repo:
+
+1. **Tracking markers** on pages that need `cfgcmd`/`opcmd` conversion (these are intentionally added).
+2. **Stale markers** on pages that already have full content (these should be removed).
+
+A PR that removes some TODOs and adds others is not contradictory — the intent matters.
 
 ### VyOS Directives
 
 - `.. cfgcmd::` for configuration mode commands
 - `.. opcmd::` for operational mode commands
 - Do not convert these to plain `.. code-block::` — they are tracked for command coverage.
+
+### YAML in Code Blocks
+
+Ansible playbook examples in `.. code-block::` use RST indentation (typically 4 spaces from the directive). The YAML indentation within the block may differ from standalone YAML files. Verify carefully before flagging YAML as invalid — count spaces from the code-block's own indentation base, not from column 0.
 
 ### Page Structure
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,8 +27,9 @@ Maximum 80 characters per line. Exception: content inside `.. code-block::` dire
 
 `.. stop_vyoslinter` and `.. start_vyoslinter` are RST comments used to suppress CI linter checks. Key conventions:
 
-- **Always placed at column 0**, even when inside indented directives (`.. opcmd::`, `.. cfgcmd::`, numbered lists). This is the established repo convention. Do not flag column-0 placement as incorrect.
-- They are RST comments and do not break directive structure or nesting.
+- When used **inside an indented directive** (`.. cfgcmd::`, `.. opcmd::`, list items), markers should match the surrounding indentation to stay within the block.
+- When used **at top level** (outside any directive), markers are placed at column 0.
+- Both patterns exist in this repo. Do not flag either placement as incorrect.
 - They must always appear in pairs (stop then start). A missing `start_vyoslinter` is a real issue.
 - A `stop_vyoslinter` that covers a large section is acceptable when the content requires it (e.g., files full of real debug output with production IPs).
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,30 @@
+## VyOS Documentation Project
+
+This is VyOS user documentation written in reStructuredText (RST) and built with Sphinx.
+
+### RST Heading Hierarchy
+
+All files must use this heading order:
+
+```
+##### (Title — one per file, with overline)
+***** (Chapters)
+===== (Sections)
+----- (Subsections)
+^^^^^ (Subsubsections)
+""""" (Paragraphs)
+```
+
+### Line Length
+
+Maximum 80 characters per line. Exception: content inside `.. code-block::` directives is exempt because it renders with `<pre>` tags.
+
+### VyOS Directives
+
+- `.. cfgcmd::` for configuration mode commands
+- `.. opcmd::` for operational mode commands
+- Do not convert these to plain `.. code-block::` — they are tracked for command coverage.
+
+### Page Structure
+
+Configuration pages follow this order: Theory, Configuration (cfgcmd), Examples, Known Issues, Debugging.

--- a/.github/instructions/rst-linter.instructions.md
+++ b/.github/instructions/rst-linter.instructions.md
@@ -1,0 +1,71 @@
+---
+applyTo: "**/*.rst"
+---
+
+## RST Linter Rules
+
+Every pull request is automatically linted by `doc-linter.py` (from the `vyos/.github` repository). It checks **only changed files** for two things: IP address usage and line length.
+
+### IP Address Rules
+
+The linter rejects public IP addresses that are not reserved for documentation.
+
+**Use these documentation-reserved addresses (no suppression needed):**
+
+| Type | Range | RFC |
+|------|-------|-----|
+| IPv4 | `192.0.2.0/24` (TEST-NET-1) | RFC 5737 |
+| IPv4 | `198.51.100.0/24` (TEST-NET-2) | RFC 5737 |
+| IPv4 | `203.0.113.0/24` (TEST-NET-3) | RFC 5737 |
+| IPv6 | `2001:db8::/32` | RFC 3849 |
+
+**These are allowed without suppression (not flagged by linter):**
+
+| Type | Range | Why |
+|------|-------|-----|
+| RFC 1918 private | `10.0.0.0/8` | Private address space |
+| RFC 1918 private | `172.16.0.0/12` | Private address space |
+| RFC 1918 private | `192.168.0.0/16` | Private address space |
+| Loopback | `127.0.0.0/8` | Loopback range |
+| Link-local | `169.254.0.0/16` | Link-local |
+
+**These require `stop/start_vyoslinter` suppression:**
+
+| Example | Why suppression is needed |
+|---------|--------------------------|
+| `8.8.8.8` (Google DNS) | Real public IP, not documentation-reserved |
+| `64:ff9b::/96` (NAT64) | Well-known prefix, not in doc ranges |
+| Real provider IPs in examples | Authenticity matters for the example |
+
+### Line Length Rules
+
+Maximum 80 characters per line. Lines inside `.. code-block::` are still checked by the linter unless suppressed.
+
+### Suppression Syntax
+
+When real public IPs or long lines are unavoidable, wrap the block:
+
+```rst
+.. stop_vyoslinter
+
+.. code-block:: none
+
+   set system name-server '8.8.8.8'
+
+.. start_vyoslinter
+```
+
+**Rules for suppression markers:**
+
+- Place `.. stop_vyoslinter` on its own line, immediately before the content
+- Place `.. start_vyoslinter` on its own line, immediately after the content
+- Always re-enable the linter — never leave it stopped for the rest of the file
+- Suppress the smallest possible region
+- Do NOT use suppression for content that can use documentation-reserved addresses instead
+
+### Common Mistakes
+
+- Removing `stop/start_vyoslinter` markers without fixing the underlying issue (exposes the line to the linter and fails CI)
+- Using `0.0.0.0/0` in examples — this is allowed (non-public)
+- Using real public IPs when documentation addresses would work just as well
+- Adding suppression markers around content that only has private (RFC 1918) addresses — unnecessary

--- a/.github/instructions/rst-linter.instructions.md
+++ b/.github/instructions/rst-linter.instructions.md
@@ -39,7 +39,7 @@ The linter rejects public IP addresses that are not reserved for documentation.
 
 ### Line Length Rules
 
-Maximum 80 characters per line. Lines inside `.. code-block::` are still checked by the linter unless suppressed.
+Maximum 80 characters per line. Lines inside `.. code-block::` directives are **exempt** from the line length limit (they render with `<pre>` tags and preserve source formatting).
 
 ### Suppression Syntax
 
@@ -66,6 +66,5 @@ When real public IPs or long lines are unavoidable, wrap the block:
 ### Common Mistakes
 
 - Removing `stop/start_vyoslinter` markers without fixing the underlying issue (exposes the line to the linter and fails CI)
-- Using `0.0.0.0/0` in examples — this is allowed (non-public)
 - Using real public IPs when documentation addresses would work just as well
-- Adding suppression markers around content that only has private (RFC 1918) addresses — unnecessary
+- Adding suppression markers around content that only has private (RFC 1918) addresses or `0.0.0.0/0` — these are allowed and don't need suppression

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,114 @@
+# VyOS Documentation
+
+RST documentation for VyOS, built with Sphinx and hosted on Read the Docs.
+
+## Build
+
+```bash
+# Docker (recommended)
+docker build -t vyos-docs .
+docker run --rm -v "$(pwd)":/docs vyos-docs make html
+
+# Local
+pip install -r requirements.txt
+make html
+```
+
+Output goes to `docs/_build/html/`.
+
+## RST Conventions
+
+### Heading Hierarchy
+
+```rst
+#####
+Title
+#####
+
+********
+Chapters
+********
+
+Sections
+========
+
+Subsections
+-----------
+
+Subsubsections
+^^^^^^^^^^^^^^
+
+Paragraphs
+""""""""""
+```
+
+Every RST file must start with a `#` overline+underline title.
+
+### Formatting Rules
+
+- 80 character line limit (except inside `.. code-block::`)
+- American English
+- Indent with 2 spaces
+- Leave a blank line before and after headers
+- Use double backticks for inline code: `` ``command`` ``
+- Use `.. code-block:: none` for command/output blocks
+
+### Address Space (RFC 5737 / RFC 3849)
+
+The linter enforces documentation-reserved addresses. Use only:
+
+- IPv4: `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`
+- IPv6: `2001:db8::/32`
+- ASN: `64496-64511` (16-bit), `65536-65551` (32-bit)
+- MAC: `00-53-00` to `00-53-FF` (unicast), `90-10-00` to `90-10-FF` (multicast)
+
+**Allowed without suppression:**
+- RFC 1918 private ranges: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+- Link-local, loopback, and other non-public ranges
+
+**Requires `stop/start_vyoslinter`:**
+- Real public IPs when needed for authenticity (e.g., `8.8.8.8` in DNS examples)
+- NAT64 well-known prefix `64:ff9b::/96`
+- Long URLs or certificate fingerprints that exceed 80 chars
+
+### Linter Suppression
+
+```rst
+.. stop_vyoslinter
+
+.. code-block:: none
+
+   content with real IPs or long lines here
+
+.. start_vyoslinter
+```
+
+Place markers immediately before/after the block they suppress. Always re-enable with `start_vyoslinter`.
+
+### VyOS-Specific Directives
+
+- `.. cfgcmd::` — configuration mode commands
+- `.. opcmd::` — operational mode commands
+- `.. cmdinclude::` — include command definitions from XML
+
+### Page Structure
+
+Each configuration page should contain:
+
+1. **Theory** — what it is, when to use it, relevant RFCs
+2. **Configuration** — all CLI options with `.. cfgcmd::` directives
+3. **Examples** — practical configurations with topology diagrams
+4. **Known issues** — problems and workarounds
+5. **Debugging** — log collection, `show` commands, state indicators
+
+## CI
+
+- **Linter** (`doc-linter.py` from `vyos/.github`): checks line length and IP addresses on changed files only
+- **Sphinx build**: runs on Read the Docs for each PR
+- **CLA check**: contributors must sign the CLA
+
+## Git Workflow
+
+- Base branch: `current`
+- Branch naming: `fix/docs-*`, `feat/docs-*`
+- PRs target `current` branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,14 @@ RST documentation for VyOS, built with Sphinx and hosted on Read the Docs.
 
 ```bash
 # Docker (recommended)
-docker build -t vyos-docs .
-docker run --rm -v "$(pwd)":/docs vyos-docs make html
+docker build -t vyos/vyos-documentation docker
+docker run --rm -it -v "$(pwd)":/vyos -w /vyos/docs \
+  -e GOSU_UID=$(id -u) -e GOSU_GID=$(id -g) \
+  vyos/vyos-documentation make html
 
-# Local
+# Local (run from docs/ directory)
 pip install -r requirements.txt
-make html
+cd docs && make html
 ```
 
 Output goes to `docs/_build/html/`.
@@ -50,10 +52,12 @@ Every RST file must start with a `#` overline+underline title.
 - American English
 - Indent with 2 spaces
 - Leave a blank line before and after headers
-- Use double backticks for inline code: `` ``command`` ``
+- Use double backticks for inline code (RST syntax: ````command````)
 - Use `.. code-block:: none` for command/output blocks
 
-### Address Space (RFC 5737 / RFC 3849)
+### Address Space
+
+See `docs/documentation.rst` for canonical rules. Per RFC 5737, RFC 3849, RFC 5389, and RFC 7042:
 
 The linter enforces documentation-reserved addresses. Use only:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Every RST file must start with a `#` overline+underline title.
 - American English
 - Indent with 2 spaces
 - Leave a blank line before and after headers
-- Use double backticks for inline code (RST syntax: ````command````)
+- Use double backticks for inline code: ``` ``command`` ```
 - Use `.. code-block:: none` for command/output blocks
 
 ### Address Space


### PR DESCRIPTION
## Summary
- Add CLAUDE.md with project conventions (RST heading hierarchy, address space rules, linter suppression, build commands, page structure)
- Add .github/copilot-instructions.md for repo-wide Copilot context
- Add .github/instructions/rst-linter.instructions.md with path-specific linter rules for RST files — documents allowed/blocked IP ranges, suppression syntax, and common mistakes

These files give AI code review tools (Copilot, Claude) awareness of the project RST linter rules so they stop flagging RFC 1918 private addresses or suggesting removal of necessary stop/start_vyoslinter markers.

## Test plan
- [x] No impact on Sphinx build
- [x] Linter ignores non-RST files (markdown instructions)