### PR TITLE
feat: LLM documentation adaptation (llms.txt, sitemap, robots.txt)

### DIFF
--- a/docs/_html_extra/llms.txt
+++ b/docs/_html_extra/llms.txt
@@ -1,0 +1,52 @@
+# VyOS
+
+> VyOS is a free, open-source network operating system based on Debian GNU/Linux.
+> It provides routing, firewall, and VPN functionality via a unified CLI using
+> `set`/`delete`/`show` command hierarchy. Current rolling release is 1.5.x (circinus).
+
+VyOS configuration follows a tree structure. All configuration commands start with
+`set` (to add/change) or `delete` (to remove). Changes are staged and applied with
+`commit`. The CLI hierarchy maps directly to the documentation structure.
+
+## Quick Start
+
+- [Quick Start Guide](https://docs.vyos.io/en/latest/quick-start.html): Minimal setup walkthrough
+- [CLI Overview](https://docs.vyos.io/en/latest/cli.html): Command-line interface usage
+
+## Configuration
+
+- [Firewall](https://docs.vyos.io/en/latest/configuration/firewall/index.html): Zone-based firewall, rules, groups
+- [Interfaces](https://docs.vyos.io/en/latest/configuration/interfaces/index.html): Ethernet, bonding, bridge, VLAN, tunnel, wireless
+- [Protocols](https://docs.vyos.io/en/latest/configuration/protocols/index.html): BGP, OSPF, IS-IS, static routing, MPLS
+- [VPN](https://docs.vyos.io/en/latest/configuration/vpn/index.html): IPsec, OpenVPN, WireGuard, L2TP, PPTP
+- [NAT](https://docs.vyos.io/en/latest/configuration/nat/index.html): Source NAT, destination NAT, NAT66
+- [System](https://docs.vyos.io/en/latest/configuration/system/index.html): DNS, NTP, syslog, users, task scheduler
+- [High Availability](https://docs.vyos.io/en/latest/configuration/highavailability/index.html): VRRP
+- [Load Balancing](https://docs.vyos.io/en/latest/configuration/loadbalancing/index.html): WAN and reverse proxy
+- [Containers](https://docs.vyos.io/en/latest/configuration/container/index.html): Podman-based container support
+- [PKI](https://docs.vyos.io/en/latest/configuration/pki/index.html): Certificate management
+- [Policy](https://docs.vyos.io/en/latest/configuration/policy/index.html): Route maps, prefix lists, access lists
+- [Traffic Policy](https://docs.vyos.io/en/latest/configuration/trafficpolicy/index.html): QoS and shaping
+- [Service](https://docs.vyos.io/en/latest/configuration/service/index.html): DHCP, DNS forwarding, SNMP, SSH, HTTPS API
+- [VRF](https://docs.vyos.io/en/latest/configuration/vrf/index.html): Virtual routing and forwarding
+
+## Operations
+
+- [Operational Commands](https://docs.vyos.io/en/latest/operation/index.html): Show, monitor, restart commands
+
+## Installation
+
+- [Installation Guide](https://docs.vyos.io/en/latest/installation/index.html): Bare metal, virtual, cloud deployments
+
+## Automation
+
+- [Automation](https://docs.vyos.io/en/latest/automation/index.html): Ansible, Terraform, HTTP API, NETCONF
+
+## Configuration Examples
+
+- [Blueprints](https://docs.vyos.io/en/latest/configexamples/index.html): Real-world topology examples
+
+## Optional
+
+- [Contributing](https://docs.vyos.io/en/latest/contributing/index.html): Development workflow
+- [VPP](https://docs.vyos.io/en/latest/vpp/index.html): Vector Packet Processing integration

--- a/docs/_html_extra/robots.txt
+++ b/docs/_html_extra/robots.txt
@@ -1,7 +1,36 @@
-User-agent: atlassian-bot
-Disallow: 
-
 User-agent: *
-Disallow: # Allow everything
+Allow: /
+
+# AI Training Crawlers
+User-agent: GPTBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+# AI Search/Retrieval
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
 
 Sitemap: https://docs.vyos.io/sitemap.xml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,9 @@ extensions = ['sphinx.ext.intersphinx',
               'autosectionlabel',
               'myst_parser',
               'sphinx_design',
-              'vyos'
+              'vyos',
+              'sphinx_llms_txt',
+              'sphinx_sitemap',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -110,6 +112,8 @@ html_theme = "sphinx_rtd_theme"
 html_static_path = ['_static']
 
 html_extra_path = ['_html_extra']
+
+html_baseurl = 'https://docs.vyos.io/en/latest/'
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,6 +115,13 @@ html_extra_path = ['_html_extra']
 
 html_baseurl = 'https://docs.vyos.io/en/latest/'
 
+# sphinx-sitemap: baseurl already includes /en/latest/, so skip lang+version
+sitemap_url_scheme = '{link}'
+
+# sphinx-llms-txt: disable auto-generated llms.txt, keep curated one from
+# _html_extra; llms-full.txt is still auto-generated
+llms_txt_file = False
+
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ sphinx-notfound-page==1.0.0
 lxml==5.1.0
 myst-parser==2.0.0
 sphinx_design==0.5.0
+sphinx-llms-txt==0.7.1
+sphinx-sitemap==2.9.0


### PR DESCRIPTION
## Summary

- Add `sphinx-llms-txt` and `sphinx-sitemap` extensions to the Sphinx build pipeline
- Create curated `llms.txt` entry point for LLM discovery at site root
- Auto-generate `llms-full.txt` with full documentation content (64k+ lines)
- Auto-generate `sitemap.xml` with 257 page URLs
- Update `robots.txt` with explicit `Allow: /` for AI training crawlers (GPTBot, ClaudeBot, Google-Extended, CCBot, PerplexityBot) and AI search bots (ChatGPT-User, Claude-SearchBot, OAI-SearchBot, Perplexity-User)

## Build outputs

| File | Source |
|------|--------|
| `llms.txt` | Hand-curated, copied from `_html_extra/` |
| `llms-full.txt` | Auto-generated by `sphinx-llms-txt` |
| `robots.txt` | Hand-maintained, copied from `_html_extra/` |
| `sitemap.xml` | Auto-generated by `sphinx-sitemap` |

## Notes

- `llms_txt_file = False` in conf.py — disables auto-generated `llms.txt` so the curated version from `_html_extra/` is preserved
- `sitemap_url_scheme = '{link}'` — prevents doubled `lang/version` path segments since `html_baseurl` already includes `/en/latest/`

Jira: MT-939 (epic: MT-922)

## Test plan

- [ ] Sphinx build completes without new errors
- [ ] `llms.txt` in build output starts with `# VyOS` (curated content)
- [ ] `llms-full.txt` exists and contains full documentation
- [ ] `sitemap.xml` URLs match `https://docs.vyos.io/en/latest/<page>.html`
- [ ] `robots.txt` contains AI bot allowances

🤖 Generated with [Claude Code](https://claude.com/claude-code)