### PR TITLE
docs(robots): allow AI crawlers + correct sitemap URL (sagitta)

### DIFF
--- a/docs/_html_extra/robots.txt
+++ b/docs/_html_extra/robots.txt
@@ -1,7 +1,36 @@
-User-agent: atlassian-bot
+User-agent: *
 Allow: /
 
-User-agent: *
-Disallow: # Allow everything
+# AI Training Crawlers
+User-agent: GPTBot
+Allow: /
 
-Sitemap: https://docs.vyos.io/sitemap.xml
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+# AI Search/Retrieval
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+Sitemap: https://docs.vyos.io/en/1.4/sitemap.xml


### PR DESCRIPTION
Backports the AI-crawler allow rules and sitemap URL fix from [#1832](https://github.com/vyos/vyos-documentation/pull/1832) (current) and #1873 (circinus) to sagitta.

This was the only still-needed deliverable from the now-closed [#1870](https://github.com/vyos/vyos-documentation/pull/1870) — the other 3 (`_html_extra/llms.txt`, `conf.py` extensions, `requirements.txt` pins) were superseded by [#1876](https://github.com/vyos/vyos-documentation/pull/1876) which landed the build-time `llms.txt` render on sagitta.

## Summary

- **Allow rules for AI crawlers** — same set already on `current`/`circinus`: `GPTBot`, `ClaudeBot`, `Google-Extended`, `CCBot`, `PerplexityBot` (training); `ChatGPT-User`, `Claude-SearchBot`, `Claude-User`, `OAI-SearchBot`, `Perplexity-User` (search/retrieval).
- **Fix `Sitemap:` URL** — was `https://docs.vyos.io/sitemap.xml` (doesn't exist on RTD's per-version layout). Now `https://docs.vyos.io/en/1.4/sitemap.xml` matching `html_baseurl` and `sphinx-sitemap`'s output.
- **Drop `atlassian-bot` Allow** — covered by `User-agent: *`. Matches the form on `current`/`circinus`.

## Why

`current` (1.5+ rolling) and `circinus` (1.5 LTS) already have this; sagitta is the only branch still using the pre-MT-939 robots.txt. With sagitta now publishing `llms.txt` + `llms-full.txt` + `<page>.md` raw markdown via [#1876](https://github.com/vyos/vyos-documentation/pull/1876), having LLM crawlers blocked by the wrong robots.txt is a regression.

## Test plan

- [x] `docs/_html_extra/robots.txt` parses cleanly
- [ ] RTD preview build succeeds
- [ ] After merge: `https://docs.vyos.io/en/1.4/robots.txt` shows the AI-crawler allow rules + `Sitemap: /en/1.4/sitemap.xml`

🤖 Generated by [robots](https://vyos.io)
