### PR TITLE
docs: link "View page source" to GitHub instead of raw text

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,6 +115,14 @@ html_extra_path = ['_html_extra']
 
 html_baseurl = 'https://docs.vyos.io/en/latest/'
 
+html_context = {
+    'display_github': True,
+    'github_user': 'vyos',
+    'github_repo': 'vyos-documentation',
+    'github_version': os.environ.get('READTHEDOCS_GIT_IDENTIFIER', 'current'),
+    'conf_py_path': '/docs/',
+}
+
 # sphinx-sitemap: baseurl already includes /en/latest/, so skip lang+version
 sitemap_url_scheme = '{link}'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,11 +115,18 @@ html_extra_path = ['_html_extra']
 
 html_baseurl = 'https://docs.vyos.io/en/latest/'
 
+_rtd_version_type = os.environ.get('READTHEDOCS_VERSION_TYPE', '')
+_github_version = (
+    os.environ.get('READTHEDOCS_GIT_COMMIT_HASH', 'current')
+    if _rtd_version_type == 'external'
+    else os.environ.get('READTHEDOCS_GIT_IDENTIFIER', 'current')
+)
+
 html_context = {
     'display_github': True,
     'github_user': 'vyos',
     'github_repo': 'vyos-documentation',
-    'github_version': os.environ.get('READTHEDOCS_GIT_IDENTIFIER', 'current'),
+    'github_version': _github_version,
     'conf_py_path': '/docs/',
 }
 


### PR DESCRIPTION
## Summary

- Adds `html_context` to `docs/conf.py` with `display_github: True`
- The `sphinx_rtd_theme` uses this to replace the "View page source" button (which opened raw RST/MD in the browser) with an "Edit on GitHub" link pointing at the correct file and branch
- For RTD PR preview builds (`READTHEDOCS_VERSION_TYPE == 'external'`), `READTHEDOCS_GIT_COMMIT_HASH` is used as the GitHub ref (the commit SHA), since `READTHEDOCS_GIT_IDENTIFIER` for PR builds contains only the numeric PR number which is not a valid GitHub ref; local builds fall back to `current`

## Test plan

- [ ] Check RTD preview: clicking "Edit on GitHub" on any page opens the file on GitHub rather than raw text in the browser
- [ ] Verify local build still works

🤖 Generated by [robots](https://vyos.io)