### PR TITLE
Add context7.json for repo ownership on context7.com

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/vyos/vyos-documentation",
+  "public_key": "pk_CL1d8D3hhCrefEKCC4K8L"
+}


### PR DESCRIPTION
## Summary
- Adds `context7.json` at the repo root containing the project URL and public key issued by [context7.com](https://context7.com/vyos/vyos-documentation).
- This file is the ownership-verification artifact Context7 uses to grant settings control (refresh cadence, exclusions, branding) to the repo owner.

## Backport
- [x] circinus
- [x] sagitta

Not backporting — ownership claim only needs to live on the default branch.

## Test plan
- [ ] No build impact: file is not referenced by Sphinx config and lives outside `docs/`.

🤖 Generated by [robots](https://vyos.io)