### PR TITLE
chore(makefile): remove dead AUTOOPTS variable

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,6 @@ BUILDDIR      = _build
 
 AUTOHOST      = 0.0.0.0
 AUTOPORT      = 8000
-AUTOOPTS      = --watch .
 
 SWAP          = python3 ../scripts/swap_sources.py
 


### PR DESCRIPTION
## Change Summary

AUTOOPTS = --watch . is defined in docs/Makefile but never referenced. The livehtml target uses explicit --ignore flags, making this variable dead since the --ignore refactor.

Circinus is unaffected (its livehtml still uses $(AUTOOPTS) directly).

## Backport

@Mergifyio backport sagitta

Generated by robots (https://vyos.io)