### PR TITLE
Fix terraformvyos.rst typos and linter issues

### DIFF
--- a/docs/automation/terraform/terraformvyos.rst
+++ b/docs/automation/terraform/terraformvyos.rst
@@ -5,12 +5,14 @@
 Terraform for VyOS
 ==================
 
-VyOS supports development infrastructure via Terraform and provisioning via Ansible.
-Terraform allows you to automate the process of deploying instances on many cloud and virtual platforms. 
-In this article, we will look at using terraforms to deploy VyOS on platforms - AWS, Azure, and vSphere.
-For more details about Terraform please have a look here link_.
+VyOS supports development infrastructure via Terraform and
+provisioning via Ansible. Terraform allows you to automate the
+process of deploying instances on many cloud and virtual
+platforms. In this article, we will look at using Terraform to
+deploy VyOS on platforms - AWS, Azure, and vSphere. For more
+details about Terraform please have a look at link_.
 
-Need to install_ Terraform
+You will need to install_ Terraform before proceeding.
 
 Structure of files in the standard Terraform project:
 
@@ -20,7 +22,7 @@ Structure of files in the standard Terraform project:
  ├── main.tf             # The main script
  ├── version.tf          # File for the changing version of Terraform.
  ├── variables.tf        # The file of all variables in "main.tf"
- └── terraform.tfvars    # The value of all variables (passwords, login, ip adresses and so on)
+ └── terraform.tfvars    # The value of all variables (passwords, login, IP addresses and so on)
 
 
 General commands that we will use for running Terraform scripts
@@ -28,12 +30,14 @@ General commands that we will use for running Terraform scripts
 
 .. code-block:: none
 
-  cd /<your folder>       # go to the Terrafom project
-  terraform init          # install all addons and provider (aws az and so on)
+  cd /<your folder>       # go to the Terraform project
+  terraform init          # install all add-ons and providers (AWS, Azure, and so on)
   terraform plan          # show what is changing
   terraform apply         # run script
   yes                     # apply running
 
 
+.. stop_vyoslinter
 .. _link: https://developer.hashicorp.com/terraform/intro
 .. _install: https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli
+.. start_vyoslinter


### PR DESCRIPTION
## Summary
- Fix typos: "Terrafom", "terraforms", "ip adresses"
- Wrap prose lines to ≤80 chars
- Add `stop/start_vyoslinter` around long URL targets
- Fix grammar: "addons and provider" → "add-ons and providers"
- Rewrite fragment sentence

Same fixes as PR #1856 (current branch), applied to circinus source.

## Test plan
- [ ] Sphinx build passes
- [ ] Linter passes

🤖 Generated by [robots](https://vyos.io)