### PR TITLE
chore(github): fix grammar in PR template comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- All PR should follow this template to allow a clean and transparent review -->
+<!-- All PRs should follow this template to allow a clean and transparent review -->
 <!-- Text placed between these delimiters is considered a comment and is not rendered -->
 
 ## Change Summary


### PR DESCRIPTION
## Change Summary

Fix the subject/verb disagreement on line 1 of the PR template comment:

> ~~All PR should follow~~ → **All PRs should follow**

This was a one-word typo; no functional change.

## Backport

@Mergifyio backport circinus
@Mergifyio backport sagitta

🤖 Generated by [robots](https://vyos.io)