### PR TITLE
chore(readme): remove broken vale lint section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,16 +102,3 @@ $ docker run --rm -it -v "$(pwd)":/vyos -w /vyos/docs -e GOSU_UID=$(id -u) -e GO
 $ docker run --rm -it -p 8000:8000 -v "$(pwd)":/vyos -w /vyos/docs -e GOSU_UID=$(id -u) -e GOSU_GID=$(id -g) vyos/vyos-documentation make livehtml
 ```
 
-### Test the docs
-
-To test all files, run:
-
-```bash
-$ docker run --rm -it -v "$(pwd)":/vyos -w /vyos/docs -e GOSU_UID=$(id -u) -e GOSU_GID=$(id -g) vyos/vyos-documentation vale .
-```
-
-to test a specific file (e.g. `quick-start.rst`)
-
-```bash
-$ docker run --rm -it -v "$(pwd)":/vyos -w /vyos/docs -e GOSU_UID=$(id -u) -e GOSU_GID=$(id -g) vyos/vyos-documentation vale quick-start.rst
-```


### PR DESCRIPTION
## Change Summary

Remove the **Test the docs** subsection that documented running vale through Docker. The commands fail because:

- vale is not installed in the Docker image
- No `.vale.ini` config exists in the repo
- No `styles/` directory with rules exists in the repo

CI uses `vyoslinter` (`doc-linter.py` from the `vyos/.github` repo) for linting, not vale.

## Backport

@Mergifyio backport circinus
@Mergifyio backport sagitta

Generated by robots (https://vyos.io)