### PR TITLE
ci: defensive triggers ahead of current→rolling default-branch rename

### DIFF
--- a/.github/workflows/check-open-prs-conflict.yml
+++ b/.github/workflows/check-open-prs-conflict.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - current
+      - rolling
       - sagitta
       - circinus
   workflow_dispatch:

--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -3,7 +3,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [current]
+    branches: [current, rolling]
   workflow_dispatch:
     inputs:
       sync_branch:
@@ -13,6 +13,7 @@ on:
         type: choice
         options:
           - current
+          - rolling
 
 permissions:
   pull-requests: write

--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -30,7 +30,7 @@ jobs:
       )
     uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@current
     with:
-      sync_branch: ${{ github.event.inputs.sync_branch || 'current' }}
+      sync_branch: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.event.inputs.sync_branch || 'current' }}
     secrets:
       PAT: ${{ secrets.PAT }}
       REMOTE_OWNER: ${{ secrets.REMOTE_OWNER }}

--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - current
+      - rolling
       - circinus
       - sagitta
 
@@ -27,7 +28,7 @@ jobs:
         run: |
           set -euo pipefail
           case "$BRANCH" in
-            current)  TAG=rolling ;;
+            current|rolling) TAG=rolling ;;
             circinus) TAG=1.5 ;;
             sagitta)  TAG=1.4 ;;
             *) echo "Unexpected branch: $BRANCH" >&2; exit 1 ;;


### PR DESCRIPTION
## Summary

Pre-flight for renaming the default branch `current` → `rolling`. Adds `rolling` alongside `current` in the workflows whose triggers/case-statements pin the old branch name, so CI continues to fire atomically across the rename.

- [.github/workflows/pr-mirror-repo-sync.yml](.github/workflows/pr-mirror-repo-sync.yml): `pull_request_target.branches: [current, rolling]`; `workflow_dispatch` choice gains `rolling`; `sync_branch` now derives from `github.event.pull_request.base.ref` for PR events so a PR merging into `rolling` syncs `rolling` (not the literal `'current'` fallback).
- [.github/workflows/check-open-prs-conflict.yml](.github/workflows/check-open-prs-conflict.yml): adds `rolling` to the `push.branches` list.
- [.github/workflows/update-version-tags.yml](.github/workflows/update-version-tags.yml): adds `rolling` to `push.branches`; case statement folds `current|rolling` → `rolling` tag so the `rolling` tag stays current both before and after the rename.

After this PR merges, the GitHub branch rename is safe to trigger:
- Open PRs targeting `current` ([#1865](https://github.com/vyos/vyos-documentation/pull/1865), [#1799](https://github.com/vyos/vyos-documentation/pull/1799), [#1891](https://github.com/vyos/vyos-documentation/pull/1891)) will auto-retarget to `rolling`.
- Branch protection rules tied to `current` will auto-migrate.
- Web/API URLs against the old name keep working via GitHub's redirect.

## Deferred to a post-rename cleanup PR

These would document or default to a branch that does not yet exist, so they are intentionally not in this PR:

- Drop `current` from the trigger lists (leaving only `rolling`)
- Flip `pr-mirror-repo-sync.yml` `workflow_dispatch` input default `current` → `rolling`
- Drop the `current)` arm from the `update-version-tags.yml` case statement
- Cosmetic CI naming: [submodules.yml](.github/workflows/submodules.yml) `update_current` job + `update-dependencies-current` PR branch + commit/title strings; [update-translations.yml](.github/workflows/update-translations.yml) `update-translations-current` PR branch
- [docs/conf.py](docs/conf.py) `READTHEDOCS_GIT_IDENTIFIER` fallback `'current'` → `'rolling'`
- [README.md](README.md) explanatory text about the default branch
- [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) `blob/current/CONTRIBUTING.md` link

## Out of scope

External `@current` reusable-workflow refs ([vyos/.github](https://github.com/vyos/.github), [vyos/vyos-cla-signatures](https://github.com/vyos/vyos-cla-signatures)) point at *those* repos' `current` branches, not this one — unaffected by this rename, deferred to whenever those orgs/repos rename their own defaults.

## Test plan

- [ ] Merge to `current`
- [ ] Trigger GitHub branch rename `current` → `rolling`
- [ ] Verify open PRs auto-retargeted to `rolling`
- [ ] Push to `rolling` triggers `Open PRs Conflicts checker`, `Update version tags`, and (on PR merge) `PR Mirror and Repo Sync`
- [ ] Open the cleanup PR to drop `current` from triggers and update cosmetic items

🤖 Generated by [robots](https://vyos.io)