### PR TITLE
ci: fix CLAUDE.md wording and add Copilot false positives list

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,3 +66,15 @@ Ansible playbook examples in `.. code-block::` use RST indentation (typically 4 
 ### Page Structure
 
 Configuration pages follow this order: Theory, Configuration (cfgcmd), Examples, Known Issues, Debugging.
+
+### Known False Positives
+
+Do **not** flag the following — they have been verified as correct or intentional:
+
+- **Markdown tables rendering with `||`**: Diff views may show table pipes as double-pipes. Check the raw source file before flagging.
+- **`stop/start_vyoslinter` at column 0 inside directives**: This is one of two accepted patterns. The other is indented markers matching the directive. Both are valid.
+- **RFC 1918 addresses without linter suppression**: Private IPs (`10.x`, `172.16.x`, `192.168.x`) are allowed. Do not suggest adding `stop/start_vyoslinter` around them.
+- **Long lines inside `.. code-block::`**: Code blocks are exempt from the 80-character line limit.
+- **Pre-existing typos or grammar issues in unchanged lines**: Only flag issues introduced by the current PR's diff. If a typo exists on an unchanged line, it is out of scope.
+- **Ansible YAML indentation in RST code blocks**: YAML inside `.. code-block::` is indented relative to the directive, not column 0. Verify from the code-block's indentation base before flagging as invalid.
+- **Adding `.. TODO::` while removing others**: Tracking TODOs on pages needing `cfgcmd` conversion is intentional. Removing stale TODOs on completed pages is also intentional. Both can happen in the same PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ docker run --rm -it -v "$(pwd)":/vyos -w /vyos/docs \
   -e GOSU_UID=$(id -u) -e GOSU_GID=$(id -g) \
   vyos/vyos-documentation make html
 
-# Local (run from docs/ directory)
+# Local
 pip install -r requirements.txt
 cd docs && make html
 ```
@@ -44,7 +44,7 @@ Paragraphs
 """"""""""
 ```
 
-Every RST file must start with a `#` overline+underline title.
+The first heading in every RST file must use `#` overline+underline. Files may have field lists (e.g., `:lastproofread:`) or labels before the heading.
 
 ### Formatting Rules
 


### PR DESCRIPTION
## Summary
Follow-up to #1830 — changes that landed after the squash merge:

- **CLAUDE.md**: Remove misleading local build note, clarify heading rule allows field lists before first heading
- **copilot-instructions.md**: Add 'Known False Positives' section documenting 7 verified patterns from automated reviews (table rendering artifacts, column-0 markers, RFC 1918 addresses, code-block line length, pre-existing issues, YAML indentation, TODO additions)

## Test plan
- [x] No impact on Sphinx build or linter