### PR TITLE
DOCS: Update Proxmox qcow2 and iso deployment

### DIFF
--- a/docs/installation/virtual/proxmox.rst
+++ b/docs/installation/virtual/proxmox.rst
@@ -12,30 +12,37 @@ Deploy VyOS from CLI with qcow2 image
 =====================================
 
 1. Download the ``.qcow2`` image from https://support.vyos.io/. 
-   Official qcow2 images are available from the support portal 
+   Official ``.qcow2`` images are available from the support portal 
    for users with a valid subscription.
+
 2. Copy the ``.qcow2`` image to a temporary directory on the Proxmox server.
-3. The commands assume virtual machine ID 200 is unused and you want
+
+3. The commands assume virtual machine ID `200` is unused and you want
    the disk stored in a storage pool named `local-lvm`.
 
-.. code-block:: none
 
-  $ qm create 200 --name vyos --memory 4096 --net0 virtio,bridge=vmbr0
-  $ qm importdisk 200 /var/lib/vz/images/vyos-<version>-proxmox-amd64.qcow2 local-lvm
-  $ qm set 200 --virtio0 local-lvm:vm-200-disk-0
-  $ qm set 200 --boot order=virtio0 
+    .. code-block:: none
 
-4. When using a ``.qcow2`` image, it does not include default login credentials.
+      $ qm create 200 --name vyos --memory 4096 --net0 virtio,bridge=vmbr0
+      $ qm importdisk 200 /var/lib/vz/images/vyos-<version>-proxmox-amd64.qcow2 local-lvm
+      $ qm set 200 --virtio0 local-lvm:vm-200-disk-0
+      $ qm set 200 --boot order=virtio0 
+
+
+4. When using a ``.qcow2`` image, default login credentials are not included.
    A user account must be defined using Cloud-Init before the first boot. 
    Without this configuration, login access is not possible.
    
-   Attach a Cloud-Init data source to the VM (example using local-lvm storage):
+   Attach a Cloud-Init data source to the VM (e.g, using 
+   `local-lvm` storage):
 
-.. code-block:: none
+    .. code-block:: none
 
-  $ qm set 200 --ide2 local-lvm:cloudinit
+      $ qm set 200 --ide2 local-lvm:cloudinit
 
-  For a complete Cloud-init configuration example in Proxmox, refer to 
+
+   For a complete Cloud-init configuration example in Proxmox,
+   refer to 
 
 5. Start the virtual machine using the Proxmox GUI or run ``qm start 200``.
 
@@ -46,9 +53,10 @@ Deploy VyOS from CLI with rolling release ISO
 
 1. Download the rolling release ISO from
    https://vyos.net/get/nightly-builds/.
-2. Prepare the VM for ISO installation. The commands below assume that the ISO image is
-   available in the 'local' storage, a VM ID `200` is unused, and
-   a 15GB disk will be created on storage pool 'local-lvm'.
+2. Prepare the VM for ISO installation.
+   The commands below assume that the ISO image is available in the
+   `local` storage, a VM ID `200` is unused, and a 15GB disk will be
+   created on storage pool `local-lvm`.
 
 .. code-block:: none
 

--- a/docs/installation/virtual/proxmox.rst
+++ b/docs/installation/virtual/proxmox.rst
@@ -28,11 +28,13 @@ Deploy VyOS from CLI with qcow2 image
       $ qm set 200 --boot order=virtio0 
 
 
-4. When using a ``qcow2`` image on proxmox, the system
-   **does not include any preconfigured user accounts**. 
-   You must define a user account using **Cloud-Init** before the first boot. Otherwise, login access is not possible.
+4. When using a ``qcow2`` image on Proxmox, the system
+   **does not include any preconfigured user accounts**.
+   You must define a user account using **Cloud-Init** before the
+   first boot. Otherwise, login access is not possible.
 
-   Attach a Cloud-Init data source to the VM. For example, using ``local-lvm`` storage:
+   Attach a Cloud-Init data source to the VM. For example, using
+   ``local-lvm`` storage:
 
    .. code-block:: bash
 
@@ -69,13 +71,15 @@ Deploy VyOS from CLI with rolling release ISO
   --ide2 local:iso/vyos-<version>.iso,media=cdrom \
   --boot order=ide2
 
-3. Start the VM using ``qm start 200`` or by clicking **Start** button in the
-   Proxmox GUI.
-4. In the Proxmox GUI, open the virtual console for your new VM. The login username and password are `vyos`/`vyos`
+3. Start the VM using ``qm start 200`` or by clicking the **Start**
+   button in the Proxmox GUI.
+4. In the Proxmox GUI, open the virtual console for your new VM.
+   The login username and password are ``vyos``/``vyos``.
 5. After booting into the live system, type ``install image`` and follow
    the prompts to install VyOS to the virtual drive. 
 6. After installation completes, remove the installation ISO using the
-   GUI or run ``qm set 200 --ide2 none``, then set the boot device with ``qm set 200 --boot order=scsi0``.
+   GUI or run ``qm set 200 --ide2 none``, then set the boot device
+   with ``qm set 200 --boot order=scsi0``.
 7. Reboot the virtual machine using the GUI or run ``qm reboot 200``.
 
 

--- a/docs/installation/virtual/proxmox.rst
+++ b/docs/installation/virtual/proxmox.rst
@@ -12,13 +12,12 @@ Deploy VyOS from CLI with qcow2 image
 =====================================
 
 1. Download the ``.qcow2`` image from https://support.vyos.io/. 
-   Official ``.qcow2`` images are available from the support portal 
-   for users with a valid subscription.
+   Official images are available to users with a valid subscription.
 
 2. Copy the ``.qcow2`` image to a temporary directory on the Proxmox server.
 
-3. The commands assume virtual machine ID `200` is unused and you want
-   the disk stored in a storage pool named `local-lvm`.
+3. The following commands assume that virtual machine (VM) ID `200` is unused
+   and that the imported disk will be stored in a storage pool named `local-lvm`.
 
 
     .. code-block:: none
@@ -29,22 +28,25 @@ Deploy VyOS from CLI with qcow2 image
       $ qm set 200 --boot order=virtio0 
 
 
-4. When using a ``.qcow2`` image, default login credentials are not included.
-   A user account must be defined using Cloud-Init before the first boot. 
-   Without this configuration, login access is not possible.
-   
-   Attach a Cloud-Init data source to the VM (e.g, using 
-   `local-lvm` storage):
+4. When using a ``qcow2`` image on proxmox, the system
+   **does not include any preconfigured user accounts**. 
+   You must define a user account using **Cloud-Init** before the first boot. Otherwise, login access is not possible.
 
-    .. code-block:: none
+   Attach a Cloud-Init data source to the VM. For example, using ``local-lvm`` storage:
+
+   .. code-block:: bash
 
       $ qm set 200 --ide2 local-lvm:cloudinit
 
+   Alternatively, add a Cloud-Init drive using the Proxmox GUI:
 
-   For a complete Cloud-init configuration example in Proxmox,
-   refer to 
+   #. Open the VM and navigate to **Hardware**
+   #. Click **Add** → **CloudInit Drive**
+   #. Select a storage (for example, ``local-lvm``)
+   #. Click **Add**
 
-5. Start the virtual machine using the Proxmox GUI or run ``qm start 200``.
+
+5. Start the virtual machine using the Proxmox GUI or by running ``qm start 200``.
 
 
 
@@ -67,11 +69,10 @@ Deploy VyOS from CLI with rolling release ISO
   --ide2 local:iso/vyos-<version>.iso,media=cdrom \
   --boot order=ide2
 
-3. Start the VM using ``qm start 200`` or using the start button in the
+3. Start the VM using ``qm start 200`` or by clicking **Start** button in the
    Proxmox GUI.
-4. Open the virtual console for your VM using the Proxmox web GUI.
-   Login username and password are both ``vyos``.
-5. Once booted into the live system, type ``install image`` and follow
+4. In the Proxmox GUI, open the virtual console for your new VM. The login username and password are `vyos`/`vyos`
+5. After booting into the live system, type ``install image`` and follow
    the prompts to install VyOS to the virtual drive. 
 6. After installation completes, remove the installation ISO using the
    GUI or run ``qm set 200 --ide2 none``, then set the boot device with ``qm set 200 --boot order=scsi0``.

--- a/docs/installation/virtual/proxmox.rst
+++ b/docs/installation/virtual/proxmox.rst
@@ -17,7 +17,7 @@ Deploy VyOS from CLI with qcow2 image
 2. Copy the ``.qcow2`` image to a temporary directory on the Proxmox server.
 
 3. The following commands assume that virtual machine (VM) ID `200` is unused
-   and that the imported disk will be stored in a storage pool named `local-lvm`.
+   and that the imported disk will be stored in a storage pool named ``local-lvm``.
 
 
     .. code-block:: none

--- a/docs/installation/virtual/proxmox.rst
+++ b/docs/installation/virtual/proxmox.rst
@@ -6,33 +6,38 @@
 Running on Proxmox
 ******************
 
-Proxmox is an open-source platform for virtualization. Visit
-https://vyos.io to download a ``.qcow2`` image that you can import into
-Proxmox.
+Proxmox is an open-source platform for virtualization.
 
 Deploy VyOS from CLI with qcow2 image
 =====================================
 
-1. Copy the ``.qcow2`` image to a temporary directory on the Proxmox server.
-2. The commands assume virtual machine ID 200 is unused and you want
+1. Download the ``.qcow2`` image from https://support.vyos.io/. 
+   Official qcow2 images are available from the support portal 
+   for users with a valid subscription.
+2. Copy the ``.qcow2`` image to a temporary directory on the Proxmox server.
+3. The commands assume virtual machine ID 200 is unused and you want
    the disk stored in a storage pool named `local-lvm`.
 
 .. code-block:: none
 
-  $ qm create 200 --name vyos2 --memory 2048 --net0 virtio,bridge=vmbr0
-  $ qm importdisk 200 /path/to/image/vyos-1.2.8-proxmox-2G.qcow2 local-lvm
+  $ qm create 200 --name vyos --memory 4096 --net0 virtio,bridge=vmbr0
+  $ qm importdisk 200 /var/lib/vz/images/vyos-<version>-proxmox-amd64.qcow2 local-lvm
   $ qm set 200 --virtio0 local-lvm:vm-200-disk-0
   $ qm set 200 --boot order=virtio0 
 
-3. You can optionally attach a CDROM with an ISO as a cloud-init data
-   source. The command assumes the ISO is uploaded to the `local`
-   storage pool as `seed.iso`.
+4. When using a ``.qcow2`` image, it does not include default login credentials.
+   A user account must be defined using Cloud-Init before the first boot. 
+   Without this configuration, login access is not possible.
+   
+   Attach a Cloud-Init data source to the VM (example using local-lvm storage):
 
 .. code-block:: none
 
-  $ qm set 200 --ide2 media=cdrom,file=local:iso/seed.iso
+  $ qm set 200 --ide2 local-lvm:cloudinit
 
-4. Start the virtual machine using the Proxmox GUI or run ``qm start 200``.
+  For a complete Cloud-init configuration example in Proxmox, refer to 
+
+5. Start the virtual machine using the Proxmox GUI or run ``qm start 200``.
 
 
 
@@ -40,26 +45,28 @@ Deploy VyOS from CLI with rolling release ISO
 =============================================
 
 1. Download the rolling release ISO from
-   https://vyos.net/get/nightly-builds/. Non-subscribers can use the
-   LTS release by building from source. For instructions, see the
-   :ref:`build` section. The VyOS source code repository
-   is available at https://github.com/vyos/vyos-build.
-2. Prepare the VM for ISO installation. The commands assume your ISO is
-   in storage pool 'local', you want VM ID '200', and you want to create
-   a new 15GB disk on storage pool 'local-lvm'.
+   https://vyos.net/get/nightly-builds/.
+2. Prepare the VM for ISO installation. The commands below assume that the ISO image is
+   available in the 'local' storage, a VM ID `200` is unused, and
+   a 15GB disk will be created on storage pool 'local-lvm'.
 
 .. code-block:: none
 
-  qm create 200 --name vyos --memory 2048 --net0 virtio,bridge=vmbr0 --ide2 media=cdrom,file=local:iso/live-image-amd64.hybrid.iso --virtio0 local-lvm:15
+  qm create 200 --name vyos --memory 4096 \
+  --net0 virtio,bridge=vmbr0 \
+  --scsihw virtio-scsi-pci \
+  --scsi0 local-lvm:15 \
+  --ide2 local:iso/vyos-<version>.iso,media=cdrom \
+  --boot order=ide2
 
-3. Start the VM using ``qm start 200`` or the start button in the
+3. Start the VM using ``qm start 200`` or using the start button in the
    Proxmox GUI.
 4. Open the virtual console for your VM using the Proxmox web GUI.
    Login username and password are both ``vyos``.
 5. Once booted into the live system, type ``install image`` and follow
    the prompts to install VyOS to the virtual drive. 
 6. After installation completes, remove the installation ISO using the
-   GUI or run ``qm set 200 --ide2 none``.
+   GUI or run ``qm set 200 --ide2 none``, then set the boot device with ``qm set 200 --boot order=scsi0``.
 7. Reboot the virtual machine using the GUI or run ``qm reboot 200``.
 
 


### PR DESCRIPTION
## Change Summary

Update Proxmox deployment guide for qcow2 and iso workflow:

- Clarify that qcow2 images do not include preconfigured user accounts
- Add Cloud-Init requirement before first boot
- Include CLI and GUI methods for attaching Cloud-Init
- Update commands and formatting

## Related Task(s)

N/A

## Related PR(s)

N/A

## Backport

N/A

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document