### PR TITLE
docs(conf): set branch-localized html_title on circinus

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,7 +133,7 @@ html_favicon = '_static/images/vyos-logo-icon.png'
 # The "title" for HTML documentation generated with Sphinx's own templates.
 # This is appended to the `<title>` tag of individual pages, and used
 # in the navigation bar as the "topmost" element.
-html_title = f'{project} rolling release (current)'
+html_title = f'{project} {release} LTS'
 
 # -- Options for HTMLHelp output ---------------------------------------------
 


### PR DESCRIPTION
## What

Replace the hard-coded `html_title = f'{project} rolling release (current)'` in `docs/conf.py` with the branch-localized `f'{project} {release} LTS'`.

On circinus this resolves to **"VyOS 1.5.x (circinus) LTS"** instead of the current incorrect **"VyOS rolling release (current)"** that was copied verbatim from the `current` branch and never localized.

## Why

Circinus is the 1.5 LTS train. Showing "rolling release (current)" in the page `<title>` and navigation bar of the 1.5 LTS docs is misleading.

The existing `release = u'1.5.x (circinus)'` variable a few lines above already carries the correct branch identity — re-using it via f-string keeps the title in sync with whatever `release` is set to.

## Verification

```
$ python3 -c "project='VyOS'; release='1.5.x (circinus)'; print(f'{project} {release} LTS')"
VyOS 1.5.x (circinus) LTS
```

Diff is a single logical change in `docs/conf.py`.

## Notes

Spotted while reviewing the LLM doc backport PR (#1869) — unrelated to that change and pre-existing. A sibling PR will land the equivalent fix on `sagitta` (which today has no `html_title` defined at all and falls back to Sphinx's default).

The `current` branch keeps its existing "rolling release (current)" title — that one is correct there.

🤖 Generated by [robots](https://vyos.io)
