### PR TITLE
Add Terraform for VyOS overview page from circinus

### DIFF
--- a/docs/automation/terraform/index.rst
+++ b/docs/automation/terraform/index.rst
@@ -20,6 +20,7 @@ official documentation for Terraform_ and Ansible_.
    :maxdepth: 1
    :caption: Guides
    
+   terraformvyos
    terraformAWS
    terraformAZ
    terraformGoogle

--- a/docs/automation/terraform/terraformvyos.rst
+++ b/docs/automation/terraform/terraformvyos.rst
@@ -1,0 +1,39 @@
+:lastproofread: 2024-03-03
+
+.. _terraformvyos:
+
+Terraform for VyOS
+==================
+
+VyOS supports development infrastructure via Terraform and provisioning via Ansible.
+Terraform allows you to automate the process of deploying instances on many cloud and virtual platforms. 
+In this article, we will look at using terraforms to deploy VyOS on platforms - AWS, Azure, and vSphere.
+For more details about Terraform please have a look here link_.
+
+Need to install_ Terraform
+
+Structure of files in the standard Terraform project:
+
+.. code-block:: none
+
+ .
+ ├── main.tf             # The main script
+ ├── version.tf          # File for the changing version of Terraform.
+ ├── variables.tf        # The file of all variables in "main.tf"
+ └── terraform.tfvars    # The value of all variables (passwords, login, ip adresses and so on)
+
+
+General commands that we will use for running Terraform scripts
+
+
+.. code-block:: none
+
+  cd /<your folder>       # go to the Terrafom project
+  terraform init          # install all addons and provider (aws az and so on)
+  terraform plan          # show what is changing
+  terraform apply         # run script
+  yes                     # apply running
+
+
+.. _link: https://developer.hashicorp.com/terraform/intro
+.. _install: https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli

--- a/docs/automation/terraform/terraformvyos.rst
+++ b/docs/automation/terraform/terraformvyos.rst
@@ -5,12 +5,14 @@
 Terraform for VyOS
 ==================
 
-VyOS supports development infrastructure via Terraform and provisioning via Ansible.
-Terraform allows you to automate the process of deploying instances on many cloud and virtual platforms. 
-In this article, we will look at using terraforms to deploy VyOS on platforms - AWS, Azure, and vSphere.
-For more details about Terraform please have a look here link_.
+VyOS supports development infrastructure via Terraform and
+provisioning via Ansible. Terraform allows you to automate the
+process of deploying instances on many cloud and virtual
+platforms. In this article, we will look at using Terraform to
+deploy VyOS on platforms - AWS, Azure, and vSphere. For more
+details about Terraform please have a look at link_.
 
-Need to install_ Terraform
+You will need to install_ Terraform before proceeding.
 
 Structure of files in the standard Terraform project:
 
@@ -20,7 +22,7 @@ Structure of files in the standard Terraform project:
  ├── main.tf             # The main script
  ├── version.tf          # File for the changing version of Terraform.
  ├── variables.tf        # The file of all variables in "main.tf"
- └── terraform.tfvars    # The value of all variables (passwords, login, ip adresses and so on)
+ └── terraform.tfvars    # The value of all variables (passwords, login, IP addresses and so on)
 
 
 General commands that we will use for running Terraform scripts
@@ -28,12 +30,14 @@ General commands that we will use for running Terraform scripts
 
 .. code-block:: none
 
-  cd /<your folder>       # go to the Terrafom project
-  terraform init          # install all addons and provider (aws az and so on)
+  cd /<your folder>       # go to the Terraform project
+  terraform init          # install all add-ons and providers (AWS, Azure, and so on)
   terraform plan          # show what is changing
   terraform apply         # run script
   yes                     # apply running
 
 
+.. stop_vyoslinter
 .. _link: https://developer.hashicorp.com/terraform/intro
 .. _install: https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli
+.. start_vyoslinter


### PR DESCRIPTION
## Summary
- Sync `terraformvyos.rst` from `circinus` branch to `current`
- Add to terraform index toctree

Aligns `current` with `circinus` — this page existed on circinus but was missing from current.

## Test plan
- [ ] Sphinx build passes
- [ ] Page renders at `/automation/terraform/terraformvyos.html`

🤖 Generated by [robots](https://vyos.io)