### PR TITLE
feat(docs): add Cookiebot CMP and GTM with Consent Mode v2 (sagitta)

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -30,7 +30,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-T5VQHRT');</script>
+    })(window,document,'script','dataLayer','{{ gtm_id }}');</script>
 
     <style>#vyos-header-iframe{position:fixed;top:0;left:0;right:0;z-index:999999999;width:100%;border:none}</style>
     <style>#vyos-footer-iframe{width:100%;border:none}</style>
@@ -63,7 +63,7 @@
 
 {% block body %}
     {# GTM noscript fallback #}
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5VQHRT"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_id }}"
                       height="0" width="0" style="display:none;visibility:hidden"
                       title="Google Tag Manager"></iframe></noscript>
     {{ super() }}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,11 +1,11 @@
 {% extends "!layout.html" %}
 {%- set current_version = "1.4.x sagitta" %}
 {% block extrahead %}
-    {% if gtm_id %}
+    {% if gtm_id and cookiebot_id %}
     {# Cookiebot CMP — must load first so its auto-blocker can scan/block other tags #}
     <script id="Cookiebot"
             src="https://consent.cookiebot.com/uc.js"
-            data-cbid="932cb8b9-5141-4dc9-9018-21fc31a0586f"
+            data-cbid="{{ cookiebot_id }}"
             data-blockingmode="auto"
             type="text/javascript"></script>
 
@@ -64,7 +64,7 @@
 {% endblock %}
 
 {% block body %}
-    {% if gtm_id %}
+    {% if gtm_id and cookiebot_id %}
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_id }}"
                       height="0" width="0" style="display:none;visibility:hidden"
                       title="Google Tag Manager"></iframe></noscript>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -64,6 +64,7 @@
 {% block body %}
     {# GTM noscript fallback #}
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5VQHRT"
-                      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+                      height="0" width="0" style="display:none;visibility:hidden"
+                      title="Google Tag Manager"></iframe></noscript>
     {{ super() }}
 {% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,6 +1,7 @@
 {% extends "!layout.html" %}
 {%- set current_version = "1.4.x sagitta" %}
 {% block extrahead %}
+    {% if gtm_id %}
     {# Cookiebot CMP — must load first so its auto-blocker can scan/block other tags #}
     <script id="Cookiebot"
             src="https://consent.cookiebot.com/uc.js"
@@ -31,6 +32,7 @@
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','{{ gtm_id }}');</script>
+    {% endif %}
 
     <style>#vyos-header-iframe{position:fixed;top:0;left:0;right:0;z-index:999999999;width:100%;border:none}</style>
     <style>#vyos-footer-iframe{width:100%;border:none}</style>
@@ -62,9 +64,10 @@
 {% endblock %}
 
 {% block body %}
-    {# GTM noscript fallback #}
+    {% if gtm_id %}
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_id }}"
                       height="0" width="0" style="display:none;visibility:hidden"
                       title="Google Tag Manager"></iframe></noscript>
+    {% endif %}
     {{ super() }}
 {% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -11,7 +11,7 @@
     {# Google Consent Mode v2 defaults — deny everything until Cookiebot fires the update #}
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
+      function gtag(){window.dataLayer.push(arguments);}
       gtag('consent', 'default', {
         'ad_storage':             'denied',
         'ad_user_data':           'denied',
@@ -59,7 +59,6 @@
     <script type="text/javascript" charset="utf8" src="{{ pathto("_static/js/codecopier.js", True) }}"></script>
     <script type="text/javascript" charset="utf8" src="{{ pathto("_static/js/sidebar.js", True) }}"></script>
     <script type="text/javascript" charset="utf8" src="{{ pathto("_static/js/footer.js", True) }}"></script>
-    </script>
 {% endblock %}
 
 {% block body %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,6 +1,37 @@
 {% extends "!layout.html" %}
 {%- set current_version = "1.4.x sagitta" %}
 {% block extrahead %}
+    {# Cookiebot CMP — must load first so its auto-blocker can scan/block other tags #}
+    <script id="Cookiebot"
+            src="https://consent.cookiebot.com/uc.js"
+            data-cbid="932cb8b9-5141-4dc9-9018-21fc31a0586f"
+            data-blockingmode="auto"
+            type="text/javascript"></script>
+
+    {# Google Consent Mode v2 defaults — deny everything until Cookiebot fires the update #}
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('consent', 'default', {
+        'ad_storage':             'denied',
+        'ad_user_data':           'denied',
+        'ad_personalization':     'denied',
+        'analytics_storage':      'denied',
+        'functionality_storage':  'denied',
+        'personalization_storage':'denied',
+        'security_storage':       'granted',
+        'wait_for_update': 500
+      });
+      gtag('set', 'ads_data_redaction', true);
+    </script>
+
+    {# Google Tag Manager #}
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-T5VQHRT');</script>
+
     <style>#vyos-header-iframe{position:fixed;top:0;left:0;right:0;z-index:999999999;width:100%;border:none}</style>
     <style>#vyos-footer-iframe{width:100%;border:none}</style>
     <iframe src='https://vyos.io/iframes/header' id='vyos-header-iframe'></iframe>
@@ -29,4 +60,11 @@
     <script type="text/javascript" charset="utf8" src="{{ pathto("_static/js/sidebar.js", True) }}"></script>
     <script type="text/javascript" charset="utf8" src="{{ pathto("_static/js/footer.js", True) }}"></script>
     </script>
+{% endblock %}
+
+{% block body %}
+    {# GTM noscript fallback #}
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5VQHRT"
+                      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    {{ super() }}
 {% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -19,7 +19,7 @@
         'ad_personalization':     'denied',
         'analytics_storage':      'denied',
         'functionality_storage':  'denied',
-        'personalization_storage':'denied',
+        'personalization_storage': 'denied',
         'security_storage':       'granted',
         'wait_for_update': 500
       });

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,6 +147,7 @@ html_context = {
     'github_repo': 'vyos-documentation',
     'github_version': _github_version,
     'conf_py_path': '/docs/',
+    'gtm_id': os.environ.get('GTM_ID', ''),
 }
 
 # Custom sidebar templates, must be a dictionary that maps document names

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -148,6 +148,7 @@ html_context = {
     'github_version': _github_version,
     'conf_py_path': '/docs/',
     'gtm_id': os.environ.get('GTM_ID', ''),
+    'cookiebot_id': os.environ.get('COOKIEBOT_ID', ''),
 }
 
 # Custom sidebar templates, must be a dictionary that maps document names


### PR DESCRIPTION
Backport of #1871 (`current` → `sagitta`).

## Summary

- Cookiebot CMP (CBID `932cb8b9-5141-4dc9-9018-21fc31a0586f`) at the top of `extrahead` so its auto-blocker scans/blocks downstream tags before they execute.
- Google Consent Mode v2 defaults — every category denied except `security_storage`, with `wait_for_update: 500` and `ads_data_redaction: true`.
- Google Tag Manager (`GTM-T5VQHRT`) container plus a `<noscript>` iframe fallback in a new `body` block.

## Why

`docs.vyos.io` runs on Sphinx (RTD today, Cloudflare Pages tomorrow per MT-943). RTD does not inject Cookiebot or GTM — analytics and consent are our responsibility.

## Out-of-repo follow-ups

- [ ] **GTM workspace:** import Cookiebot CMP template; wire GA4/Ads tags to consent checks
- [ ] **RTD admin:** clear Admin → Advanced Settings → Analytics code

## Test plan

- [ ] RTD build of this PR succeeds
- [ ] Incognito load shows Cookiebot banner before any `_ga*` cookies
- [ ] Consent state goes denied → granted on accept; no GA4 cookies on reject
- [ ] `<noscript>` GTM iframe present in source

🤖 Generated by [robots](https://vyos.io)