### PR TITLE
docs: link "View page source" to GitHub instead of raw text

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,11 +111,18 @@ html_static_path = ['_static']
 
 html_extra_path = ['_html_extra']
 
+_rtd_version_type = os.environ.get('READTHEDOCS_VERSION_TYPE', '')
+_github_version = (
+    os.environ.get('READTHEDOCS_GIT_COMMIT_HASH', 'circinus')
+    if _rtd_version_type == 'external'
+    else os.environ.get('READTHEDOCS_GIT_IDENTIFIER', 'circinus')
+)
+
 html_context = {
     'display_github': True,
     'github_user': 'vyos',
     'github_repo': 'vyos-documentation',
-    'github_version': os.environ.get('READTHEDOCS_GIT_IDENTIFIER', 'circinus'),
+    'github_version': _github_version,
     'conf_py_path': '/docs/',
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,6 +111,14 @@ html_static_path = ['_static']
 
 html_extra_path = ['_html_extra']
 
+html_context = {
+    'display_github': True,
+    'github_user': 'vyos',
+    'github_repo': 'vyos-documentation',
+    'github_version': os.environ.get('READTHEDOCS_GIT_IDENTIFIER', 'circinus'),
+    'conf_py_path': '/docs/',
+}
+
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #


### PR DESCRIPTION
## Summary

- Adds `html_context` to `docs/conf.py` with `display_github: True`
- The `sphinx_rtd_theme` uses this to replace the "View page source" button (which opened raw RST/MD in the browser) with an "Edit on GitHub" link pointing at the correct file and branch
- For RTD PR preview builds (`READTHEDOCS_VERSION_TYPE == 'external'`), `READTHEDOCS_GIT_COMMIT_HASH` is used as the GitHub ref (the commit SHA), since `READTHEDOCS_GIT_IDENTIFIER` for PR builds contains only the numeric PR number which is not a valid GitHub ref; local builds fall back to `circinus`

Backport of [#1887](https://github.com/vyos/vyos-documentation/pull/1887).

## Test plan

- [ ] Check RTD preview: clicking "Edit on GitHub" on any page opens the file on GitHub rather than raw text in the browser

🤖 Generated by [robots](https://vyos.io)