### PR TITLE
Enrich context7.json with project metadata, scope, and rules

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,36 @@
 {
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "VyOS Networking Platform",
+  "description": "VyOS, Enterprise-Grade Open Source Networking Platform for Bare Metal, Cloud, and Edge",
   "url": "https://context7.com/vyos/vyos-documentation",
-  "public_key": "pk_CL1d8D3hhCrefEKCC4K8L"
+  "public_key": "pk_CL1d8D3hhCrefEKCC4K8L",
+  "folders": ["docs"],
+  "excludeFolders": [
+    "docs/_build",
+    "docs/_static",
+    "docs/_templates",
+    "docs/_ext",
+    "scripts",
+    "tests",
+    ".github",
+    "node_modules"
+  ],
+  "excludeFiles": [
+    "CHANGELOG.md",
+    "LICENSE",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md"
+  ],
+  "rules": [
+    "Documentation sources are MyST Markdown (.md). Cite and link to the .md form.",
+    "VyOS has two CLI modes: configuration mode (`set ...`, `delete ...`, `commit`, `save`) and operational mode (`show ...`, `monitor ...`, `restart ...`). Do not mix them.",
+    "Configuration commands are wrapped in `cfgcmd` fenced blocks; operational commands in `opcmd` fenced blocks. Treat these as authoritative command syntax.",
+    "Branch `current` tracks the rolling release and the next stable line (1.5+). Branch `circinus` tracks 1.5.x. Branch `sagitta` tracks 1.4.x. Always cite version-appropriate documentation.",
+    "Do not invent CLI commands. If a command isn't in the docs, say so rather than guess — VyOS syntax is strict and unknown commands fail validation at commit time.",
+    "Use reserved documentation IP space in examples: 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24 (RFC 5737), 2001:db8::/32 (RFC 3849). Never use real or RFC1918 addresses."
+  ],
+  "previousVersions": [
+    { "branch": "circinus" },
+    { "branch": "sagitta" }
+  ]
 }


### PR DESCRIPTION
## Summary
Follow-up to [vyos-documentation#1932](https://github.com/vyos/vyos-documentation/pull/1932) (initial ownership-claim file). Populates the optional schema fields documented at https://context7.com/docs/adding-libraries so Context7 indexes the repo with the right scope, metadata, and LLM guidance:

- **`projectTitle` / `description`** — stable display strings instead of LLM guesses on every refresh.
- **`folders` / `excludeFolders` / `excludeFiles`** — limit indexing to `docs/` and skip build artifacts (`docs/_build`, `_static`, `_templates`, `_ext`), tooling (`scripts`, `tests`, `.github`, `node_modules`), and meta files (`CHANGELOG.md`, `LICENSE`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`).
- **`rules`** — surface the conventions LLMs should respect when answering from VyOS docs:
  - MyST `.md` is the canonical citation form.
  - Configuration mode (`set …`, `commit`) vs operational mode (`show …`) must not mix.
  - `cfgcmd` / `opcmd` fenced blocks are authoritative command syntax.
  - Branch → version mapping (`current` = rolling/1.5+, `circinus` = 1.5.x, `sagitta` = 1.4.x).
  - Don't invent commands — VyOS validates strictly at `commit` time.
  - Use RFC 5737 / RFC 3849 documentation address space in examples.
- **`previousVersions`** — `{ "branch": "circinus" }` and `{ "branch": "sagitta" }` so Context7 can serve version-appropriate answers for the 1.5.x and 1.4.x lines.

Schema reference: `https://context7.com/schema/context7.json` (linked via `\$schema`).

## Backport
- [ ] circinus
- [ ] sagitta

Not backporting — config only needs to live on the default branch; the `previousVersions` field already covers indexing of the maintenance branches.

## Test plan
- [x] `python3 -c "import json; json.load(open('context7.json'))"` — valid JSON.
- [ ] No build impact — file is not referenced by Sphinx config and lives outside `docs/`.
- [ ] Confirm in the Context7 admin panel after merge that the new metadata is picked up on next refresh.

🤖 Generated by [robots](https://vyos.io)