### PR TITLE
docs(robots): fix stale sitemap URL on current

### DIFF
--- a/docs/_html_extra/robots.txt
+++ b/docs/_html_extra/robots.txt
@@ -33,4 +33,4 @@ Allow: /
 User-agent: Perplexity-User
 Allow: /
 
-Sitemap: https://docs.vyos.io/sitemap.xml
+Sitemap: https://docs.vyos.io/en/rolling/sitemap.xml


### PR DESCRIPTION
One-line fix: `Sitemap:` URL in `docs/_html_extra/robots.txt` was `https://docs.vyos.io/sitemap.xml`, which doesn't exist on RTD's per-version layout. The actual sitemap is generated by `sphinx-sitemap` at `/en/rolling/sitemap.xml` (matching `html_baseurl`).

## Summary

```diff
- Sitemap: https://docs.vyos.io/sitemap.xml
+ Sitemap: https://docs.vyos.io/en/rolling/sitemap.xml
```

## Per-branch state after this lands

| Branch | Sitemap URL | Status |
|--------|-------------|--------|
| `current` (this PR) | `/en/rolling/sitemap.xml` | ✓ canonical |
| `circinus` | `/en/1.5/sitemap.xml` | ✓ already correct |
| `sagitta` | `/en/1.4/sitemap.xml` (after [#1904](https://github.com/vyos/vyos-documentation/pull/1904)) | ✓ |

## Test plan

- [ ] RTD preview build succeeds
- [ ] After merge: `curl https://docs.vyos.io/en/rolling/robots.txt` shows `Sitemap: https://docs.vyos.io/en/rolling/sitemap.xml`
- [ ] `https://docs.vyos.io/en/rolling/sitemap.xml` already serves (verified by sphinx-sitemap output)

🤖 Generated by [robots](https://vyos.io)
