### PR TITLE
fix(docs): integrate swap_sources into sagitta Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,22 +12,44 @@ AUTOHOST      = 0.0.0.0
 AUTOPORT      = 8000
 AUTOOPTS      = --watch .
 
+SWAP          = python3 ../scripts/swap_sources.py
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help Makefile swap restore html dirhtml pdf livehtml defaultvalue
+
+swap:
+	$(SWAP) --swap
+
+restore:
+	$(SWAP) --restore
+
+html: swap
+	@trap '$(SWAP) --restore' EXIT; \
+		$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+dirhtml: swap
+	@trap '$(SWAP) --restore' EXIT; \
+		$(SPHINXBUILD) -M dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+pdf: swap
+	@trap '$(SWAP) --restore' EXIT; \
+		$(SPHINXBUILD) -M latexpdf "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+livehtml: swap
+	@trap '$(SWAP) --restore' EXIT; \
+		sphinx-autobuild --host $(AUTOHOST) --port $(AUTOPORT) \
+		--ignore '$(BUILDDIR)/**' \
+		--ignore '**/_build/**' \
+		--ignore '**/md-*' \
+		"$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+defaultvalue: export VYOS_DEFAULT=True
+defaultvalue: html
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
-livehtml:
-	sphinx-autobuild --host $(AUTOHOST) --port $(AUTOPORT) $(AUTOOPTS) \
-		"$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
-
-defaultvalue: export VYOS_DEFAULT=True
-defaultvalue:	
-	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
Brings sagitta's `docs/Makefile` to parity with the post-MyST-flip Makefile that already lives on `current` and `circinus`. The two are byte-identical; sagitta is the outlier.

## Why

`current`/`circinus` auto-run `swap_sources.py --swap` as a prerequisite of `html`/`dirhtml`/`pdf`/`livehtml`, with a `--restore` trap on exit so the working tree is left clean even on build failure. Sagitta's Makefile lacks this entirely.

Today the override list (`docs/_rst_overrides.txt`) is empty on all branches, so the missing integration doesn't actually break anything. But the moment a maintainer flags a page in sagitta's `_rst_overrides.txt` (e.g. for one-off RST fallback), `make html` would silently skip the swap and ship the wrong content. Better to fix the latent footgun now.

## What changes

```diff
+SWAP          = python3 ../scripts/swap_sources.py
...
-.PHONY: help Makefile
+.PHONY: help Makefile swap restore html dirhtml pdf livehtml defaultvalue
+
+swap:
+	$(SWAP) --swap
+
+restore:
+	$(SWAP) --restore
+
+html: swap
+	@trap '$(SWAP) --restore' EXIT; \
+		$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+dirhtml: swap
+	@trap '$(SWAP) --restore' EXIT; ...
+pdf: swap
+	@trap '$(SWAP) --restore' EXIT; ...
+livehtml: swap
+	@trap '$(SWAP) --restore' EXIT; ...
+
 defaultvalue: export VYOS_DEFAULT=True
-defaultvalue:	
-	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+defaultvalue: html
```

The result is byte-identical to `docs/Makefile` on `current` and `circinus` at the time of writing.

## Cross-PR note

[#1907](https://github.com/vyos/vyos-documentation/pull/1907) (sagitta CLAUDE.md backport) currently has a commit by Copilot fixing the docs to say "swap is manual" — that's accurate against today's sagitta. Once this PR merges, that wording becomes wrong; will push a small follow-up commit to #1907 to revert it back to the current/circinus wording ("Running `make html` runs the swap automatically").

## Test plan

- [x] `make swap` and `make restore` parse cleanly
- [x] Diff against current/circinus Makefile is empty (verified locally)
- [ ] RTD preview build succeeds (`make html` would invoke swap as prereq, then trap-restore on exit)
- [ ] Verify on RTD preview that the build still completes — empty `_rst_overrides.txt` means swap is a no-op anyway

🤖 Generated by [robots](https://vyos.io)
