### PR TITLE
fix(css): increase copyFailedNotifier specificity to override copyDiv base style

### DIFF
--- a/docs/_static/css/code-snippets.css
+++ b/docs/_static/css/code-snippets.css
@@ -77,7 +77,7 @@
   margin-bottom: 0;
 }
 
-.copyDiv.copyFailedNotifier {
+.highlight > .copyDiv.copyFailedNotifier {
   background-color: #b3261e;
 }
 

--- a/docs/_static/css/code-snippets.css
+++ b/docs/_static/css/code-snippets.css
@@ -77,7 +77,7 @@
   margin-bottom: 0;
 }
 
-.copyFailedNotifier {
+.copyDiv.copyFailedNotifier {
   background-color: #b3261e;
 }
 


### PR DESCRIPTION
Follow-up to #1890. Copilot caught a CSS specificity bug during backport review.

`.copyFailedNotifier` had specificity (0,1,0) which lost to `.highlight > .copyDiv` at (0,1,1), so the red failure background never rendered. Fixed by scoping to `.copyDiv.copyFailedNotifier` (0,2,0).

## Backport

@Mergifyio backport circinus
@Mergifyio backport sagitta

🤖 Generated by [robots](https://vyos.io)