### PR TITLE
ci+docs: fix open-prs-conflict caller ref + refresh Mergify backport guidance

### DIFF
--- a/.github/workflows/check-open-prs-conflict.yml
+++ b/.github/workflows/check-open-prs-conflict.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   check-pr-conflict-call:
-    uses: vyos/.github/.github/workflows/check-open-prs-conflict.yml@current
+    uses: vyos/.github/.github/workflows/check-pr-conflict.yml@current
     secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,12 +50,13 @@ One long-lived branch per VyOS release line. Branch names are constellations sor
 | `equuleus` | 1.3.x (legacy) |
 | `crux` | 1.2.x (legacy) |
 
-PRs target `rolling`. After merge, request backports via a **post-merge comment** on the PR:
+PRs target `rolling`. After merge, request backports via a **post-merge comment** on the PR. Multiple branches go in a single command, space-separated:
 
 ```text
-@Mergifyio backport circinus
-@Mergifyio backport sagitta
+@Mergifyio backport circinus sagitta
 ```
+
+Only **Maintainers team members** can invoke `@Mergifyio` commands — Mergify silently drops commands from anyone outside the team (no error reply). If a backport doesn't trigger, check team membership first. Ask a Maintainer to post the comment on your behalf.
 
 Mergify only reads commands from **PR comments** — mentions in the PR body are ignored.
 Mergify is configured at the org level (no `.mergify.yml` in the repo). The PR template has a `## Backport` section to declare intent, but that does not trigger the backport; the comment does.


### PR DESCRIPTION
Two related cleanups bundled — both surfaced while wrapping up the swap-removal PR trio.

## 1. CI fix: `open-prs-conflict` caller ref

The caller workflow at `.github/workflows/check-open-prs-conflict.yml` references `vyos/.github/.github/workflows/check-open-prs-conflict.yml@current`, but that file does not exist in `vyos/.github`. The actual workflow is named `check-pr-conflict.yml` (without "open"). Verified via:

```
gh api repos/vyos/.github/contents/.github/workflows --jq ".[].name"
```

The caller was added 2025-05-26 in [vyos-documentation#1638](https://github.com/vyos/vyos-documentation/pull/1638) as `86a282ec` (T7445). The called workflow was later renamed in `vyos/.github` and the docs caller was not updated. Every push to a watched branch since at least 2026-05-07 has produced a "workflow file issue" failure — most recent: [run 25632241348](https://github.com/vyos/vyos-documentation/actions/runs/25632241348).

One-line `uses:` ref update. The called workflow is `workflow_call`-callable with no inputs.

## 2. Docs refresh: Mergify backport syntax + maintainer-only

- Update example to the consolidated `@Mergifyio backport circinus sagitta` form (multiple branches in one command, space-separated). The one-branch-per-line form still works but is no longer required.
- Document that only Maintainers team members can invoke `@Mergifyio` commands — Mergify silently drops commands from anyone outside the team, with no error reply. Useful failure mode to know about: if a backport does not trigger, check team membership first.

## Backport

Will request backport to `circinus` post-merge (sagitta has neither file modified here — no copy of `check-open-prs-conflict.yml`, but its AGENTS.md does carry the old backport snippet, so include it):

```
@Mergifyio backport circinus sagitta
```

🤖 Generated by [robots](https://vyos.io)