### PR TITLE
docs(claude-md): fix llms.txt backtick, redirect aliases, template path examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ A PR that both adds and removes TODOs is not contradictory; intent matters.
 
 Both files are regenerated on every `html` and `readthedocs` builder run.
 The `dirhtml` builder is intentionally skipped — production publishes
-only via `html`/`readthedocs`, and we don't render llms.txt for builds
+only via `html`/`readthedocs`, and we don't render `llms.txt` for builds
 we don't ship. Local `make dirhtml` is a developer convenience and
 won't emit `llms.txt`.
 
@@ -209,11 +209,13 @@ Files are shipped at the docs root for each version
 
 When adding new top-level sections to the docs, add a corresponding bullet in
 `docs/_templates/llms.txt.j2`. Branch-specific differences (e.g. sagitta has
-no `vpp/` or `contributing/index`) live in that branch's copy of the template.
+no `vpp/index.md` or `contributing/index.md`) live in that branch's copy of the template.
 
 ## Read the Docs Layout
 
-RTD slugs as of 2026-05-04 (verified via API):
+RTD slugs as of 2026-05-04 (verified via API). Re-verify via the RTD
+Versions API (project `vyos`) and update the date stamp before editing this
+table.
 
 | Slug | Verbose | Branch | Role |
 |---|---|---|---|
@@ -224,8 +226,9 @@ RTD slugs as of 2026-05-04 (verified via API):
 
 URL-level redirect aliases (resolve to the canonicals above):
 `/en/latest/* → /en/rolling/`, `/en/lts/* → /en/1.5/`,
-`/en/stable/* → /en/lts/`, `/en/circinus*`, `/en/sagitta*`,
-`/en/equuleus*`, `/en/crux*` → numeric slugs.
+`/en/stable/* → /en/lts/`, `/en/circinus/* → /en/1.5/`,
+`/en/sagitta/* → /en/1.4/`, `/en/equuleus/* → /en/1.3/`,
+`/en/crux/* → /en/1.2/`.
 
 `html_baseurl` per branch must point at the canonical (numeric or `rolling`),
 not the alias, so `<link rel="canonical">` and the sitemap match what RTD


### PR DESCRIPTION
## Description

Three small consistency fixes in `CLAUDE.md`:

1. **Backtick around `llms.txt`** — line 194: `we don't render llms.txt` → `we don't render \`llms.txt\`` to match the surrounding inline-code style.
2. **Explicit redirect alias destinations** — `/en/circinus*` → `/en/circinus/* → /en/1.5/` etc. Adds the destination slug for each codename alias and uses consistent `/*` suffix.
3. **Exact template paths** — `vpp/` and `contributing/index` → `vpp/index.md` and `contributing/index.md` to match the actual paths used in `docs/_templates/llms.txt.j2`.
4. **RTD table re-verification note** — brief instruction to re-verify via the RTD Versions API before editing the dated slug table.

These same fixes were applied to the `circinus` (#1911) and `sagitta` (#1912) branches in response to Copilot review feedback. This PR brings `current` in sync.

## Backport

None needed — circinus and sagitta already have this content.

🤖 Generated by [robots](https://vyos.io)