### PR TITLE
docs: Fix typos and a few grammar issues (rebased from #1801)

### DIFF
--- a/docs/_static/js/codecopier.js
+++ b/docs/_static/js/codecopier.js
@@ -40,7 +40,7 @@ $(document).ready(async function () {
     try {
       await navigator.clipboard.writeText(currentTarget.offsetParent.innerText)
     } catch (error) {
-      console.log('Copiing text failed, please try again', {
+      console.log('Copying text failed, please try again', {
         error
       })
     }

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -141,7 +141,7 @@ perform by itself at a later point.
 Examples:
 
 -  ``force arp request interface eth1 address 10.3.0.2`` — send a
-   gratuitious ARP request.
+   gratuitous ARP request.
 -  ``force root-partition-auto-resize`` — grow the root filesystem to
    the size of the system partition (this is also done on startup, but
    this command can do it without a reboot).
@@ -149,7 +149,7 @@ Examples:
 execute
 '''''''
 
-"Execute" commands are for executing various diagnostic and auxilliary
+"Execute" commands are for executing various diagnostic and auxiliary
 actions that the system would never perform by itself.
 
 Examples:

--- a/docs/configexamples/autotest/OpenVPN_with_LDAP/OpenVPN_with_LDAP.log
+++ b/docs/configexamples/autotest/OpenVPN_with_LDAP/OpenVPN_with_LDAP.log
@@ -373,7 +373,7 @@ See the timeout setting options in the Network Debug and Troubleshooting Guide.
 2023-05-11 14:39:54,941 p=69617 u=rob n=ansible | [WARNING]: To ensure idempotency and correct diff the input configuration lines should be similar to how they appear if present in the running configuration on device including the indentation
 
 2023-05-11 14:39:54,943 p=69617 u=rob n=ansible | changed: [ovpn-server]
-2023-05-11 14:39:54,954 p=69617 u=rob n=ansible | TASK [eve-ng-lab-test : generate openvpn client conifg] *************************************************************************************************************************************************************************
+2023-05-11 14:39:54,954 p=69617 u=rob n=ansible | TASK [eve-ng-lab-test : generate openvpn client config] *************************************************************************************************************************************************************************
 2023-05-11 14:39:54,977 p=69617 u=rob n=ansible | skipping: [eveng]
 2023-05-11 14:39:54,985 p=69617 u=rob n=ansible | skipping: [vyos-oobm]
 2023-05-11 14:39:54,996 p=69617 u=rob n=ansible | skipping: [client]

--- a/docs/configexamples/fwall-and-bridge.rst
+++ b/docs/configexamples/fwall-and-bridge.rst
@@ -15,7 +15,7 @@ own requirements.
 
 * Bridge br0:
    * Isolated layer 2 bridge.
-   * Accept only IPv6 communication whithin the bridge.
+   * Accept only IPv6 communication within the bridge.
 
 * Bridge br1:
    * Drop all DHCP discover packets.
@@ -47,7 +47,7 @@ First, we need to configure the interfaces and bridges:
 
 .. code-block:: none
 
-  # Brige br0
+  # Bridge br0
   set interfaces bridge br0 description 'Isolated L2 bridge'
   set interfaces bridge br0 member interface eth1
   set interfaces bridge br0 member interface eth2
@@ -218,7 +218,7 @@ And the content of the custom rulesets:
   set firewall bridge name br1-fwd rule 20 action 'accept'
   set firewall bridge name br1-fwd rule 20 source address '10.1.1.102'
   set firewall bridge name br1-fwd rule 20 state 'new'
-    # Drop everythin else within the bridge:
+    # Drop everything else within the bridge:
   set firewall bridge name br1-fwd default-action 'drop'
 
   ### br2 - br2-fwd
@@ -265,7 +265,7 @@ router itself, to other local networks, and to the Internet.
 
 As a reminder, here's a link to the :doc:`firewall documentation
 </configuration/firewall/index>`, where you can find more information about
-the packet flow for traffic that comes from bridge layer and should be analized
+the packet flow for traffic that comes from bridge layer and should be analyzed
 by the IP firewall.
 
 Access to the router itself is controlled by the base chain ``input``, and

--- a/docs/configexamples/inter-vrf-routing-vrf-lite.rst
+++ b/docs/configexamples/inter-vrf-routing-vrf-lite.rst
@@ -128,7 +128,7 @@ in our topology.
    set interface eth eth<N> address <IP ADDRESS/CIDR>
 
    # Static default route back to Core
-   set procotols static route 0.0.0.0/0 next-hop <CORE IP ADDRESS>
+   set protocols static route 0.0.0.0/0 next-hop <CORE IP ADDRESS>
 
 Core Router
 ===========
@@ -832,7 +832,7 @@ the import statement in the vrf we need to filter.
    S>* 172.16.0.0/24 [1/0] via 172.16.2.2, eth1, weight 1, 00:45:32
    C>* 172.16.2.0/30 is directly connected, eth1, 00:45:39
    B>* 192.0.2.0/24 [20/0] via 10.2.2.2, eth3 (vrf Internet), weight 1, 00:45:24
-   B>* 192.168.0.0/24 [20/0] via 192.168.3.2, eth2 (vrf Managment), weight 1, 00:45:27
+   B>* 192.168.0.0/24 [20/0] via 192.168.3.2, eth2 (vrf Management), weight 1, 00:45:27
    B>* 198.51.100.0/24 [20/0] via 10.2.2.2, eth3 (vrf Internet), weight 1, 00:45:24
 
    # show ipv6 route vrf LAN2
@@ -840,7 +840,7 @@ the import statement in the vrf we need to filter.
    C>* 2001:db8::2/127 is directly connected, eth1, 00:46:26
    B>* 2001:db8:0:1::/64 [20/0] via 2001:db8::1, eth0 (vrf LAN1), weight 1, 00:46:17
    S>* 2001:db8:0:2::/64 [1/0] via 2001:db8::3, eth1, weight 1, 00:46:21
-   B>* 2001:db8:0:3::/64 [20/0] via 2001:db8::5, eth2 (vrf Managment), weight 1, 00:46:16
+   B>* 2001:db8:0:3::/64 [20/0] via 2001:db8::5, eth2 (vrf Management), weight 1, 00:46:16
    B>* 2001:db8:1::/48 [20/0] via fe80::5200:ff:fe02:3, eth3 (vrf Internet), weight 1, 00:46:13
    B>* 2001:db8:2::/48 [20/0] via fe80::5200:ff:fe02:3, eth3 (vrf Internet), weight 1, 00:46:13
    C>* fe80::/64 is directly connected, eth1, 00:46:27

--- a/docs/configuration/firewall/bridge.rst
+++ b/docs/configuration/firewall/bridge.rst
@@ -393,7 +393,7 @@ Packet Modifications
 ====================
 
 Starting from **VyOS-1.5-rolling-202410060007**, the firewall can modify
-packets before they are sent out. This feaure provides more flexibility in
+packets before they are sent out. This feature provides more flexibility in
 packet handling.
 
 .. cfgcmd:: set firewall bridge [prerouting | forward | output] filter

--- a/docs/configuration/firewall/ipv4.rst
+++ b/docs/configuration/firewall/ipv4.rst
@@ -1178,7 +1178,7 @@ Rule-set overview
       SUPPORT                  address_group       VyOS_MANAGEMENT-20       192.168.1.2
                                                    WAN_IN-20
       PHONE_VPN_SERVERS        address_group       WAN_IN-160               10.6.32.2
-      PINGABLE_ADRESSES        address_group       WAN_IN-170               192.168.5.2
+      PINGABLE_ADDRESSES        address_group       WAN_IN-170               192.168.5.2
                                                    WAN_IN-171
       PBX                      ipv6_address_group  IPV6-WAN_IN-100          2001:db8::1
       SERVERS                  ipv6_address_group  IPV6-WAN_IN-110          2001:db8::2

--- a/docs/configuration/firewall/ipv6.rst
+++ b/docs/configuration/firewall/ipv6.rst
@@ -1176,7 +1176,7 @@ Rule-set overview
       SUPPORT                  address_group       VyOS_MANAGEMENT-20       192.168.1.2
                                                    WAN_IN-20
       PHONE_VPN_SERVERS        address_group       WAN_IN-160               10.6.32.2
-      PINGABLE_ADRESSES        address_group       WAN_IN-170               192.168.5.2
+      PINGABLE_ADDRESSES        address_group       WAN_IN-170               192.168.5.2
                                                    WAN_IN-171
       PBX                      ipv6_address_group  IPV6-WAN_IN-100          2001:db8::1
       SERVERS                  ipv6_address_group  IPV6-WAN_IN-110          2001:db8::2

--- a/docs/configuration/nat/nat44.rst
+++ b/docs/configuration/nat/nat44.rst
@@ -654,7 +654,7 @@ Load Balance
 ------------
 Here we provide two examples on how to apply NAT Load Balance.
 
-First scenario: apply destination NAT for all HTTP traffic comming through
+First scenario: apply destination NAT for all HTTP traffic coming through
 interface eth0, and user 4 backends. First backend should received 30% of
 the request, second backend should get 20%, third 15% and the fourth 35%
 We will use source and destination address for hash generation.

--- a/docs/configuration/policy/examples.rst
+++ b/docs/configuration/policy/examples.rst
@@ -158,8 +158,8 @@ ISP's and VyOS router will respond from the same interface that the packet was
 received. Also, it used, if we want that one VPN tunnel to be through one
 provider, and the second through another.
 
-* ``203.0.113.254`` IP addreess on VyOS eth1 from ISP1
-* ``192.168.2.254`` IP addreess on VyOS eth2 from ISP2
+* ``203.0.113.254`` IP address on VyOS eth1 from ISP1
+* ``192.168.2.254`` IP address on VyOS eth2 from ISP2
 * ``table 10`` Routing table used for ISP1
 * ``table 11`` Routing table used for ISP2
 

--- a/docs/configuration/policy/route-map.rst
+++ b/docs/configuration/policy/route-map.rst
@@ -2,7 +2,7 @@
 Route Map Policy
 ################
 
-Route map is a powerfull command, that gives network administrators a very
+Route map is a powerful command, that gives network administrators a very
 useful and flexible tool for traffic manipulation.
 
 *************

--- a/docs/configuration/policy/route.rst
+++ b/docs/configuration/policy/route.rst
@@ -168,7 +168,7 @@ And for ipv6:
 .. cfgcmd:: set policy route <name> rule <n> limit burst <0-4294967295>
 .. cfgcmd:: set policy route6 <name> rule <n> limit burst <0-4294967295>
 
-   Set maximum number of packets to alow in excess of rate.
+   Set maximum number of packets to allow in excess of rate.
 
 .. cfgcmd:: set policy route <name> rule <n> limit rate <text>
 .. cfgcmd:: set policy route6 <name> rule <n> limit rate <text>
@@ -256,8 +256,8 @@ And for ipv6:
 Actions
 =======
 
-When mathcing all patterns defined in a rule, then different actions can
-be made. This includes droping the packet, modifying certain data, or
+When matching all patterns defined in a rule, then different actions can
+be made. This includes dropping the packet, modifying certain data, or
 setting a different routing table.
 
 .. cfgcmd:: set policy route <name> rule <n> action drop

--- a/docs/configuration/protocols/bfd.rst
+++ b/docs/configuration/protocols/bfd.rst
@@ -159,7 +159,7 @@ Configuration
    bfd multi-hop source <address> profile <profile>
    
    Configure a static route for <subnet> using gateway <address> 
-   , use source address to indentify the peer when is multi-hop session 
+   , use source address to identify the peer when is multi-hop session
    and the gateway address as BFD peer destination address.
 
 .. cfgcmd::  set protocols static route6 <subnet> next-hop <address> 
@@ -172,7 +172,7 @@ Configuration
    bfd multi-hop source <address> profile <profile>
    
    Configure a static route for <subnet> using gateway <address> 
-   , use source address to indentify the peer when is multi-hop session 
+   , use source address to identify the peer when is multi-hop session
    and the gateway address as BFD peer destination address.
 
 

--- a/docs/configuration/protocols/bgp.rst
+++ b/docs/configuration/protocols/bgp.rst
@@ -335,7 +335,7 @@ Peer Parameters
    but you can’t connect them directly.
 
    The number parameter (1-10) configures the amount of accepted
-   occurences of the system AS number in AS path.
+   occurrences of the system AS number in AS path.
 
    This command is only allowed for eBGP peers. It is not applicable
    for peer groups.

--- a/docs/configuration/protocols/segment-routing.rst
+++ b/docs/configuration/protocols/segment-routing.rst
@@ -90,7 +90,7 @@ devices, below configuration shows how to enable SR on IS-IS:
    
   A segment ID that contains an IP address prefix calculated by an IGP in the
   service provider core network. Prefix SIDs are globally unique, this value
-  indentify it 
+  identify it
 
 .. cfgcmd:: set protocols isis segment-routing prefix <address> index
    <no-php-flag | explicit-null| n-flag-clear>
@@ -168,7 +168,7 @@ devices, below configuration shows how to enable SR on OSPF:
    
   A segment ID that contains an IP address prefix calculated by an IGP in the
   service provider core network. Prefix SIDs are globally unique, this value
-  indentify it 
+  identify it
 
 .. cfgcmd:: set protocols ospf segment-routing prefix <address> index
    <no-php-flag | explicit-null| n-flag-clear>

--- a/docs/configuration/service/conntrack-sync.rst
+++ b/docs/configuration/service/conntrack-sync.rst
@@ -29,7 +29,7 @@ will be mandatorily defragmented.
 
 It is possible to use either Multicast or Unicast to sync conntrack traffic.
 Most examples below show Multicast, but unicast can be specified by using the
-"peer" keywork after the specified interface, as in the following example:
+"peer" keyword after the specified interface, as in the following example:
 
 :cfgcmd:`set service conntrack-sync interface eth0 peer 192.168.0.250`
 
@@ -86,8 +86,8 @@ Configuration
 
 .. cfgcmd:: set service conntrack-sync interface <name> peer <address>
 
-    Peer to send unicast UDP conntrack sync entires to, if not using Multicast
-    configuration from above above.
+    Peer to send unicast UDP conntrack sync entries to, if not using Multicast
+    configuration from above.
 
 .. cfgcmd:: set service conntrack-sync sync-queue-size <size>
 
@@ -95,7 +95,7 @@ Configuration
 
 .. cfgcmd:: set service conntrack-sync disable-external-cache
 
-   This diable the external cache and directly injects the flow-states into the
+   This disables the external cache and directly injects the flow-states into the
    in-kernel Connection Tracking System of the backup firewall.
 
 .. cfgcmd:: set service conntrack-sync purge-timeout <timeout>

--- a/docs/configuration/service/console-server.rst
+++ b/docs/configuration/service/console-server.rst
@@ -66,7 +66,7 @@ port.
 .. cfgcmd:: set service console-server device <device> ssh port <port>
 
   Accept SSH connections for the given `<device>` on TCP port `<port>`.
-  After successfull authentication the user will be directly dropped to
+  After successful authentication the user will be directly dropped to
   the connected serial device.
 
   .. hint:: Multiple users can connect to the same serial device but only

--- a/docs/configuration/service/dhcp-server.rst
+++ b/docs/configuration/service/dhcp-server.rst
@@ -191,7 +191,7 @@ level, i.e. for individual shared networks or subnets. See examples below.
 
    If set to ``enable`` on global level, updates for all scopes will be enabled,
    except if explicitly set to ``disable`` on the scope level. If set to ``disable``,
-   updates will only be sent for scopes, where ``send-updates`` is explicity
+   updates will only be sent for scopes, where ``send-updates`` is explicitly
    set to ``enable``.
 
    This model is followed for a few behavioral settings below: if the option is
@@ -519,7 +519,7 @@ NB: Kea (the DHCP server used by VyOS) is programmed to offer as many
 alternatives as it can to repeated DHCP Discover requests. Some operating
 systems (Notably Microsoft Windows) make multiple DHCP Discover requests before
 settling on an address. This particularly seems to happen when the DHCP server
-isn't set to authorative. This may explain why the address you espect isn't
+isn't set to authoritative. This may explain why the address you expect isn't
 being chosen. Wireshark is helpful in these situations.
 
 **Example:**
@@ -913,13 +913,13 @@ used:
 
 
 .. cfgcmd:: set service dhcpv6-server shared-network-name <name> subnet
-   <prefix> prefix-delegation prefix <pd-prefix> prefix-length <lenght>
+   <prefix> prefix-delegation prefix <pd-prefix> prefix-length <length>
 
    Delegate prefixes from `<pd-prefix>` to clients in subnet `<prefix>`. Range
-   is defined by `<lenght>` in bits, 32 to 64.
+   is defined by `<length>` in bits, 32 to 64.
 
 .. cfgcmd:: set service dhcpv6-server shared-network-name <name> subnet
-   <prefix> prefix-delegation prefix <pd-prefix> delegated-length <lenght>
+   <prefix> prefix-delegation prefix <pd-prefix> delegated-length <length>
 
    Hand out prefixes of size `<length>` in bits from `<pd-prefix>` to clients
    in subnet `<prefix>` when the request for prefix delegation.
@@ -933,7 +933,7 @@ used:
 .. cfgcmd:: set service dhcpv6-server shared-network-name <name> subnet
    <prefix> prefix-delegation prefix <pd-prefix> excluded-prefix-length <length>
 
-   Define lenght of exclude prefix in `<pd-prefix>`.
+   Define length of exclude prefix in `<pd-prefix>`.
 
 **Example:**
 

--- a/docs/configuration/service/eventhandler.rst
+++ b/docs/configuration/service/eventhandler.rst
@@ -102,7 +102,7 @@ Event Handler Configuration Steps
     This is an optional command. Adds arguments to the script.
     Arguments must be separated by spaces.
 
-    .. note:: We don't recommend to use arguments. Using environments
+    .. note:: We don't recommend using arguments. Using environments
        is more preferable.
     
 

--- a/docs/configuration/service/ipoe-server.rst
+++ b/docs/configuration/service/ipoe-server.rst
@@ -148,7 +148,7 @@ to a single source IP e.g. the loopback interface.
 
 .. cfgcmd:: set service ipoe-server authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. note:: The ``source-address`` must be configured on one of VyOS interface.
    Best practice would be a loopback or dummy interface.
@@ -205,7 +205,7 @@ RADIUS advanced options
 
 .. cfgcmd:: set service ipoe-server authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. cfgcmd:: set service ipoe-server authentication radius rate-limit attribute <attribute>
 
@@ -241,7 +241,7 @@ If the RADIUS server sends the attribute ``Stateful-IPv6-Address-Pool``, IPv6 ad
 will be allocated from a predefined IPv6 pool ``prefix`` whose name equals the attribute value.
 
 If the RADIUS server sends the attribute ``Delegated-IPv6-Prefix-Pool``, IPv6
-delegation pefix will be allocated from a predefined IPv6 pool ``delegate``
+delegation prefix will be allocated from a predefined IPv6 pool ``delegate``
 whose name equals the attribute value.
 
 .. note:: ``Stateful-IPv6-Address-Pool`` and ``Delegated-IPv6-Prefix-Pool`` are defined in
@@ -258,7 +258,7 @@ IPv6
 .. cfgcmd:: set service ipoe-server client-ipv6-pool <IPv6-POOL-NAME> prefix <address>
    mask <number-of-bits>
 
-  Use this comand to set the IPv6 address pool from which an IPoE client
+  Use this command to set the IPv6 address pool from which an IPoE client
   will get an IPv6 prefix of your defined length (mask) to terminate the
   IPoE endpoint at their side. The mask length can be set from 48 to 128
   bit long, the default value is 64.
@@ -429,7 +429,7 @@ Monitoring
       delayed: 0
 
 **************
-Toubleshooting
+Troubleshooting
 **************
 
 .. code-block:: none

--- a/docs/configuration/service/monitoring.rst
+++ b/docs/configuration/service/monitoring.rst
@@ -81,7 +81,7 @@ for Prometheus native metrics through exporters see section below.
 
 .. cfgcmd:: set service monitoring telegraf prometheus-client metric-version <1 | 2>
 
-   Metris version, the default is ``2``
+   Metrics version, the default is ``2``
 
 .. cfgcmd:: set service monitoring telegraf prometheus-client port <port>
 

--- a/docs/configuration/service/pppoe-server.rst
+++ b/docs/configuration/service/pppoe-server.rst
@@ -113,7 +113,7 @@ to a single source IP e.g. the loopback interface.
 .. cfgcmd:: set service pppoe-server authentication radius
    source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. note:: The ``source-address`` must be configured on one of VyOS interface.
    Best practice would be a loopback or dummy interface.
@@ -182,7 +182,7 @@ RADIUS advanced options
 .. cfgcmd:: set service pppoe-server authentication radius
    source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. cfgcmd:: set service pppoe-server authentication radius
    rate-limit attribute <attribute>
@@ -222,7 +222,7 @@ IPv6 address will be allocated from a predefined IPv6 pool ``prefix``
 whose name equals the attribute value.
 
 If the RADIUS server sends the attribute ``Delegated-IPv6-Prefix-Pool``,
-IPv6 delegation pefix will be allocated from a predefined IPv6 pool ``delegate``
+IPv6 delegation prefix will be allocated from a predefined IPv6 pool ``delegate``
 whose name equals the attribute value.
 
 .. note:: ``Stateful-IPv6-Address-Pool`` and ``Delegated-IPv6-Prefix-Pool``
@@ -373,7 +373,7 @@ IPv6
 .. cfgcmd:: set service pppoe-server client-ipv6-pool <IPv6-POOL-NAME>
    prefix <address> mask <number-of-bits>
 
-  Use this comand to set the IPv6 address pool from which an PPPoE client
+  Use this command to set the IPv6 address pool from which a PPPoE client
   will get an IPv6 prefix of your defined length (mask) to terminate the
   PPPoE endpoint at their side. The mask length can be set from 48 to 128
   bit long, the default value is 64.

--- a/docs/configuration/service/salt-minion.rst
+++ b/docs/configuration/service/salt-minion.rst
@@ -45,7 +45,7 @@ Configuration
     URL with signature of master for auth reply verification
 
 
-Please take a look in the Automation section to find some usefull
+Please take a look in the Automation section to find some useful
 Examples.
 
 

--- a/docs/configuration/system/conntrack.rst
+++ b/docs/configuration/system/conntrack.rst
@@ -41,9 +41,9 @@ Configure
 .. cfgcmd:: set system conntrack modules tftp
 
     Configure the connection tracking protocol helper modules.
-    All modules are enable by default.
+    All modules are enabled by default.
 
-    | Use `delete system conntrack modules` to deactive all modules.
+    | Use `delete system conntrack modules` to deactivate all modules.
     | Or, for example ftp, `delete system conntrack modules ftp`.
 
 .. cfgcmd:: set system conntrack tcp half-open-connections <1-21474836>

--- a/docs/configuration/system/frr.rst
+++ b/docs/configuration/system/frr.rst
@@ -12,7 +12,7 @@ but requires either a restart of the routing daemon, or a reboot of the system.
 
    Enable :abbr:`BMP (BGP Monitoring Protocol)` support.
 
-.. cfgcmd:: set system frr descriptors <numer>
+.. cfgcmd:: set system frr descriptors <number>
 
    This allows the operator to control the number of open file descriptors
    each daemon is allowed to start with. If the operator plans to run bgp with

--- a/docs/configuration/system/option.rst
+++ b/docs/configuration/system/option.rst
@@ -142,7 +142,7 @@ the used keyboard layout on the system console.
 Performance
 ***********
 
-As more and more routers run on Hypervisors, expecially with a :abbr:`NOS
+As more and more routers run on Hypervisors, especially with a :abbr:`NOS
 (Network Operating System)` as VyOS, it makes fewer and fewer sense to use
 static resource bindings like ``smp-affinity`` as present in VyOS 1.2 and
 earlier to pin certain interrupt handlers to specific CPUs.

--- a/docs/configuration/system/proxy.rst
+++ b/docs/configuration/system/proxy.rst
@@ -19,10 +19,10 @@ using the :opcmd:`add system image` command (:ref:`update_vyos`).
 
 .. cfgcmd:: set system proxy username <username>
 
-   Some proxys require/support the "basic" HTTP authentication scheme as per
+   Some proxies require/support the "basic" HTTP authentication scheme as per
    :rfc:`7617`, thus a username can be configured.
 
 .. cfgcmd:: set system proxy password <password>
 
-   Some proxys require/support the "basic" HTTP authentication scheme as per
+   Some proxies require/support the "basic" HTTP authentication scheme as per
    :rfc:`7617`, thus a password can be configured.

--- a/docs/configuration/trafficpolicy/index.rst
+++ b/docs/configuration/trafficpolicy/index.rst
@@ -1114,7 +1114,7 @@ the higher the priority.
    <bytes>
 
    Use this command to configure a Shaper policy, set its name, define
-   a class and set the size of the `tocken bucket`_ in bytes, which will
+   a class and set the size of the `token bucket`_ in bytes, which will
    be available to be sent at ceiling speed (default: 15Kb).
 
 .. cfgcmd:: set qos policy shaper <policy-name> class <class-ID> ceiling
@@ -1353,7 +1353,7 @@ That is how it is possible to do the so-called "ingress shaping".
 
 .. _that can give you a great deal of flexibility: https://blog.vyos.io/using-the-policy-route-and-packet-marking-for-custom-qos-matches
 .. _tc: https://en.wikipedia.org/wiki/Tc_(Linux)
-.. _tocken bucket: https://en.wikipedia.org/wiki/Token_bucket
+.. _token bucket: https://en.wikipedia.org/wiki/Token_bucket
 .. _HFSC: https://en.wikipedia.org/wiki/Hierarchical_fair-service_curve
 .. _Intermediate Functional Block: https://www.linuxfoundation.org/collaborate/workgroups/networking/ifb
 .. _Common Applications Kept Enhanced: https://www.bufferbloat.net/projects/codel/wiki/Cake/

--- a/docs/configuration/vpn/ipsec/ipsec_general.rst
+++ b/docs/configuration/vpn/ipsec/ipsec_general.rst
@@ -118,7 +118,7 @@ available. The use of PPKs in IKEv2 is described in :rfc:`8784`.
 
 .. cfgmod:: edit vpn authentication ppk <name>
 
-PPKs can be configued within VyOS under the `vpn ipsec authentication ppk`
+PPKs can be configured within VyOS under the `vpn ipsec authentication ppk`
 config.
 
 .. cfgmod:: set vpn authentication ppk <name> secret-type <plaintext|hex|base64>
@@ -141,9 +141,9 @@ Optionally, you can require the use of PPK to have a successful connection.
 
 You can view the PPK column for information on if PPK is configured, and
 if it is in use. The output is in the format of ``<configured> / <in use>``. 
-The options for configured are none if not conifugred, opt if configured 
+The options for configured are none if not configured, opt if configured
 but optional, and req is configured and required. The in use will show yes 
-Possible values of the ``configured`` field are ``none`` if not conifgured, ``opt`` if configured 
+Possible values of the ``configured`` field are ``none`` if not configured, ``opt`` if configured
 but optional, and ``req`` is configured and required. The in use will show yes 
 
 

--- a/docs/configuration/vpn/l2tp.rst
+++ b/docs/configuration/vpn/l2tp.rst
@@ -154,7 +154,7 @@ e.g. the loopback interface.
 
 .. cfgcmd:: set vpn l2tp remote-access authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. note:: The ``source-address`` must be configured to that of an interface.
    Best practice would be a loopback or dummy interface.
@@ -211,7 +211,7 @@ RADIUS advanced options
 
 .. cfgcmd:: set vpn l2tp remote-access authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. cfgcmd:: set vpn l2tp remote-access authentication radius rate-limit attribute <attribute>
 
@@ -300,7 +300,7 @@ IPv6
 .. cfgcmd:: set vpn l2tp remote-access client-ipv6-pool <IPv6-POOL-NAME> prefix <address>
    mask <number-of-bits>
 
-  Use this comand to set the IPv6 address pool from which an l2tp client will
+  Use this command to set the IPv6 address pool from which an l2tp client will
   get an IPv6 prefix of your defined length (mask) to terminate the l2tp 
   endpoint at their side. The mask length can be set between 48 and 128 bits
   long, the default value is 64.

--- a/docs/configuration/vpn/openconnect.rst
+++ b/docs/configuration/vpn/openconnect.rst
@@ -181,7 +181,7 @@ Follow the instructions to generate server cert (in configuration mode):
 
 .. start_vyoslinter
 
-Each of the install command should be applied to the configuration and commited
+Each of the install commands should be applied to the configuration and committed
 before using under the openconnect configuration:
 
 .. code-block:: none

--- a/docs/configuration/vpn/pptp.rst
+++ b/docs/configuration/vpn/pptp.rst
@@ -94,7 +94,7 @@ to a single source IP e.g. the loopback interface.
 
 .. cfgcmd:: set vpn pptp remote-access authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. note:: The ``source-address`` must be configured on one of VyOS interface.
    Best practice would be a loopback or dummy interface.
@@ -151,7 +151,7 @@ RADIUS advanced options
 
 .. cfgcmd:: set vpn pptp remote-access authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. cfgcmd:: set vpn pptp remote-access authentication radius rate-limit attribute <attribute>
 
@@ -187,7 +187,7 @@ If the RADIUS server sends the attribute ``Stateful-IPv6-Address-Pool``, IPv6 ad
 will be allocated from a predefined IPv6 pool ``prefix`` whose name equals the attribute value.
 
 If the RADIUS server sends the attribute ``Delegated-IPv6-Prefix-Pool``, IPv6
-delegation pefix will be allocated from a predefined IPv6 pool ``delegate``
+delegation prefix will be allocated from a predefined IPv6 pool ``delegate``
 whose name equals the attribute value.
 
 .. note:: ``Stateful-IPv6-Address-Pool`` and ``Delegated-IPv6-Prefix-Pool`` are defined in
@@ -221,7 +221,7 @@ IPv6
 .. cfgcmd:: set vpn pptp remote-access client-ipv6-pool <IPv6-POOL-NAME> prefix <address>
    mask <number-of-bits>
 
-  Use this comand to set the IPv6 address pool from which an PPTP client
+  Use this command to set the IPv6 address pool from which a PPTP client
   will get an IPv6 prefix of your defined length (mask) to terminate the
   PPTP endpoint at their side. The mask length can be set from 48 to 128
   bit long, the default value is 64.

--- a/docs/configuration/vpn/rsa-keys.rst
+++ b/docs/configuration/vpn/rsa-keys.rst
@@ -11,7 +11,7 @@ To make IPSec work with dynamic address on one/both sides, we will have to use
 RSA keys for authentication. They are very fast and easy to setup.
 
 First, on both routers run the operational command "generate pki key-pair 
-install <key-pair nam>>". You may choose different length than 2048 of course.
+install <key-pair name>". You may choose different length than 2048 of course.
 
 .. stop_vyoslinter
 

--- a/docs/configuration/vpn/sstp.rst
+++ b/docs/configuration/vpn/sstp.rst
@@ -127,7 +127,7 @@ e.g. the loopback interface.
 
 .. cfgcmd:: set vpn sstp authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. note:: The ``source-address`` must be configured to that of an interface.
    Best practice would be a loopback or dummy interface.
@@ -184,7 +184,7 @@ RADIUS advanced options
 
 .. cfgcmd:: set vpn sstp authentication radius source-address <address>
 
-  Source IPv4 address used in all RADIUS server queires.
+  Source IPv4 address used in all RADIUS server queries.
 
 .. cfgcmd:: set vpn sstp authentication radius rate-limit attribute <attribute>
 
@@ -258,7 +258,7 @@ IPv6
 .. cfgcmd:: set vpn sstp client-ipv6-pool <IPv6-POOL-NAME> prefix <address>
    mask <number-of-bits>
 
-  Use this comand to set the IPv6 address pool from which an SSTP client will
+  Use this command to set the IPv6 address pool from which an SSTP client will
   get an IPv6 prefix of your defined length (mask) to terminate the SSTP
   endpoint at their side. The mask length can be set between 48 and 128 bits
   long, the default value is 64.
@@ -513,7 +513,7 @@ The following PPP configuration tests MSCHAP-v2:
   debug
 
 
-You can now "dial" the peer with the follwoing command: ``sstpc --log-level 4
+You can now "dial" the peer with the following command: ``sstpc --log-level 4
 --log-stderr --user vyos --password vyos vpn.example.com -- call vyos``.
 
 A connection attempt will be shown as:

--- a/docs/configuration/vrf/index.rst
+++ b/docs/configuration/vrf/index.rst
@@ -450,9 +450,9 @@ BGP routes may be leaked (i.e. copied) between a unicast VRF RIB and the VPN
 SAFI RIB of the default VRF for use in MPLS-based L3VPNs. Unicast routes may
 also be leaked between any VRFs (including the unicast RIB of the default BGP
 instance). A shortcut syntax is also available for specifying leaking from
-one VRF to another VRF using the default instance’s VPN RIB as the intemediary
-. A common application of the VRF-VRF feature is to connect a customer’s
-private routing domain to a provider’s VPN service. Leaking is configured from
+one VRF to another VRF using the default instance’s VPN RIB as the intermediary.
+A common application of the VRF-VRF feature is to connect a customer’s private
+routing domain to a provider’s VPN service. Leaking is configured from
 the point of view of an individual VRF: import refers to routes leaked from VPN
 to a unicast VRF, whereas export refers to routes leaked from a unicast VRF to
 VPN.

--- a/docs/installation/bare-metal.rst
+++ b/docs/installation/bare-metal.rst
@@ -414,9 +414,9 @@ Pictures
 Cooling
 -------
 
-The device itself is passivly cooled, whereas the power supply has an active fan.
+The device itself is passively cooled, whereas the power supply has an active fan.
 Even if the main processor is powered off, the power supply fan is operating and
-the entire chassis draws 7.5W. During operation the chassis drew arround 38W.
+the entire chassis draws 7.5W. During operation the chassis drew around 38W.
 
 BIOS Settings
 -------------


### PR DESCRIPTION
## Change Summary

Rebased #1801 onto `current` and applied follow-on fixes from copilot's review of that PR.

Continuation of @andrewimeson's typo sweep. The original PR has been open since March and drifted out of sync with current after several large merges (changelog removal in #1809, plus proofreading rewrites in #1800/#1834/#1835). Rather than let the work bitrot, this reopens the scope on a fresh branch.

### What is included

- All of #1801's typo fixes on files that still exist and weren't rewritten upstream (36 files).
- The 10 valid fixes copilot flagged on #1801 that the `typos-cli` sweep missed.

### What is skipped (vs #1801)

| File(s) | Reason |
|---------|--------|
| `docs/automation/cloud-init.rst` | rewritten by #1835 |
| `docs/automation/terraform/*.rst` | rewritten by #1800 |
| `docs/automation/vyos-api.rst` | rewritten by #1834 |
| `docs/changelog/*.rst` | removed by #1809 |
| `eventhandler.rst` rewording ("Using environment variables is preferable") | scope-stretch; outside a typo fix |
| 4 changelog typo comments from copilot | file no longer exists |

### Copilot follow-on fixes included

- `vrf/index.rst` — repair orphaned `.` after "intermediary"
- `service/conntrack-sync.rst` — `above above` → `above`; `This diable` → `This disables`
- `service/dhcp-server.rst` — `espect` → `expect`
- `service/pppoe-server.rst` — `an PPPoE client` → `a PPPoE client`
- `system/conntrack.rst` — `are enable` → `are enabled`
- `vpn/ipsec/ipsec_general.rst` — `conifugred` → `configured`
- `vpn/openconnect.rst` — `Each of the install command` → `commands`
- `vpn/pptp.rst` — `an PPTP client` → `a PPTP client`
- `installation/bare-metal.rst` — `passivly` → `passively`

Original authorship preserved on the single commit; I'm listed as committer / Co-Authored-By for the conflict resolution and copilot follow-ons.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document

🤖 Generated by [robots](https://vyos.io)
