### PR TITLE
fix: paragraph merges and :defaultvalue: in watchdog, conntrack, igmp-proxy, bfd, cgnat

### DIFF
--- a/docs/configuration/protocols/bfd.md
+++ b/docs/configuration/protocols/bfd.md
@@ -65,6 +65,7 @@ Disable a BFD peer
 
 For multi hop sessions only. Configure the minimum expected TTL for an
 incoming BFD control packet.
+
 This feature serves the purpose of thightening the packet validation
 requirements to avoid receiving BFD control packets from other sessions.
 ```

--- a/docs/configuration/protocols/igmp-proxy.md
+++ b/docs/configuration/protocols/igmp-proxy.md
@@ -31,8 +31,10 @@ must be on the following format 'a.b.c.d/n'. By default, the router will
 accept data from sources on the same network as configured on an interface.
 If the multicast source lies on a remote network, one must define from where
 traffic should be accepted.
+
 This is especially useful for the upstream interface, since the source for
 multicast traffic is often from a remote location.
+
 This option can be supplied multiple times.
 ```
 
@@ -43,8 +45,10 @@ message upstream as soon as it receives a Leave message for any downstream
 interface. The daemon will not ask for Membership reports on the downstream
 interfaces, and if a report is received the group is not joined again the
 upstream.
+
 If it's vital that the daemon should act exactly like a real multicast client
 on the upstream interface, this function should be enabled.
+
 Enabling this function increases the risk of bandwidth saturation.
 ```
 

--- a/docs/configuration/system/conntrack.md
+++ b/docs/configuration/system/conntrack.md
@@ -7,16 +7,14 @@ stateful firewall or NAT is configured.
 ## Configure
 
 ```{cfgcmd} set system conntrack table-size \<1-50000000\>
-
- :defaultvalue:
+:defaultvalue:
 
 The connection tracking table contains one entry for each connection being
 tracked by the system.
 ```
 
 ```{cfgcmd} set system conntrack expect-table-size \<1-50000000\>
-
- :defaultvalue:
+:defaultvalue:
 
 The connection tracking expect table contains one entry for each expected
 connection related to an existing connection. These are generally used by
@@ -25,8 +23,7 @@ The default size of the expect table is 2048 entries.
 ```
 
 ```{cfgcmd} set system conntrack hash-size \<1-50000000\>
-
- :defaultvalue:
+:defaultvalue:
 
 Set the size of the hash table. The connection tracking hash table makes
 searching the connection tracking table faster. The hash table uses
@@ -60,22 +57,19 @@ All modules are enable by default.
 ```
 
 ```{cfgcmd} set system conntrack tcp half-open-connections \<1-21474836\>
-
- :defaultvalue:
+:defaultvalue:
 
 Set the maximum number of TCP half-open connections.
 ```
 
 ```{cfgcmd} set system conntrack tcp loose \<enable | disable\>
-
- :defaultvalue:
+:defaultvalue:
 
 Policy to track previously established connections.
 ```
 
 ```{cfgcmd} set system conntrack tcp max-retrans \<1-2147483647\>
-
- :defaultvalue:
+:defaultvalue:
 
 Set the number of TCP maximum retransmit attempts.
 ```

--- a/docs/configuration/system/watchdog.md
+++ b/docs/configuration/system/watchdog.md
@@ -36,12 +36,15 @@ created, VyOS will emit a warning and will not enable the systemd watchdog.
 ```{cfgcmd} set system watchdog module \<module-name\>
 
 Specify the kernel watchdog driver module to load for ``/dev/watchdog0``.
+
 The configured module must be a watchdog driver module, not an arbitrary
 kernel module.
+
 **In most cases, this option is not required** as the kernel will
 automatically load the appropriate watchdog driver for your system. Use this
 option if the kernel fails to load the required driver, or when you want to
 use the software watchdog (``softdog``).
+
 Common modules include:
 * ``softdog`` - Software watchdog timer (available on all systems)
 * ``iTCO_wdt`` - Intel TCO watchdog timer
@@ -54,9 +57,11 @@ Common modules include:
  kernel timers and therefore depends on the Linux kernel continuing to run.
  In some fault conditions (for example, a kernel hang), ``softdog`` may not
  be able to trigger a reset.
+
  Prefer a hardware watchdog driver whenever possible, as hardware watchdogs
  can operate independently of the operating system.
 :::
+
 If no module is specified, VyOS will use an existing ``/dev/watchdog0``
 device if available.
 

--- a/docs/vpp/configuration/nat/cgnat.md
+++ b/docs/vpp/configuration/nat/cgnat.md
@@ -25,6 +25,7 @@ addresses to public IP addresses.
 **Enabling CGNAT** on an interface (both inside and outside)
 **disables normal routing** on these interfaces and **blocks management
 access** to the VyOS router itself.
+
 Ensure you have an alternative management path to the router before applying
 your CGNAT configuration.
 :::


### PR DESCRIPTION
DOM diff batch 2 fixes — paragraph merges and :defaultvalue: placement.

🤖 Generated by [robots](https://vyos.io)