### PR TITLE
ci: GitHub casing consistency in workflow PR titles

### DIFF
--- a/.github/workflows/submodules.yml
+++ b/.github/workflows/submodules.yml
@@ -65,8 +65,8 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.PR_ACTION_DOCUMENTATION_SUBMODULE_UPDATE }}
-          commit-message: "Github: update sagitta branch"
-          title: "Github: update sagitta branch"
+          commit-message: "GitHub: update sagitta branch"
+          title: "GitHub: update sagitta branch"
           body: |
             Autoupdate vyos-1x submodule
             update releasenotes
@@ -100,8 +100,8 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.PR_ACTION_DOCUMENTATION_SUBMODULE_UPDATE }}
-          commit-message: "Github: update equuleus branch"
-          title: "Github: update equuleus branch"
+          commit-message: "GitHub: update equuleus branch"
+          title: "GitHub: update equuleus branch"
           body: |
             Autoupdate vyos-1x submodule
             update releasenotes

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -53,8 +53,8 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.PR_ACTION_DOCUMENTATION_SUBMODULE_UPDATE }}
-          commit-message: "Github: update translations"
-          title: "Github: update translations"
+          commit-message: "GitHub: update translations"
+          title: "GitHub: update translations"
           body: |
             Generate, upload new and download translation files 
           branch: update-translations-rolling


### PR DESCRIPTION
## Summary

Cosmetic only. Fixes \`Github\` → \`GitHub\` in three workflow PR-creation strings that were left behind by [#1938](https://github.com/vyos/vyos-documentation/pull/1938) (which fixed only the lines it had already touched as part of the rename cleanup).

| File | Job | Lines |
|------|-----|-------|
| [.github/workflows/submodules.yml](.github/workflows/submodules.yml) | \`update_sagitta\` | 68-69 |
| [.github/workflows/submodules.yml](.github/workflows/submodules.yml) | \`update_equuleus\` | 103-104 |
| [.github/workflows/update-translations.yml](.github/workflows/update-translations.yml) | translations job | 56-57 |

These strings only appear in the titles/commit-messages of bot-created submodule/translation update PRs. No CI logic, no user-facing docs.

## Cross-branch

The same typos exist in the \`circinus\` and \`sagitta\` copies of \`submodules.yml\`. Those need separate PRs targeting those branches; rolling-only here.

## Test plan

- [ ] No CI changes expected — purely string content
- [ ] Next scheduled \`Update submodule vyos-1x\` cron run (Mondays 06:00 UTC) creates PRs with \`GitHub:\` titles

🤖 Generated by [robots](https://vyos.io)