### PR TITLE
fix: paragraph merges, linter markers, and RST syntax (batch 3)

### DIFF
--- a/docs/configuration/firewall/ipv6.md
+++ b/docs/configuration/firewall/ipv6.md
@@ -556,15 +556,13 @@ set firewall ipv6 name FOO rule 100 source address 2001:db8::202
 Apply an arbitrary netmask to mask addresses and match only a specific
 portion. This is useful for IPv6 because rules remain valid when the IPv6
 prefix changes if the host portion of the system's IPv6 address is static.
-Examples include SLAAC and `tokenised IPv6 addresses
-<https://datatracker.ietf.org/doc/id/draft-chown-6man-tokenised-ipv6-
-identifiers-02.txt>`_
+Examples include SLAAC and [tokenised IPv6 addresses](https://datatracker.ietf.org/doc/id/draft-chown-6man-tokenised-ipv6-identifiers-02.txt)
 
 
 This function works for both individual addresses and address groups.
 
 
-.. stop_vyoslinter
+% stop_vyoslinter
 
 :::{code-block} none
 # Match any IPv6 address with the suffix ::0000:0000:0000:beef
@@ -576,7 +574,7 @@ set firewall group ipv6-address-group WEBSERVERS address ::2000
 set firewall ipv6 forward filter rule 200 source group address-group WEBSERVERS
 set firewall ipv6 forward filter rule 200 source address-mask ::ffff:ffff:ffff:ffff
 :::
-.. start_vyoslinter
+% start_vyoslinter
 ```
 
 
@@ -680,9 +678,8 @@ Ensure that the router can resolve the DNS query.
 
 
 Match IP addresses based on their geolocation. For more information, see
-`GeoIP matching <https://wiki.nftables.org/wiki-nftables/index.php/GeoIP_
-matching>`_. Use inverse-match to match anything except the specified
-country codes.
+[GeoIP matching](https://wiki.nftables.org/wiki-nftables/index.php/GeoIP_matching).
+Use inverse-match to match anything except the specified country codes.
 ```
 DB-IP.com provides data under CC-BY-4.0 license. Attribution is required and
 redistribution is permitted, allowing VyOS to include a database in images

--- a/docs/configuration/policy/extcommunity-list.md
+++ b/docs/configuration/policy/extcommunity-list.md
@@ -9,7 +9,7 @@ manipulation: **extcommunity-list** is one of them.
 
 ```{cfgcmd} set policy extcommunity-list \<text\>
 
-Creat extcommunity-list policy identified by name <text>.
+Creat extcommunity-list policy identified by name `<text>`.
 ```
 ```{cfgcmd} set policy extcommunity-list \<text\> description \<text\>
 
@@ -27,7 +27,7 @@ Set description for rule.
 
 Regular expression to match against an extended community list, where text
 could be:
-* <aa:nn:nn>: Extended community list regular expression.
-* <rt aa:nn:nn>: Route Target regular expression.
-* <soo aa:nn:nn>: Site of Origin regular expression.
+* `<aa:nn:nn>`: Extended community list regular expression.
+* `<rt aa:nn:nn>`: Route Target regular expression.
+* `<soo aa:nn:nn>`: Site of Origin regular expression.
 ```

--- a/docs/configuration/protocols/bfd.md
+++ b/docs/configuration/protocols/bfd.md
@@ -65,6 +65,7 @@ Disable a BFD peer
 
 For multi hop sessions only. Configure the minimum expected TTL for an
 incoming BFD control packet.
+
 This feature serves the purpose of thightening the packet validation
 requirements to avoid receiving BFD control packets from other sessions.
 ```

--- a/docs/configuration/protocols/igmp-proxy.md
+++ b/docs/configuration/protocols/igmp-proxy.md
@@ -31,8 +31,10 @@ must be on the following format 'a.b.c.d/n'. By default, the router will
 accept data from sources on the same network as configured on an interface.
 If the multicast source lies on a remote network, one must define from where
 traffic should be accepted.
+
 This is especially useful for the upstream interface, since the source for
 multicast traffic is often from a remote location.
+
 This option can be supplied multiple times.
 ```
 
@@ -43,8 +45,10 @@ message upstream as soon as it receives a Leave message for any downstream
 interface. The daemon will not ask for Membership reports on the downstream
 interfaces, and if a report is received the group is not joined again the
 upstream.
+
 If it's vital that the daemon should act exactly like a real multicast client
 on the upstream interface, this function should be enabled.
+
 Enabling this function increases the risk of bandwidth saturation.
 ```
 

--- a/docs/configuration/system/conntrack.md
+++ b/docs/configuration/system/conntrack.md
@@ -7,16 +7,14 @@ stateful firewall or NAT is configured.
 ## Configure
 
 ```{cfgcmd} set system conntrack table-size \<1-50000000\>
-
- :defaultvalue:
+:defaultvalue:
 
 The connection tracking table contains one entry for each connection being
 tracked by the system.
 ```
 
 ```{cfgcmd} set system conntrack expect-table-size \<1-50000000\>
-
- :defaultvalue:
+:defaultvalue:
 
 The connection tracking expect table contains one entry for each expected
 connection related to an existing connection. These are generally used by
@@ -25,8 +23,7 @@ The default size of the expect table is 2048 entries.
 ```
 
 ```{cfgcmd} set system conntrack hash-size \<1-50000000\>
-
- :defaultvalue:
+:defaultvalue:
 
 Set the size of the hash table. The connection tracking hash table makes
 searching the connection tracking table faster. The hash table uses
@@ -60,22 +57,19 @@ All modules are enable by default.
 ```
 
 ```{cfgcmd} set system conntrack tcp half-open-connections \<1-21474836\>
-
- :defaultvalue:
+:defaultvalue:
 
 Set the maximum number of TCP half-open connections.
 ```
 
 ```{cfgcmd} set system conntrack tcp loose \<enable | disable\>
-
- :defaultvalue:
+:defaultvalue:
 
 Policy to track previously established connections.
 ```
 
 ```{cfgcmd} set system conntrack tcp max-retrans \<1-2147483647\>
-
- :defaultvalue:
+:defaultvalue:
 
 Set the number of TCP maximum retransmit attempts.
 ```

--- a/docs/configuration/system/flow-accounting.md
+++ b/docs/configuration/system/flow-accounting.md
@@ -53,6 +53,7 @@ interface, the interface must be configured for flow accounting.
 
 Configure and enable collection of flow information for the interface
 identified by `<interface>`.
+
 You can configure multiple interfaces which would participate in flow
 accounting.
 ```
@@ -133,6 +134,7 @@ packets, where n > 1, allows you to decrease the amount of processing
 resources required for flow accounting. The disadvantage of not sampling
 every packet is that the statistics produced are estimates of actual data
 flows.
+
 Per default every packet is sampled (that is, the sampling rate is 1).
 ```
 
@@ -140,6 +142,7 @@ Per default every packet is sampled (that is, the sampling rate is 1).
 
 Specifies the interval at which Netflow data will be sent to a collector. As
 per default, Netflow data will be sent every 60 seconds.
+
 You may also additionally configure timeouts for different types of
 connections.
 ```
@@ -167,7 +170,7 @@ display captured network traffic information for all configured interfaces.
 
 Show flow accounting information for given `<interface>`.
 
-.. stop_vyoslinter
+% stop_vyoslinter
 
 :::{code-block} none
 vyos@vyos:~$ show flow-accounting interface eth0
@@ -181,7 +184,7 @@ eth0        00:53:01:c8:33:af  ff:ff:ff:ff:ff:ff  192.0.2.3                 255.
 eth0        00:53:01:b2:22:48  00:53:02:58:a2:92  192.0.2.100               192.0.2.14            40006          22  tcp            16        146        1     9444
 eth0        00:53:01:b2:22:48  00:53:02:58:a2:92  192.0.2.100               192.0.2.14                0           0  icmp          192         27        1     4455
 :::
-.. start_vyoslinter
+% start_vyoslinter
 ```
 
 ```{opcmd} show flow-accounting interface \<interface\> host \<address\>
@@ -189,7 +192,7 @@ eth0        00:53:01:b2:22:48  00:53:02:58:a2:92  192.0.2.100               192.
 Show flow accounting information for given `<interface>` for a specific host
 only.
 
-.. stop_vyoslinter
+% stop_vyoslinter
 
 :::{code-block} none
 vyos@vyos:~$ show flow-accounting interface eth0 host 192.0.2.14
@@ -199,5 +202,5 @@ eth0        00:53:01:b2:22:48  00:53:02:58:a2:92  192.0.2.100  192.0.2.14       
 eth0        00:53:01:b2:22:48  00:53:02:58:a2:92  192.0.2.100  192.0.2.14       40152          22  tcp            16         94        1     4924
 eth0        00:53:01:b2:22:48  00:53:02:58:a2:92  192.0.2.100  192.0.2.14           0           0  icmp          192         36        1     5877
 :::
-.. start_vyoslinter
+% start_vyoslinter
 ```

--- a/docs/configuration/system/login.md
+++ b/docs/configuration/system/login.md
@@ -86,6 +86,7 @@ command. This creates two files:
   never be shared.
 - **Public key** (e.g., `id_rsa.pub`): Is used to configure the VyOS user
   account. By default, it is saved to `~/.ssh/id_rsa.pub`.
+
 Each SSH public key consists of three parts, separated by spaces:
 - **Encryption algorithm type:** `ssh-rsa`, `ssh-ed25519`, etc.
 - **Key:** The actual data (a long string beginning with `AAAA...`).
@@ -409,6 +410,7 @@ Unlike {abbr}`RADIUS (Remote Authentication Dial-In User Service)`,
 {abbr}`TACACS+ (Terminal Access Controller Access Control System)` separates
 Authentication, Authorization, and Accounting (AAA) into independent processes
 and encrypts the entire packet body for enhanced security.
+
 {abbr}`TACACS+ (Terminal Access Controller Access Control System)` is defined
 in {rfc}`8907`.
 (tacacs-configuration)=
@@ -530,11 +532,14 @@ login attempts.
 ```{cfgcmd} set system login timeout \<timeout\>
 
 **Configure the login session timeout, in seconds.**
+
 Idle login sessions are terminated after this period.
 ```
 
 ## Configuration examples
+
 Example 1: Multi-key SSH with MFA and source restrictions
+
 In this configuration, `User1` and `User2` both use the vyos user account,
 each with a unique SSH key. `User1` is restricted to authentication from a
 single IP address.

--- a/docs/configuration/system/syslog.md
+++ b/docs/configuration/system/syslog.md
@@ -151,6 +151,7 @@ Configure the source IP address (IPv4 or IPv6) for log transmission.
 #### {abbr}`TLS (Transport Layer Security)`-encrypted remote logging
 VyOS supports {abbr}`TLS (Transport Layer Security)`-encrypted remote logging
 over TCP to ensure secure transmission of syslog data to remote syslog servers.
+
 **Prerequisites**: Before configuring {abbr}`TLS (Transport Layer
 Security)`-encrypted remote logging, ensure you have:
 - A valid remote syslog server address.
@@ -175,6 +176,7 @@ Enable TLS-encrypted remote logging.
 ```{cfgcmd} set system syslog remote \<address\> tls ca-certificate \<ca_name\>
 
 **Configure the** {abbr}`CA (Certificate Authority)` **certificate.**
+
 The syslog client uses the {abbr}`CA (Certificate Authority)` certificate to
 verify the identity of the remote syslog server.
 

--- a/docs/configuration/system/watchdog.md
+++ b/docs/configuration/system/watchdog.md
@@ -36,12 +36,15 @@ created, VyOS will emit a warning and will not enable the systemd watchdog.
 ```{cfgcmd} set system watchdog module \<module-name\>
 
 Specify the kernel watchdog driver module to load for ``/dev/watchdog0``.
+
 The configured module must be a watchdog driver module, not an arbitrary
 kernel module.
+
 **In most cases, this option is not required** as the kernel will
 automatically load the appropriate watchdog driver for your system. Use this
 option if the kernel fails to load the required driver, or when you want to
 use the software watchdog (``softdog``).
+
 Common modules include:
 * ``softdog`` - Software watchdog timer (available on all systems)
 * ``iTCO_wdt`` - Intel TCO watchdog timer
@@ -54,9 +57,11 @@ Common modules include:
  kernel timers and therefore depends on the Linux kernel continuing to run.
  In some fault conditions (for example, a kernel hang), ``softdog`` may not
  be able to trigger a reset.
+
  Prefer a hardware watchdog driver whenever possible, as hardware watchdogs
  can operate independently of the operating system.
 :::
+
 If no module is specified, VyOS will use an existing ``/dev/watchdog0``
 device if available.
 

--- a/docs/configuration/vpn/ipsec/site2site_ipsec.md
+++ b/docs/configuration/vpn/ipsec/site2site_ipsec.md
@@ -194,7 +194,10 @@ Similar combinations are applicable for the dead-peer-detection.
 ```
 
 
-```{cfgcmd} set vpn ipsec authentication psk id \<id\> static ID's for authentication. In general local and remote address ``<x.x.x.x>``, ``<h:h:h:h:h:h:h:h>`` or ``%any``.
+```{cfgcmd} set vpn ipsec authentication psk id \<id\>
+
+Static ID's for authentication. In general local and remote address
+``<x.x.x.x>``, ``<h:h:h:h:h:h:h:h>`` or ``%any``.
 ```
 
 

--- a/docs/operation/raid.md
+++ b/docs/operation/raid.md
@@ -78,7 +78,6 @@ Continue creating array?
 2. To overwrite the old filesystem, enter **Yes**.
 
 3\. The system informs you that all data on both drives will be erased.
-
 Confirm you want to continue.
 
 ```none
@@ -86,7 +85,6 @@ Are you sure you want to do this?
 ```
 
 4\. Enter **Yes** at the prompt to retain the current VyOS configuration.
-
 Enter **No** to delete the current VyOS configuration.
 
 ```none
@@ -94,7 +92,6 @@ Would you like me to save the data on it before I delete it?
 ```
 
 5\. Enter **Yes** at the prompt to retain the current VyOS configuration.
-
 Enter **No** to delete the current VyOS configuration.
 
 6. Continue installing VyOS.
@@ -159,11 +156,14 @@ To replace a bad disk within a RAID 1 set:
 3. Replace the failed drive with a drive of the same size or larger.
 4. Format the new disk for RAID 1 by running the following command:
 
-```{opcmd} format disk \<disk‐device1\> like \<disk‐device2\> ``` where `disk-device1` is the replacement disk. For example, `sdb` and `disk-device2` is the existing healthy disk. For example, `sda`.
+   ```{opcmd} format disk \<disk‐device1\> like \<disk‐device2\>
+   ```
+   where `disk-device1` is the replacement disk. For example, `sdb` and
+   `disk-device2` is the existing healthy disk. For example, `sda`.
 
 5. Add the replacement disk to the RAID 1 set by running the following command:
-```{opcmd} add raid \<RAID‐1‐device\> member \<disk‐partition\>
 
+   ```{opcmd} add raid \<RAID‐1‐device\> member \<disk‐partition\>
    ```
    where `RAID-1-device` is the name of the RAID 1 device. For example,
    `md0` and `disk-partition` is the name of the replacement disk partition.
@@ -189,7 +189,10 @@ RAID 1 set (of which ``disk-device2`` is already a member).
 ```
 
 
-```{opcmd} show raid \<RAID‐1‐device\> shows output for ``show raid md0`` as ``sdb1`` is being added to the RAID 1 set and is in the process of being resynchronized.
+```{opcmd} show raid \<RAID‐1‐device\>
+
+shows output for ``show raid md0`` as ``sdb1`` is being added to the RAID 1
+set and is in the process of being resynchronized.
 
 
 :::{code-block} none

--- a/docs/vpp/configuration/nat/cgnat.md
+++ b/docs/vpp/configuration/nat/cgnat.md
@@ -25,6 +25,7 @@ addresses to public IP addresses.
 **Enabling CGNAT** on an interface (both inside and outside)
 **disables normal routing** on these interfaces and **blocks management
 access** to the VyOS router itself.
+
 Ensure you have an alternative management path to the router before applying
 your CGNAT configuration.
 :::


### PR DESCRIPTION
## Summary

- `flow-accounting`: blank lines between merged paragraphs; `.. stop/start_vyoslinter` → `%` prefix in opcmd bodies
- `firewall/ipv6`: RST hyperlinks → MyST link syntax; `.. stop/start_vyoslinter` → `%` prefix
- `extcommunity-list`: angle-bracket tokens wrapped in backticks to prevent HTML stripping
- `login`: blank lines in TACACS+, timeout, and examples sections; public key list continuation fix
- `syslog`: blank lines in TLS section and CA certificate cfgcmd body
- `site2site_ipsec`: `psk id` description moved from directive header to body
- `raid`: malformed `{opcmd}` directives fixed; numbered item continuation text merged

## Test plan

- [ ] Merge into `feat/rst-to-myst-migration` and wait for ReadTheDocs rebuild
- [ ] Re-run DOM diff on affected pages

🤖 Generated by [robots](https://vyos.io)