### PR TITLE
troubleshooting: T8608: document TCP ping

### DIFF
--- a/docs/troubleshooting/connectivity.md
+++ b/docs/troubleshooting/connectivity.md
@@ -41,6 +41,25 @@ vrf
 :::
 ```
 
+```{opcmd} ping tcp \<host\> port \<port\> [count \<n\>] [interface \<ifname\>] [vrf \<name\>] [source-address \<address\>]
+
+Test TCP connectivity to a destination host and port. This is useful when
+ICMP is blocked or when you need to verify that a specific TCP service is
+reachable.
+
+The `count` option sets the number of TCP connection attempts. Use
+`interface` to send probes through a specific interface, `vrf` to run
+the test in a VRF, and `source-address` to select the local source address.
+
+Example:
+
+:::{code-block} none
+vyos@vyos:~$ ping tcp 10.1.1.1 port 443 count 3
+vyos@vyos:~$ ping tcp example.com port 80 interface eth0
+vyos@vyos:~$ ping tcp 192.0.2.10 port 179 vrf CUSTOMER source-address 192.0.2.1
+:::
+```
+
 ```{opcmd} traceroute \<destination\>
 
 Trace path to target.


### PR DESCRIPTION
## Change summary

Document the new TCP ping operational command added for T8608.

The documented syntax is:

```text
ping tcp <host> port <port> [count <n>] [interface <ifname>] [vrf <name>] [source-address <address>]
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): documentation

## Related Task(s)

* https://vyos.dev/T8608

## Related PR(s)

* Code PR: https://github.com/vyos/vyos-1x/pull/5164

## How to test / Smoketest result

```text
$ git diff --check -- docs/troubleshooting/connectivity.rst
OK

Sphinx dummy builder completed successfully for the changed page with no warnings from docs/troubleshooting/connectivity.rst.

Full Sphinx HTML build was attempted and hit existing unrelated documentation errors outside this change.
```

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
