### PR TITLE
T8293: Add ability to set timeout for high-availability health-check

### DIFF
--- a/docs/configuration/highavailability/index.rst
+++ b/docs/configuration/highavailability/index.rst
@@ -347,6 +347,22 @@ times:
 
 .. start_vyoslinter
 
+An optional ``timeout`` can be set to define the maximum number of seconds the
+script is allowed to run. This is useful for scripts that may hang or take
+longer than expected — setting the timeout higher than the interval allows
+longer-running scripts to complete before being considered failed.
+
+.. stop_vyoslinter
+
+.. code-block:: none
+
+  set high-availability vrrp group Foo health-check script /config/scripts/vrrp-check.sh
+  set high-availability vrrp group Foo health-check interval 20
+  set high-availability vrrp group Foo health-check failure-count 3
+  set high-availability vrrp group Foo health-check timeout 40
+
+.. start_vyoslinter
+
 When the vrrp group is a member of the sync group will use only
 the sync group health check script.
 This example shows how to configure it for the sync group:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T8293

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/vyos/vyos-1x/pull/5151
## Backport
<!-- optional: the PR should backport to this documentation branch -->

@Mergifyio backport circinus

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document