### PR TITLE
ci: floating version tags + context7 switch (rolling/1.5/1.4)

### DIFF
--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Move version tag to pushed SHA
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           SHA: ${{ github.sha }}
           BRANCH: ${{ github.ref_name }}
@@ -33,7 +33,7 @@ jobs:
             *) echo "Unexpected branch: $BRANCH" >&2; exit 1 ;;
           esac
           echo "Pointing tag '$TAG' at $SHA (branch $BRANCH)"
-          if gh api "repos/$REPO/git/refs/tags/$TAG" >/dev/null 2>&1; then
+          if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
             gh api -X PATCH "repos/$REPO/git/refs/tags/$TAG" \
               -f sha="$SHA" -F force=true
           else

--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: version-tag-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   retag:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -1,0 +1,38 @@
+name: Update version tags
+
+on:
+  push:
+    branches:
+      - current
+      - circinus
+      - sagitta
+
+permissions:
+  contents: write
+
+jobs:
+  retag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move version tag to pushed SHA
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          case "$BRANCH" in
+            current)  TAG=rolling ;;
+            circinus) TAG=1.5 ;;
+            sagitta)  TAG=1.4 ;;
+            *) echo "Unexpected branch: $BRANCH" >&2; exit 1 ;;
+          esac
+          echo "Pointing tag '$TAG' at $SHA (branch $BRANCH)"
+          if gh api "repos/$REPO/git/refs/tags/$TAG" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/$REPO/git/refs/tags/$TAG" \
+              -f sha="$SHA" -F force=true
+          else
+            gh api -X POST "repos/$REPO/git/refs" \
+              -f ref="refs/tags/$TAG" -f sha="$SHA"
+          fi

--- a/context7.json
+++ b/context7.json
@@ -30,7 +30,7 @@
     "Use reserved documentation IP space in examples: 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24 (RFC 5737), 2001:db8::/32 (RFC 3849). Never use real or RFC1918 addresses."
   ],
   "previousVersions": [
-    { "branch": "circinus" },
-    { "branch": "sagitta" }
+    { "tag": "1.5" },
+    { "tag": "1.4" }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/update-version-tags.yml` that force-moves a floating tag to the pushed SHA on every push to `current`/`circinus`/`sagitta`.
- Mapping: `current → rolling`, `circinus → 1.5`, `sagitta → 1.4`.
- Switches `context7.json` `previousVersions` from internal branch names (`circinus`, `sagitta`) to the new release tags (`1.5`, `1.4`).
- Initial seed tags pushed manually; workflow keeps them current going forward.

## Why

RTD canonical version slugs (`/en/rolling/`, `/en/1.5/`, `/en/1.4/`) are decoupled from internal branch names. Floating tags give every consumer (RTD, context7, anything else) a stable ref name per release line independent of branch nomenclature. context7.json picks them up immediately.

## Mechanism

- Workflow triggered by `push` on the three branches.
- Uses `${{ github.token }}` with `contents: write` (matches the convention in `ai-validation.yml`). Whether that's sufficient against tag-protection rules is the open question — first push after merge is the test. If GitHub rejects, swap to a PAT secret in a follow-up.
- Existence check uses the singular `git/ref/tags/$TAG` endpoint (404 on miss), not the plural list endpoint.
- All inputs (`github.sha`, `github.ref_name`, `github.repository`) are GitHub-validated, passed via `env:`, and the branch name is gated with a `case` statement that exits on anything unexpected.
- `concurrency` group with `cancel-in-progress: true` prevents two rapid pushes to the same branch from racing.

## Backport

After merge, port `.github/workflows/update-version-tags.yml` to `circinus` and `sagitta` — GitHub Actions reads the workflow from the pushed branch, so it must exist on all three. `context7.json` already differs across branches via the per-branch defaults; backport that change too if the same `previousVersions` list is wanted on the older trains.

## Test plan

- [ ] Merge to `current`; push something trivial to `current` and confirm `rolling` tag advances.
- [ ] If the workflow fails with permission errors, switch to a PAT secret.
- [ ] Backport to `circinus` and `sagitta`; verify `1.5` and `1.4` advance on push.
- [ ] context7.com picks up the new tag names on the next sync.

🤖 Generated by [robots](https://vyos.io)