### PR TITLE
fix: paragraph merges, :opcmd: role, :defaultvalue: placement (DOM diff findings)

### DIFF
--- a/docs/_include/interface-description.txt
+++ b/docs/_include/interface-description.txt
@@ -4,7 +4,7 @@
 
 **Configure a clear, descriptive alias for the interface.** 
 
-This alias appears in the :opcmd:`show interfaces` command and SNMP-based 
+This alias appears in the {opcmd}`show interfaces` command and SNMP-based
 monitoring tools.
 
 Example:

--- a/docs/configuration/interfaces/vti.md
+++ b/docs/configuration/interfaces/vti.md
@@ -75,7 +75,9 @@ Show the operational status and traffic statistics for the specified VTI.
 ```
 
 ## Example
+
 **Configure a VTI**
+
 Assign IPv4 and IPv6 addresses to the VTI, along with a brief description:
 
 ```none

--- a/docs/configuration/interfaces/wireguard.md
+++ b/docs/configuration/interfaces/wireguard.md
@@ -129,16 +129,21 @@ prefix, the generated key is automatically assigned to the specified peer.
 ## Interface configuration
 The next step is to configure your local WireGuard interface and define the
 networks you want to tunnel (`allowed-ips`).
+
 If your system only initiates connections, specifying the listen port is
 optional. If your system accepts incoming connections, you must define a port
 for peers to connect to. Otherwise, WireGuard selects a random port at each
 reboot, and that may break your peers' ability to connect if that port is not enabled in your firewall rules.
+
 To configure a WireGuard tunnel, you also need your peer's public key.
+
 :::{note}
 The public key specified in the peer configuration block is always
 the **remote** peer's public key, never your local one.
 :::
+
 **Local side configuration**
+
 The local side is configured with the following parameters:
 - Local WireGuard interface IP: `10.1.0.1/30`
 - Local listen port: `51820`

--- a/docs/configuration/service/lldp.md
+++ b/docs/configuration/service/lldp.md
@@ -52,8 +52,10 @@ say ``all`` here so LLDP is turned on on every interface.
 ```{cfgcmd} set service lldp interface \<interface\> mode [disable|rx-tx|rx|tx]
 
 Configure the administrative status of the given port.
+
 By default, all ports are configured to be in rx-tx mode. This means they
 can receive and transmit LLDP frames.
+
 In rx mode, they won't emit any frames. In tx mode, they won't receive
 any frames. In disabled mode, no frame will be sent and any incoming frame
 will be discarded.

--- a/docs/configuration/service/ssh.md
+++ b/docs/configuration/service/ssh.md
@@ -283,6 +283,7 @@ public key will change.
 
 Re-generated a known pub/private keyfile which can be used to connect to
 other services (e.g. RPKI cache).
+
 Example:
 
 :::{code-block} none
@@ -311,10 +312,12 @@ will be created.
 ```
 ```{opcmd} generate public-key-command user \<username\> path \<location\>
 
- Generate the configuration mode commands to add a public key for
- {ref}`ssh_key_based_authentication`.
- ``<location>`` can be a local path or a URL pointing at a remote file.
- Supported remote protocols are FTP, FTPS, HTTP, HTTPS, SCP/SFTP and TFTP.
+Generate the configuration mode commands to add a public key for
+{ref}`ssh_key_based_authentication`.
+``<location>`` can be a local path or a URL pointing at a remote file.
+
+Supported remote protocols are FTP, FTPS, HTTP, HTTPS, SCP/SFTP and TFTP.
+
 Example:
 
 :::{code-block} none

--- a/docs/configuration/system/syslog.md
+++ b/docs/configuration/system/syslog.md
@@ -58,6 +58,7 @@ Configure which log messages to save to a local log file.
 
 **Configure syslog to save log messages for a specific facility and
 severity level to ``/var/log/messages``.**
+
 Refer to the tables below for valid facility and severity options.
 ```
 
@@ -70,6 +71,7 @@ Configure which log messages to send to `/dev/console`.
 
 **Configure syslog to send log messages for a specific facility and severity
 level to the device's console.**
+
 Refer to the tables below for valid facility and severity options.
 ```
 
@@ -86,14 +88,17 @@ to multiple hosts.
 
 **Configure log transmission to the remote syslog server for a specific
 facility and severity level.**
+
 The server’s address can be specified using either a {abbr}`FQDN (Fully
 Qualified Domain Name)` or an IP address.
+
 Refer to the tables below for valid facility and severity options.
 ```
 
 ```{cfgcmd} set system syslog remote \<address\> protocol \<udp | tcp\>
 
 **Configure the protocol for log transmission.**
+
 The protocol can be either UDP or TCP. By default, log messages are sent
 over UDP.
 ```
@@ -101,17 +106,20 @@ over UDP.
 ```{cfgcmd} set system syslog remote \<address\> port \<port\>
 
 **Configure the port for log transmission.**
+
 By default, the standard port 514 is used.
 ```
 
 ```{cfgcmd} set system syslog remote \<address\> format include-timezone
 
 **Configure log transmission in the RFC 5424 format.**
+
 The RFC 5424 format includes the timezone in the timestamp. For example:
 
 :::{code-block} none
 <34>1 2003-10-11T22:14:15.003-07:00 mymachine.example.com su - ID47 - BOM’su root’ failed for lonvick on /dev/pts/8.
 :::
+
 By default, log messages are sent in the RFC 3164 format. For example:
 
 :::{code-block} none
@@ -122,8 +130,10 @@ By default, log messages are sent in the RFC 3164 format. For example:
 ```{cfgcmd} set system syslog remote \<address\> format octet-counted
 
 **Enable octet-counted framing for log transmission.**
+
 When enabled, multi-line log messages are sent without splitting. Ensure
 the remote server supports octet-counted framing to avoid parsing errors.
+
 Octet-counted framing is not available for the UDP protocol.
 ```
 
@@ -176,6 +186,7 @@ authentication modes except ``anon``.
 ```{cfgcmd} set system syslog remote \<address\> tls certificate \<cert_name\>
 
 **Configure the client certificate.**
+
 The remote syslog server uses the client certificate to verify the identity
 of the syslog client.
 
@@ -187,6 +198,7 @@ client certificate verification.
 ```{cfgcmd} set system syslog remote \<address\> tls auth-mode \<anon | fingerprint | certvalid | name\>
 
 **Configure the authentication mode.**
+
 The authentication mode defines how the syslog client verifies the syslog
 server's identity.
 
@@ -218,6 +230,7 @@ The following authentication modes are available:
 ```{cfgcmd} set system syslog remote \<address\> tls permitted-peer \<peer\>
 
 **Configure the peer certificate identifiers.**
+
 The certificate identifier format depends on the authentication mode:
 * ``fingerprint``: Enter the expected certificate fingerprints (SHA-1 or
   SHA-256).
@@ -325,6 +338,7 @@ tools, rather than strict directives.
 ```{opcmd} show log [all | authorization | cluster | conntrack-sync | ...]
 
 **Display logs for a specific category on the console.**
+
 Use tab completion to view a list of available categories.
 
 If no category is specified, all logs are shown.
@@ -334,6 +348,7 @@ If no category is specified, all logs are shown.
 ```{opcmd} show log image \<name\> [all | authorization | directory | file \<file name\> | tail \<lines\>]
 
 **Display logs for a specific image on the console.**
+
 Available log categories:
 - ``all`` — Displays the contents of system log files of the specified image.
 - ``authorization`` — Displays authorization attempts of the specified image.

--- a/docs/configuration/system/watchdog.md
+++ b/docs/configuration/system/watchdog.md
@@ -20,6 +20,7 @@ tree. The presence of the `system watchdog` node enables the watchdog feature.
 ```{cfgcmd} set system watchdog
 
 Enable watchdog support.
+
 The watchdog is enabled only when a watchdog device is available as
 ``/dev/watchdog0``.
 
@@ -71,10 +72,10 @@ set system watchdog module softdog
 ```
 
 ```{cfgcmd} set system watchdog timeout \<seconds\>
-
 :defaultvalue:
 
 Set the watchdog timeout for normal runtime operation in seconds.
+
 Valid range: 1-65535 seconds
 
 :::{note}
@@ -82,9 +83,11 @@ Some watchdog drivers expose minimum and maximum supported runtime
  timeouts via sysfs. When available, VyOS validates ``timeout`` against
  those driver limits during commit.
 :::
+
 This is the interval during which the system must respond to the watchdog.
 If the system does not respond within this time, the watchdog will trigger
 a reboot.
+
 Example:
 
 :::{code-block} none
@@ -93,11 +96,12 @@ set system watchdog timeout 30
 ```
 
 ```{cfgcmd} set system watchdog shutdown-timeout \<seconds\>
-
 :defaultvalue:
 
 Set the watchdog timeout during system shutdown in seconds.
+
 Valid range: 60-65535 seconds
+
 This extended timeout allows the system to complete a graceful shutdown
 without triggering the watchdog.
 
@@ -115,11 +119,12 @@ set system watchdog shutdown-timeout 180
 ```
 
 ```{cfgcmd} set system watchdog reboot-timeout \<seconds\>
-
 :defaultvalue:
 
 Set the watchdog timeout during system reboot in seconds.
+
 Valid range: 60-65535 seconds
+
 This extended timeout allows the system to complete the reboot process
 without triggering the watchdog during the transition.
 


### PR DESCRIPTION
## Summary

Fixes found by running a DOM text diff (Playwright) against docs.vyos.io reference vs PR #1838 preview.

- **`interface-description.txt`**: `:opcmd:` → `{opcmd}` role — template rendered `show interfaces` as literal `:opcmd:show interfaces` text instead of a styled link; affects all interface pages that include this template (~10 pages)
- **`watchdog.md`**: `:defaultvalue:` moved before first blank line so it is picked up in `title_text` by the Sphinx extension and renders in the panel header, not as a `<dt>` element in the body
- **`wireguard.md`, `vti.md`, `lldp.md`, `ssh.md`, `syslog.md`, `watchdog.md`**: added missing blank lines between paragraphs in cfgcmd/opcmd bodies that were merged into single paragraphs during rst-to-myst conversion

🤖 Generated by [robots](https://vyos.io)