### PR TITLE
fix: coverage page table CSS regression in MyST build

### DIFF
--- a/docs/_static/css/coverage.css
+++ b/docs/_static/css/coverage.css
@@ -1,0 +1,13 @@
+/*
+ * Coverage page table CSS fix for MyST build.
+ *
+ * Problem: After RST-to-MyST migration (PR #1838), the auto-generated
+ * coverage page renders table rows at ~2x height compared to the RST build.
+ * The testcoverage.py extension generates docutils table nodes which pick up
+ * different CSS in the MyST build context.
+ *
+ * TODO: Identify the specific selector causing excess row padding and add
+ * the override here. Compare computed styles on:
+ *   Reference: https://docs.vyos.io/en/latest/coverage.html
+ *   MyST:      https://vyos--1838.org.readthedocs.build/en/1838/coverage.html
+ */


### PR DESCRIPTION
## Problem

After the RST-to-MyST migration (PR #1838), the auto-generated coverage page (`/en/latest/coverage.html`) has a visual CSS regression: table rows are significantly taller than in the RST build, causing the page to render at roughly 2x the height.

**Reference (RST build on docs.vyos.io):** Compact table rows, small cell padding.
**MyST build (PR #1838 preview):** Tall table rows with excessive padding, page is much longer.

This is a styling/CSS difference, not a content error — all commands are correctly listed.

## Root cause (to investigate)

The coverage page is generated by the `testcoverage.py` Sphinx extension. The table structure or CSS classes applied in the MyST build may differ from the RST build. Possible causes:

- MyST Markdown pipe tables render with different CSS than RST list-tables in the generated output
- The `testcoverage.py` extension emits raw RST/docutils nodes that get styled differently in the MyST build context
- A custom CSS rule that applied to RST-generated tables does not apply in the MyST build

## To fix

1. Identify which CSS class/rule controls the table row height on the coverage page
2. Add a targeted CSS override in `docs/_static/` or adjust the extension output
3. Verify the coverage page matches the reference after fix

## Context

- Known, explained diff from the migration visual scan — not blocking PR #1838
- Tracked separately so the migration PR can proceed to review
- Related: PR #1838 (RST-to-MyST migration)
