### PR TITLE
docs: fix typos and grammar (ported from #1852 RST → MyST)

### DIFF
--- a/docs/_static/js/codecopier.js
+++ b/docs/_static/js/codecopier.js
@@ -40,7 +40,7 @@ $(document).ready(async function () {
     try {
       await navigator.clipboard.writeText(currentTarget.offsetParent.innerText)
     } catch (error) {
-      console.log('Copiing text failed, please try again', {
+      console.log('Copying text failed, please try again', {
         error
       })
     }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,12 +99,12 @@ They should be used with extreme caution.
 \"Force\" commands force the system to perform an action that it might perform by itself at a later point.
 
 Examples:
-- `force arp request interface eth1 address 10.3.0.2` --- send a gratuitious ARP request.
+- `force arp request interface eth1 address 10.3.0.2` --- send a gratuitous ARP request.
 - `force root-partition-auto-resize` --- grow the root filesystem to the size of the system partition (this is also done on startup, but this command can do it without a reboot).
 
 #### execute
 
-\"Execute\" commands are for executing various diagnostic and auxilliary actions that the system would never perform by itself.
+\"Execute\" commands are for executing various diagnostic and auxiliary actions that the system would never perform by itself.
 
 Examples:
 - `execute wake-on-lan interface <intf> host <MAC>` --- send a Wake-On-LAN packet to a host.

--- a/docs/configexamples/autotest/OpenVPN_with_LDAP/OpenVPN_with_LDAP.log
+++ b/docs/configexamples/autotest/OpenVPN_with_LDAP/OpenVPN_with_LDAP.log
@@ -373,7 +373,7 @@ See the timeout setting options in the Network Debug and Troubleshooting Guide.
 2023-05-11 14:39:54,941 p=69617 u=rob n=ansible | [WARNING]: To ensure idempotency and correct diff the input configuration lines should be similar to how they appear if present in the running configuration on device including the indentation
 
 2023-05-11 14:39:54,943 p=69617 u=rob n=ansible | changed: [ovpn-server]
-2023-05-11 14:39:54,954 p=69617 u=rob n=ansible | TASK [eve-ng-lab-test : generate openvpn client conifg] *************************************************************************************************************************************************************************
+2023-05-11 14:39:54,954 p=69617 u=rob n=ansible | TASK [eve-ng-lab-test : generate openvpn client config] *************************************************************************************************************************************************************************
 2023-05-11 14:39:54,977 p=69617 u=rob n=ansible | skipping: [eveng]
 2023-05-11 14:39:54,985 p=69617 u=rob n=ansible | skipping: [vyos-oobm]
 2023-05-11 14:39:54,996 p=69617 u=rob n=ansible | skipping: [client]

--- a/docs/configexamples/fwall-and-bridge.md
+++ b/docs/configexamples/fwall-and-bridge.md
@@ -133,7 +133,7 @@ And then create the custom rulesets:
 set firewall bridge name br0-pre rule 10 description 'Accept IPv6 traffic'
 set firewall bridge name br0-pre rule 10 action 'accept'
 set firewall bridge name br0-pre rule 10 ethernet-type 'ipv6'
-  # And drop everythingg else
+  # And drop everything else
 set firewall bridge name br0-pre default-action 'drop'
 
 ### br1 - br1-pre
@@ -149,7 +149,7 @@ set firewall bridge name br1-pre rule 10 log
 set firewall bridge name br1-pre rule 20 description 'Drop IPv6 traffic'
 set firewall bridge name br1-pre rule 20 action 'drop'
 set firewall bridge name br1-pre rule 20 ethernet-type 'ipv6'
-  # Accept everythingg else so it can be parsed later
+  # Accept everything else so it can be parsed later
 set firewall bridge name br1-pre default-action 'accept'
 
 ### br2 - br2-pre
@@ -157,7 +157,7 @@ set firewall bridge name br1-pre default-action 'accept'
 set firewall bridge name br2-pre rule 10 description 'Drop IPv6 traffic'
 set firewall bridge name br2-pre rule 10 action 'drop'
 set firewall bridge name br2-pre rule 10 ethernet-type 'ipv6'
-  # Accept everythingg else so it can be parsed later
+  # Accept everything else so it can be parsed later
 set firewall bridge name br2-pre default-action 'accept'
 ```
 
@@ -199,7 +199,7 @@ And the content of the custom rulesets:
 
 ```none
 ### br0 - br0-fwd
-  # Accept everythingg that wasn't dropped in prerouting
+  # Accept everything that wasn't dropped in prerouting
 set firewall bridge name br0-fwd default-action 'accept'
 
 ### br1 - br1-fwd
@@ -245,7 +245,7 @@ set firewall bridge name br2-fwd rule 30 ethernet-type 'arp'
 set firewall bridge name br2-fwd rule 40 description 'Accept ipv4'
 set firewall bridge name br2-fwd rule 40 action 'accept'
 set firewall bridge name br2-fwd rule 40 ethernet-type 'ipv4'
-  # Drop everythingg else
+  # Drop everything else
 set firewall bridge name br2-fwd default-action 'drop'
 ```
 

--- a/docs/configexamples/fwall-and-bridge.md
+++ b/docs/configexamples/fwall-and-bridge.md
@@ -14,7 +14,7 @@ own requirements.
 
 - Bridge br0:
   : - Isolated layer 2 bridge.
-    - Accept only IPv6 communication whithin the bridge.
+    - Accept only IPv6 communication within the bridge.
 - Bridge br1:
   : - Drop all DHCP discover packets.
     - Accept all ARP packets.
@@ -41,7 +41,7 @@ own requirements.
 First, we need to configure the interfaces and bridges:
 
 ```none
-# Brige br0
+# Bridge br0
 set interfaces bridge br0 description 'Isolated L2 bridge'
 set interfaces bridge br0 member interface eth1
 set interfaces bridge br0 member interface eth2
@@ -133,7 +133,7 @@ And then create the custom rulesets:
 set firewall bridge name br0-pre rule 10 description 'Accept IPv6 traffic'
 set firewall bridge name br0-pre rule 10 action 'accept'
 set firewall bridge name br0-pre rule 10 ethernet-type 'ipv6'
-  # And drop everything else
+  # And drop everythingg else
 set firewall bridge name br0-pre default-action 'drop'
 
 ### br1 - br1-pre
@@ -149,7 +149,7 @@ set firewall bridge name br1-pre rule 10 log
 set firewall bridge name br1-pre rule 20 description 'Drop IPv6 traffic'
 set firewall bridge name br1-pre rule 20 action 'drop'
 set firewall bridge name br1-pre rule 20 ethernet-type 'ipv6'
-  # Accept everything else so it can be parsed later
+  # Accept everythingg else so it can be parsed later
 set firewall bridge name br1-pre default-action 'accept'
 
 ### br2 - br2-pre
@@ -157,7 +157,7 @@ set firewall bridge name br1-pre default-action 'accept'
 set firewall bridge name br2-pre rule 10 description 'Drop IPv6 traffic'
 set firewall bridge name br2-pre rule 10 action 'drop'
 set firewall bridge name br2-pre rule 10 ethernet-type 'ipv6'
-  # Accept everything else so it can be parsed later
+  # Accept everythingg else so it can be parsed later
 set firewall bridge name br2-pre default-action 'accept'
 ```
 
@@ -199,7 +199,7 @@ And the content of the custom rulesets:
 
 ```none
 ### br0 - br0-fwd
-  # Accept everything that wasn't dropped in prerouting
+  # Accept everythingg that wasn't dropped in prerouting
 set firewall bridge name br0-fwd default-action 'accept'
 
 ### br1 - br1-fwd
@@ -212,7 +212,7 @@ set firewall bridge name br1-fwd rule 20 description 'Accept ipv4 from host'
 set firewall bridge name br1-fwd rule 20 action 'accept'
 set firewall bridge name br1-fwd rule 20 source address '10.1.1.102'
 set firewall bridge name br1-fwd rule 20 state 'new'
-  # Drop everythin else within the bridge:
+  # Drop everything else within the bridge:
 set firewall bridge name br1-fwd default-action 'drop'
 
 ### br2 - br2-fwd
@@ -245,7 +245,7 @@ set firewall bridge name br2-fwd rule 30 ethernet-type 'arp'
 set firewall bridge name br2-fwd rule 40 description 'Accept ipv4'
 set firewall bridge name br2-fwd rule 40 action 'accept'
 set firewall bridge name br2-fwd rule 40 ethernet-type 'ipv4'
-  # Drop everything else
+  # Drop everythingg else
 set firewall bridge name br2-fwd default-action 'drop'
 ```
 
@@ -259,7 +259,7 @@ router itself, to other local networks, and to the Internet.
 
 As a reminder, here's a link to the {doc}`firewall documentation
 </configuration/firewall/index>`, where you can find more information about
-the packet flow for traffic that comes from bridge layer and should be analized
+the packet flow for traffic that comes from bridge layer and should be analyzed
 by the IP firewall.
 
 Access to the router itself is controlled by the base chain `input`, and

--- a/docs/configexamples/inter-vrf-routing-vrf-lite.md
+++ b/docs/configexamples/inter-vrf-routing-vrf-lite.md
@@ -122,7 +122,7 @@ in our topology.
 set interface eth eth<N> address <IP ADDRESS/CIDR>
 
 # Static default route back to Core
-set procotols static route 0.0.0.0/0 next-hop <CORE IP ADDRESS>
+set protocols static route 0.0.0.0/0 next-hop <CORE IP ADDRESS>
 ```
 
 
@@ -779,7 +779,7 @@ B>* 10.0.0.0/24 [20/0] via 10.1.1.2, eth0 (vrf LAN1), weight 1, 00:45:28
 S>* 172.16.0.0/24 [1/0] via 172.16.2.2, eth1, weight 1, 00:45:32
 C>* 172.16.2.0/30 is directly connected, eth1, 00:45:39
 B>* 192.0.2.0/24 [20/0] via 10.2.2.2, eth3 (vrf Internet), weight 1, 00:45:24
-B>* 192.168.0.0/24 [20/0] via 192.168.3.2, eth2 (vrf Managment), weight 1, 00:45:27
+B>* 192.168.0.0/24 [20/0] via 192.168.3.2, eth2 (vrf Management), weight 1, 00:45:27
 B>* 198.51.100.0/24 [20/0] via 10.2.2.2, eth3 (vrf Internet), weight 1, 00:45:24
 
 # show ipv6 route vrf LAN2
@@ -787,7 +787,7 @@ B>* 198.51.100.0/24 [20/0] via 10.2.2.2, eth3 (vrf Internet), weight 1, 00:45:24
 C>* 2001:db8::2/127 is directly connected, eth1, 00:46:26
 B>* 2001:db8:0:1::/64 [20/0] via 2001:db8::1, eth0 (vrf LAN1), weight 1, 00:46:17
 S>* 2001:db8:0:2::/64 [1/0] via 2001:db8::3, eth1, weight 1, 00:46:21
-B>* 2001:db8:0:3::/64 [20/0] via 2001:db8::5, eth2 (vrf Managment), weight 1, 00:46:16
+B>* 2001:db8:0:3::/64 [20/0] via 2001:db8::5, eth2 (vrf Management), weight 1, 00:46:16
 B>* 2001:db8:1::/48 [20/0] via fe80::5200:ff:fe02:3, eth3 (vrf Internet), weight 1, 00:46:13
 B>* 2001:db8:2::/48 [20/0] via fe80::5200:ff:fe02:3, eth3 (vrf Internet), weight 1, 00:46:13
 C>* fe80::/64 is directly connected, eth1, 00:46:27

--- a/docs/configuration/firewall/bridge.md
+++ b/docs/configuration/firewall/bridge.md
@@ -489,7 +489,7 @@ supported.
 
 
 Starting from **VyOS-1.5-rolling-202410060007**, the firewall can modify
-packets before they are sent out. This feaure provides more flexibility in
+packets before they are sent out. This feature provides more flexibility in
 packet handling.
 
 ```{cfgcmd} set firewall bridge [prerouting | forward | output] filter rule \<1-999999\> set dscp \<0-63\>

--- a/docs/configuration/firewall/ipv4.md
+++ b/docs/configuration/firewall/ipv4.md
@@ -1404,7 +1404,7 @@ WAN_IN-122
 SUPPORT                  address_group       VyOS_MANAGEMENT-20       192.168.1.2
 WAN_IN-20
 PHONE_VPN_SERVERS        address_group       WAN_IN-160               10.6.32.2
-PINGABLE_ADRESSES        address_group       WAN_IN-170               192.168.5.2
+PINGABLE_ADDRESSES        address_group       WAN_IN-170               192.168.5.2
 WAN_IN-171
 PBX                      ipv6_address_group  IPV6-WAN_IN-100          2001:db8::1
 SERVERS                  ipv6_address_group  IPV6-WAN_IN-110          2001:db8::2

--- a/docs/configuration/firewall/ipv6.md
+++ b/docs/configuration/firewall/ipv6.md
@@ -1425,7 +1425,7 @@ WAN_IN-122
 SUPPORT                  address_group       VyOS_MANAGEMENT-20       192.168.1.2
 WAN_IN-20
 PHONE_VPN_SERVERS        address_group       WAN_IN-160               10.6.32.2
-PINGABLE_ADRESSES        address_group       WAN_IN-170               192.168.5.2
+PINGABLE_ADDRESSES        address_group       WAN_IN-170               192.168.5.2
 WAN_IN-171
 PBX                      ipv6_address_group  IPV6-WAN_IN-100          2001:db8::1
 SERVERS                  ipv6_address_group  IPV6-WAN_IN-110          2001:db8::2

--- a/docs/configuration/nat/nat44.md
+++ b/docs/configuration/nat/nat44.md
@@ -630,7 +630,7 @@ network to a source address provided by the ASP.
 
 Here we provide two examples on how to apply NAT Load Balance.
 
-First scenario: apply destination NAT for all HTTP traffic comming through
+First scenario: apply destination NAT for all HTTP traffic coming through
 interface eth0, and user 4 backends. First backend should received 30% of
 the request, second backend should get 20%, third 15% and the fourth 35%
 We will use source and destination address for hash generation.

--- a/docs/configuration/policy/examples.md
+++ b/docs/configuration/policy/examples.md
@@ -152,8 +152,8 @@ ISP's and VyOS router will respond from the same interface that the packet was
 received. Also, it used, if we want that one VPN tunnel to be through one
 provider, and the second through another.
 
-- `203.0.113.254` IP addreess on VyOS eth1 from ISP1
-- `192.168.2.254` IP addreess on VyOS eth2 from ISP2
+- `203.0.113.254` IP address on VyOS eth1 from ISP1
+- `192.168.2.254` IP address on VyOS eth2 from ISP2
 - `table 10` Routing table used for ISP1
 - `table 11` Routing table used for ISP2
 

--- a/docs/configuration/policy/route-map.md
+++ b/docs/configuration/policy/route-map.md
@@ -1,6 +1,6 @@
 # Route Map Policy
 
-Route map is a powerfull command, that gives network administrators a very
+Route map is a powerful command, that gives network administrators a very
 useful and flexible tool for traffic manipulation.
 
 ## Configuration

--- a/docs/configuration/policy/route.md
+++ b/docs/configuration/policy/route.md
@@ -211,7 +211,7 @@ Set IPSec inbound match criterias, where:
 
 ```{cfgcmd} set policy route6 \<name\> rule \<n\> limit burst \<0-4294967295\>
 
-Set maximum number of packets to alow in excess of rate.
+Set maximum number of packets to allow in excess of rate.
 ```
 
 ```{cfgcmd} set policy route \<name\> rule \<n\> limit rate \<text\>
@@ -351,8 +351,8 @@ Match hop-limit parameter, where 'eq' stands for 'equal'; 'gt' stands for
 
 ### Actions
 
-When mathcing all patterns defined in a rule, then different actions can
-be made. This includes droping the packet, modifying certain data, or
+When matching all patterns defined in a rule, then different actions can
+be made. This includes dropping the packet, modifying certain data, or
 setting a different routing table.
 
 ```{cfgcmd} set policy route \<name\> rule \<n\> action drop

--- a/docs/configuration/protocols/bfd.md
+++ b/docs/configuration/protocols/bfd.md
@@ -165,7 +165,7 @@ and use the gateway address as BFD peer destination address.
 ```{cfgcmd} set protocols static route \<subnet\> next-hop \<address\> bfd multi-hop source \<address\> profile \<profile\>
 
 Configure a static route for \<subnet\> using gateway \<address\>,
-use source address to indentify the peer when is multi-hop session
+use source address to identify the peer when is multi-hop session
 and the gateway address as BFD peer destination address.
 ```
 
@@ -178,7 +178,7 @@ and use the gateway address as BFD peer destination address.
 ```{cfgcmd} set protocols static route6 \<subnet\> next-hop \<address\> bfd multi-hop source \<address\> profile \<profile\>
 
 Configure a static route for \<subnet\> using gateway \<address\>,
-use source address to indentify the peer when is multi-hop session
+use source address to identify the peer when is multi-hop session
 and the gateway address as BFD peer destination address.
 ```
 

--- a/docs/configuration/protocols/bgp.md
+++ b/docs/configuration/protocols/bgp.md
@@ -375,7 +375,7 @@ used when you want to use the same AS number in your sites,
 but you can’t connect them directly.
 
    The number parameter (1-10) configures the amount of accepted
-   occurences of the system AS number in AS path.
+   occurrences of the system AS number in AS path.
 
    This command is only allowed for eBGP peers. It is not applicable
    for peer groups.

--- a/docs/configuration/protocols/segment-routing.md
+++ b/docs/configuration/protocols/segment-routing.md
@@ -91,7 +91,7 @@ the MPLS dataplane.
 
 A segment ID that contains an IP address prefix calculated by an IGP in the
 service provider core network. Prefix SIDs are globally unique, this value
-indentify it
+identify it
 ```
 
 
@@ -174,7 +174,7 @@ the MPLS dataplane.
 
 A segment ID that contains an IP address prefix calculated by an IGP in the
 service provider core network. Prefix SIDs are globally unique, this value
-indentify it
+identify it
 ```
 
 ```{cfgcmd} set protocols ospf segment-routing prefix \<address\> index \<no-php-flag | explicit-null| n-flag-clear\>

--- a/docs/configuration/service/conntrack-sync.md
+++ b/docs/configuration/service/conntrack-sync.md
@@ -27,7 +27,7 @@ will be mandatorily defragmented.
 
 It is possible to use either Multicast or Unicast to sync conntrack traffic.
 Most examples below show Multicast, but unicast can be specified by using the
-"peer" keywork after the specified interface, as in the following example:
+"peer" keyword after the specified interface, as in the following example:
 
 {cfgcmd}`set service conntrack-sync interface eth0 peer 192.168.0.250`
 
@@ -100,8 +100,8 @@ Defaults to 225.0.0.50.
 
 ```{cfgcmd} set service conntrack-sync interface \<name\> peer \<address\>
 
-Peer to send unicast UDP conntrack sync entires to, if not using Multicast
-configuration from above above.
+Peer to send unicast UDP conntrack sync entries to, if not using Multicast
+configuration from above.
 ```
 
 
@@ -113,7 +113,7 @@ Queue size for syncing conntrack entries in MB.
 
 ```{cfgcmd} set service conntrack-sync disable-external-cache
 
-This diable the external cache and directly injects the flow-states into the
+This disables the external cache and directly injects the flow-states into the
 in-kernel Connection Tracking System of the backup firewall.
 ```
 

--- a/docs/configuration/service/console-server.md
+++ b/docs/configuration/service/console-server.md
@@ -75,7 +75,7 @@ port.
 ```{cfgcmd} set service console-server device \<device\> ssh port \<port\>
 
 Accept SSH connections for the given `<device>` on TCP port `<port>`.
-After successfull authentication the user will be directly dropped to
+After successful authentication the user will be directly dropped to
 the connected serial device.
 
 :::{hint}

--- a/docs/configuration/service/dhcp-server.md
+++ b/docs/configuration/service/dhcp-server.md
@@ -209,7 +209,7 @@ level, i.e. for individual shared networks or subnets. See examples below.
 
 If set to ``enable`` on global level, updates for all scopes will be enabled,
 except if explicitly set to ``disable`` on the scope level. If set to ``disable``,
-updates will only be sent for scopes, where ``send-updates`` is explicity
+updates will only be sent for scopes, where ``send-updates`` is explicitly
 set to ``enable``.
 
 This model is followed for a few behavioral settings below: if the option is
@@ -579,7 +579,7 @@ NB: Kea (the DHCP server used by VyOS) is programmed to offer as many
 alternatives as it can to repeated DHCP Discover requests. Some operating
 systems (Notably Microsoft Windows) make multiple DHCP Discover requests before
 settling on an address. This particularly seems to happen when the DHCP server
-isn't set to authorative. This may explain why the address you espect isn't
+isn't set to authoritative. This may explain why the address you expect isn't
 being chosen. Wireshark is helpful in these situations.
 
 
@@ -1010,14 +1010,14 @@ A SNTP server address can be specified for DHCPv6 clients.
 To hand out individual prefixes to your clients the following configuration is
 used:
 
-```{cfgcmd} set service dhcpv6-server shared-network-name \<name\> subnet \<prefix\> prefix-delegation prefix \<pd-prefix\> prefix-length \<lenght\>
+```{cfgcmd} set service dhcpv6-server shared-network-name \<name\> subnet \<prefix\> prefix-delegation prefix \<pd-prefix\> prefix-length \<length\>
 
 Delegate prefixes from `<pd-prefix>` to clients in subnet `<prefix>`. Range
-is defined by `<lenght>` in bits, 32 to 64.
+is defined by `<length>` in bits, 32 to 64.
 ```
 
 
-```{cfgcmd} set service dhcpv6-server shared-network-name \<name\> subnet \<prefix\> prefix-delegation prefix \<pd-prefix\> delegated-length \<lenght\>
+```{cfgcmd} set service dhcpv6-server shared-network-name \<name\> subnet \<prefix\> prefix-delegation prefix \<pd-prefix\> delegated-length \<length\>
 
 Hand out prefixes of size `<length>` in bits from `<pd-prefix>` to clients
 in subnet `<prefix>` when the request for prefix delegation.
@@ -1030,7 +1030,7 @@ Exclude `<exclude-prefix>` from `<pd-prefix>`.
 ```
 ```{cfgcmd} set service dhcpv6-server shared-network-name \<name\> subnet \<prefix\> prefix-delegation prefix \<pd-prefix\> excluded-prefix-length \<length\>
 
-Define lenght of exclude prefix in `<pd-prefix>`.
+Define length of exclude prefix in `<pd-prefix>`.
 ```
 
 **Example:**

--- a/docs/configuration/service/eventhandler.md
+++ b/docs/configuration/service/eventhandler.md
@@ -76,8 +76,7 @@ This is an optional command. Adds arguments to the script.
 Arguments must be separated by spaces.
 
 :::{note}
-We don't recommend to use arguments. Using environments
-is more preferable.
+We don't recommend using arguments. Using environment variables is preferable.
 :::
 ```
 

--- a/docs/configuration/service/ipoe-server.md
+++ b/docs/configuration/service/ipoe-server.md
@@ -162,7 +162,7 @@ to a single source IP e.g. the loopback interface.
 
 ```{cfgcmd} set service ipoe-server authentication radius source-address \<address\>
 
-Source IPv4 address used in all RADIUS server queires.
+Source IPv4 address used in all RADIUS server queries.
 ```
 
 :::{note}
@@ -244,7 +244,7 @@ in DM/CoA requests. Also DM/CoA server will bind to that address.
 
 ```{cfgcmd} set service ipoe-server authentication radius source-address \<address\>
 
-Source IPv4 address used in all RADIUS server queires.
+Source IPv4 address used in all RADIUS server queries.
 ```
 
 
@@ -292,7 +292,7 @@ will be allocated from a predefined IPv6 pool ``prefix`` whose name equals the a
 
 
 If the RADIUS server sends the attribute ``Delegated-IPv6-Prefix-Pool``, IPv6
-delegation pefix will be allocated from a predefined IPv6 pool ``delegate``
+delegation prefix will be allocated from a predefined IPv6 pool ``delegate``
 whose name equals the attribute value.
 
 
@@ -311,7 +311,7 @@ Define it in your RADIUS server.
 
 ```{cfgcmd} set service ipoe-server client-ipv6-pool \<IPv6-POOL-NAME\> prefix \<address\>  mask \<number-of-bits\>
 
-Use this comand to set the IPv6 address pool from which an IPoE client
+Use this command to set the IPv6 address pool from which an IPoE client
 will get an IPv6 prefix of your defined length (mask) to terminate the
 IPoE endpoint at their side. The mask length can be set from 48 to 128
 bit long, the default value is 64.
@@ -492,7 +492,7 @@ ipoe:
   delayed: 0
 ```
 
-## Toubleshooting
+## Troubleshooting
 
 ```none
 vyos@vyos:~$ show log ipoe-server

--- a/docs/configuration/service/monitoring.md
+++ b/docs/configuration/service/monitoring.md
@@ -98,7 +98,7 @@ Local IP addresses to listen on
 
 ```{cfgcmd} set service monitoring telegraf prometheus-client metric-version \<1 | 2\>
 
-Metris version, the default is ``2``
+Metrics version, the default is ``2``
 ```
 
 

--- a/docs/configuration/service/pppoe-server.md
+++ b/docs/configuration/service/pppoe-server.md
@@ -123,7 +123,7 @@ to a single source IP e.g. the loopback interface.
 
 ```{cfgcmd} set service pppoe-server authentication radius source-address \<address\>
 
-Source IPv4 address used in all RADIUS server queires.
+Source IPv4 address used in all RADIUS server queries.
 ```
 
 :::{note}
@@ -205,7 +205,7 @@ in DM/CoA requests. Also DM/CoA server will bind to that address.
 
 ```{cfgcmd} set service pppoe-server authentication radius source-address \<address\>
 
-Source IPv4 address used in all RADIUS server queires.
+Source IPv4 address used in all RADIUS server queries.
 ```
 
 
@@ -254,7 +254,7 @@ whose name equals the attribute value.
 
 
 If the RADIUS server sends the attribute `Delegated-IPv6-Prefix-Pool`,
-IPv6 delegation pefix will be allocated from a predefined IPv6 pool `delegate`
+IPv6 delegation prefix will be allocated from a predefined IPv6 pool `delegate`
 whose name equals the attribute value.
 
 
@@ -407,7 +407,7 @@ Specifies IPv6 negotiation preference.
 
 ```{cfgcmd} set service pppoe-server client-ipv6-pool \<IPv6-POOL-NAME\> prefix \<address\> mask \<number-of-bits\>
 
-Use this comand to set the IPv6 address pool from which an PPPoE client
+Use this command to set the IPv6 address pool from which a PPPoE client
 will get an IPv6 prefix of your defined length (mask) to terminate the
 PPPoE endpoint at their side. The mask length can be set from 48 to 128
 bit long, the default value is 64.

--- a/docs/configuration/service/salt-minion.md
+++ b/docs/configuration/service/salt-minion.md
@@ -45,7 +45,7 @@ The hostname or IP address of the master
 URL with signature of master for auth reply verification
 ```
 
-Please take a look in the Automation section to find some usefull
+Please take a look in the Automation section to find some useful
 Examples.
 
 [saltstack]: https://saltproject.io/

--- a/docs/configuration/system/conntrack.md
+++ b/docs/configuration/system/conntrack.md
@@ -40,9 +40,9 @@ searching the connection tracking table faster. The hash table uses
 .. cfgcmd:: set system conntrack modules tftp
 
     Configure the connection tracking protocol helper modules.
-    All modules are enable by default.
+    All modules are enabled by default.
 
-    | Use `delete system conntrack modules` to deactive all modules.
+    | Use `delete system conntrack modules` to deactivate all modules.
     | Or, for example ftp, `delete system conntrack modules ftp`.
 ```
 
@@ -52,7 +52,7 @@ searching the connection tracking table faster. The hash table uses
 Set the maximum number of TCP half-open connections.
 ```
 
-```{cfgcmd} set system conntrack tcp loose \<enable | disable\>
+```{cfgcmd} set system conntrack tcp loose \<enabled | disable\>
 :defaultvalue:
 
 Policy to track previously established connections.

--- a/docs/configuration/system/conntrack.md
+++ b/docs/configuration/system/conntrack.md
@@ -52,7 +52,7 @@ searching the connection tracking table faster. The hash table uses
 Set the maximum number of TCP half-open connections.
 ```
 
-```{cfgcmd} set system conntrack tcp loose \<enabled | disable\>
+```{cfgcmd} set system conntrack tcp loose \<enable | disable\>
 :defaultvalue:
 
 Policy to track previously established connections.

--- a/docs/configuration/system/frr.md
+++ b/docs/configuration/system/frr.md
@@ -11,7 +11,7 @@ but requires either a restart of the routing daemon, or a reboot of the system.
 Enable {abbr}`BMP (BGP Monitoring Protocol)` support.
 ```
 
-```{cfgcmd} set system frr descriptors \<numer\>
+```{cfgcmd} set system frr descriptors \<number\>
 
 This allows the operator to control the number of open file descriptors
 each daemon is allowed to start with. If the operator plans to run bgp with

--- a/docs/configuration/system/option.md
+++ b/docs/configuration/system/option.md
@@ -154,7 +154,7 @@ layout here corresponds to your access system.
 
 ## Performance
 
-As more and more routers run on Hypervisors, expecially with a {abbr}`NOS
+As more and more routers run on Hypervisors, especially with a {abbr}`NOS
 (Network Operating System)` as VyOS, it makes fewer and fewer sense to use
 static resource bindings like `smp-affinity` as present in VyOS 1.2 and
 earlier to pin certain interrupt handlers to specific CPUs.

--- a/docs/configuration/system/proxy.md
+++ b/docs/configuration/system/proxy.md
@@ -17,11 +17,11 @@ Configure proxy port if it does not listen to the default port 80.
 ```
 ```{cfgcmd} set system proxy username \<username\>
 
-Some proxys require/support the "basic" HTTP authentication scheme as per
+Some proxies require/support the "basic" HTTP authentication scheme as per
 {rfc}`7617`, thus a username can be configured.
 ```
 ```{cfgcmd} set system proxy password \<password\>
 
-Some proxys require/support the "basic" HTTP authentication scheme as per
+Some proxies require/support the "basic" HTTP authentication scheme as per
 {rfc}`7617`, thus a password can be configured.
 ```

--- a/docs/configuration/trafficpolicy/index.md
+++ b/docs/configuration/trafficpolicy/index.md
@@ -1061,7 +1061,7 @@ class.
 ```{cfgcmd} set qos policy shaper \<policy-name\> class \<class-ID\> burst \<bytes\>
 
 Use this command to configure a Shaper policy, set its name, define
-a class and set the size of the tocken bucket in bytes, which will
+a class and set the size of the token bucket in bytes, which will
 be available to be sent at ceiling speed (default: 15Kb).
 ```
 
@@ -1296,4 +1296,4 @@ which can be solved with `sudo ip link delete ifb0`.
 [intermediate functional block]: https://www.linuxfoundation.org/collaborate/workgroups/networking/ifb
 [tc]: <https://en.wikipedia.org/wiki/Tc_(Linux)>
 [that can give you a great deal of flexibility]: https://blog.vyos.io/using-the-policy-route-and-packet-marking-for-custom-qos-matches
-[tocken bucket]: <https://en.wikipedia.org/wiki/Token_bucket>
+[token bucket]: <https://en.wikipedia.org/wiki/Token_bucket>

--- a/docs/configuration/vpn/ipsec/ipsec_general.md
+++ b/docs/configuration/vpn/ipsec/ipsec_general.md
@@ -112,7 +112,7 @@ available. The use of PPKs in IKEv2 is described in {rfc}`8784`.
 .. cfgmod:: edit vpn authentication ppk <name>
 ```
 
-PPKs can be configued within VyOS under the `vpn ipsec authentication ppk`
+PPKs can be configured within VyOS under the `vpn ipsec authentication ppk`
 config.
 
 ```{eval-rst}
@@ -143,10 +143,10 @@ Optionally, you can require the use of PPK to have a successful connection.
 
 You can view the PPK column for information on if PPK is configured, and
 if it is in use. The output is in the format of `<configured> / <in use>`.
-The options for configured are none if not conifugred, opt if configured
+The options for configured are none if not configured, opt if configured
 but optional, and req is configured and required. The in use will show yes
 Possible values of the `configured` field are `none` if not
-conifgured, `opt` if configured but optional, and `req` is
+configured, `opt` if configured but optional, and `req` is
 configured and required. The in use will show yes
 
 ## Configuration IKE

--- a/docs/configuration/vpn/l2tp.md
+++ b/docs/configuration/vpn/l2tp.md
@@ -159,7 +159,7 @@ e.g. the loopback interface.
 
 ```{cfgcmd} set vpn l2tp remote-access authentication radius source-address \<address\>
 
-Source IPv4 address used in all RADIUS server queires.
+Source IPv4 address used in all RADIUS server queries.
 ```
 
 :::{note}
@@ -229,7 +229,7 @@ in DM/CoA requests. Also DM/CoA server will bind to that address.
 
 ```{cfgcmd} set vpn l2tp remote-access authentication radius source-address \<address\>
 
-Source IPv4 address used in all RADIUS server queires.
+Source IPv4 address used in all RADIUS server queries.
 ```
 
 ```{cfgcmd} set vpn l2tp remote-access authentication radius rate-limit attribute \<attribute\>
@@ -324,7 +324,7 @@ Specifies IPv6 negotiation preference.
 
 ```{cfgcmd} set vpn l2tp remote-access client-ipv6-pool \<IPv6-POOL-NAME\> prefix \<address\> mask \<number-of-bits\>
 
-Use this comand to set the IPv6 address pool from which an l2tp client will
+Use this command to set the IPv6 address pool from which an l2tp client will
 get an IPv6 prefix of your defined length (mask) to terminate the l2tp
 endpoint at their side. The mask length can be set between 48 and 128 bits
 long, the default value is 64.

--- a/docs/configuration/vpn/openconnect.md
+++ b/docs/configuration/vpn/openconnect.md
@@ -156,7 +156,7 @@ Do you want to encrypt the private key with a passphrase? [y/N] N
 [edit]
 ```
 
-Each of the install command should be applied to the configuration and commited
+Each of the install commands should be applied to the configuration and committed
 before using under the openconnect configuration:
 
 ```none

--- a/docs/configuration/vpn/pptp.md
+++ b/docs/configuration/vpn/pptp.md
@@ -93,7 +93,7 @@ to a single source IP e.g. the loopback interface.
 
 ```{cfgcmd} set vpn pptp remote-access authentication radius source-address \<address\>
 
-Source IPv4 address used in all RADIUS server queires.
+Source IPv4 address used in all RADIUS server queries.
 ```
 
 :::{note}
@@ -163,7 +163,7 @@ in DM/CoA requests. Also DM/CoA server will bind to that address.
 
 ```{cfgcmd} set vpn pptp remote-access authentication radius source-address \<address\>
 
-Source IPv4 address used in all RADIUS server queires.
+Source IPv4 address used in all RADIUS server queries.
 ```
 
 ```{cfgcmd} set vpn pptp remote-access authentication radius rate-limit attribute \<attribute\>
@@ -204,7 +204,7 @@ If the RADIUS server sends the attribute `Stateful-IPv6-Address-Pool`, IPv6 addr
 will be allocated from a predefined IPv6 pool `prefix` whose name equals the attribute value.
 
 If the RADIUS server sends the attribute `Delegated-IPv6-Prefix-Pool`, IPv6
-delegation pefix will be allocated from a predefined IPv6 pool `delegate`
+delegation prefix will be allocated from a predefined IPv6 pool `delegate`
 whose name equals the attribute value.
 
 :::{note}
@@ -239,7 +239,7 @@ Specifies IPv6 negotiation preference.
 
 ```{cfgcmd} set vpn pptp remote-access client-ipv6-pool \<IPv6-POOL-NAME\> prefix \<address\> mask \<number-of-bits\>
 
-Use this comand to set the IPv6 address pool from which an PPTP client
+Use this command to set the IPv6 address pool from which a PPTP client
 will get an IPv6 prefix of your defined length (mask) to terminate the
 PPTP endpoint at their side. The mask length can be set from 48 to 128
 bit long, the default value is 64.

--- a/docs/configuration/vpn/sstp.md
+++ b/docs/configuration/vpn/sstp.md
@@ -129,7 +129,7 @@ e.g. the loopback interface.
 
 ```{cfgcmd} set vpn sstp authentication radius source-address \<address\>
 
-Source IPv4 address used in all RADIUS server queires.
+Source IPv4 address used in all RADIUS server queries.
 ```
 
 :::{note}
@@ -199,7 +199,7 @@ in DM/CoA requests. Also DM/CoA server will bind to that address.
 
 ```{cfgcmd} set vpn sstp authentication radius source-address \<address\>
 
-Source IPv4 address used in all RADIUS server queires.
+Source IPv4 address used in all RADIUS server queries.
 ```
 
 ```{cfgcmd} set vpn sstp authentication radius rate-limit attribute \<attribute\>
@@ -278,7 +278,7 @@ Specifies IPv6 negotiation preference.
 
 ```{cfgcmd} set vpn sstp client-ipv6-pool \<IPv6-POOL-NAME\> prefix \<address\> mask \<number-of-bits\>
 
-Use this comand to set the IPv6 address pool from which an SSTP client will
+Use this command to set the IPv6 address pool from which an SSTP client will
 get an IPv6 prefix of your defined length (mask) to terminate the SSTP
 endpoint at their side. The mask length can be set between 48 and 128 bits
 long, the default value is 64.
@@ -555,7 +555,7 @@ nodeflate
 debug
 ```
 
-You can now "dial" the peer with the follwoing command: `sstpc --log-level 4
+You can now "dial" the peer with the following command: `sstpc --log-level 4
 --log-stderr --user vyos --password vyos vpn.example.com -- call vyos`.
 
 A connection attempt will be shown as:

--- a/docs/configuration/vrf/index.md
+++ b/docs/configuration/vrf/index.md
@@ -495,9 +495,9 @@ BGP routes may be leaked (i.e. copied) between a unicast VRF RIB and the VPN
 SAFI RIB of the default VRF for use in MPLS-based L3VPNs. Unicast routes may
 also be leaked between any VRFs (including the unicast RIB of the default BGP
 instance). A shortcut syntax is also available for specifying leaking from
-one VRF to another VRF using the default instance’s VPN RIB as the intemediary
-. A common application of the VRF-VRF feature is to connect a customer’s
-private routing domain to a provider’s VPN service. Leaking is configured from
+one VRF to another VRF using the default instance’s VPN RIB as the intermediary.
+A common application of the VRF-VRF feature is to connect a customer’s private
+routing domain to a provider’s VPN service. Leaking is configured from
 the point of view of an individual VRF: import refers to routes leaked from VPN
 to a unicast VRF, whereas export refers to routes leaked from a unicast VRF to
 VPN.

--- a/docs/installation/bare-metal.md
+++ b/docs/installation/bare-metal.md
@@ -410,9 +410,9 @@ i3-N305 CPU and 2x 25GbE!
 
 ### Cooling
 
-The device itself is passivly cooled, whereas the power supply has an active fan.
+The device itself is passively cooled, whereas the power supply has an active fan.
 Even if the main processor is powered off, the power supply fan is operating and
-the entire chassis draws 7.5W. During operation the chassis drew arround 38W.
+the entire chassis draws 7.5W. During operation the chassis drew around 38W.
 
 ### BIOS Settings
 


### PR DESCRIPTION
## What

Ports the typo/grammar sweep originally captured in PR #1852 from `.rst` files to their MyST `.md` equivalents on this branch.

- 73 typo/grammar substitutions from PR #1852 (which rebased PR #1801)
- 1 grammar fix from Copilot's review on #1852 — `"Using environments is more preferable"` → `"Using environment variables is preferable"` in `eventhandler.md` (originally skipped as scope-stretch on #1852)

PR #1852 itself is being **discarded** since it targets the RST tree, which is being phased out in favor of MyST.

## Substitution method

The patch was extracted from #1852, parsed into 73 word-level substitution pairs, then applied per-file with two strategies:
1. **Exact block match** (52 substitutions) — direct text replacement of the changed RST line/block
2. **Trailing-whitespace-stripped block match** (3 substitutions) — same, but tolerant of RST trailing-space artifacts that don't survive MyST conversion
3. **Curated single-word fallbacks** (4 substitutions) — for cases where the block match fails because RST list-bullet syntax (`* ` vs `- `), inline-code syntax (`` `` `` vs `` ` ``), or RST link targets (`_text:`) differ from MyST. The fallback typo words (`addreess`, `entires`, `above above`, `conifgured`) are unique misspellings that don't substring-match into legitimate words.

No automatic char-level decomposition was used (one early attempt produced `proxys` → `proxies` decomposing to `y` → `ie`, corrupting `system` → `siestem` and `VyOS` → `VieOS` — discarded).

## What's in / out of scope

**In:** All 73 substitutions from #1852 + the eventhandler grammar fix.

**Out:**
- 4 RST-linter 80-char line-wrap fixes from Copilot review on #1852 — RST-specific, no MyST equivalent
- 1 RST section-underline-length fix (`Toubleshooting` → `Troubleshooting` underline mismatch) — the `*` underline syntax doesn't exist in MyST, where the heading is just `# Troubleshooting`
- The `_locale/*.pot` translation source files — auto-generated; will regenerate next build
- Other instances of `successfull` / `authorative` / `espect` outside the #1852 file list — preserved as-is; out of scope

## Verification

```
$ git diff --shortstat
 35 files changed, 89 insertions(+), 90 deletions(-)
```

Spot-checks of representative diffs (`dhcp-server.md`, `eventhandler.md`, `vrf/index.md` line-reflow, `trafficpolicy/index.md` link-target) all show clean per-typo substitutions with no unintended over-matching.

## Sibling PRs

This is the `myst/current` PR. Sibling PRs land the same fixes on:
- `myst/circinus` and `myst/sagitta` (fully-converted MyST branches)
- `feat/incremental-myst-swap[-circinus|-sagitta]` (the `md-<name>.md` swap-target files)

🤖 Generated by [robots](https://vyos.io)
