### PR TITLE
ci: bring update-version-tags.yml to sagitta

### DIFF
--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -1,0 +1,46 @@
+name: Update version tags
+
+# This workflow exists on rolling, circinus, and sagitta.
+# Keep all three copies in sync — backport edits via Mergify
+# (`@Mergifyio backport circinus sagitta`) or cherry-pick.
+
+on:
+  push:
+    branches:
+      - rolling
+      - circinus
+      - sagitta
+
+permissions:
+  contents: write
+
+concurrency:
+  group: version-tag-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  retag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move version tag to pushed SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          case "$BRANCH" in
+            rolling)  TAG=rolling ;;
+            circinus) TAG=1.5 ;;
+            sagitta)  TAG=1.4 ;;
+            *) echo "Unexpected branch: $BRANCH" >&2; exit 1 ;;
+          esac
+          echo "Pointing tag '$TAG' at $SHA (branch $BRANCH)"
+          if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/$REPO/git/refs/tags/$TAG" \
+              -f sha="$SHA" -F force=true
+          else
+            gh api -X POST "repos/$REPO/git/refs" \
+              -f ref="refs/tags/$TAG" -f sha="$SHA"
+          fi


### PR DESCRIPTION
## Summary

`update-version-tags.yml` lives on `rolling` only; pushes to `sagitta` therefore do not trigger the tag-move job, and tag `1.4` has drifted from `sagitta` HEAD. Bring the workflow over verbatim plus a sync-reminder comment.

Prerequisite for the Context7 GitHub Actions integration. See [\`~/.claude/specs/2026-05-10-context7-github-actions-integration-design.md\`](file:///Users/syncer/.claude/specs/2026-05-10-context7-github-actions-integration-design.md).

## Test plan

- [ ] Copilot review iteration on the draft until silent
- [ ] Mark ready-for-review
- [ ] Manually invoke \`@coderabbitai review\`; iterate until silent
- [ ] Merge — the merge commit itself is the first push to \`sagitta\` containing this workflow file, so it triggers the workflow's first run.
- [ ] Verify: confirm \`Update version tags\` ran on the merge commit and tag \`1.4\` advanced to the merge SHA

🤖 Generated by [robots](https://vyos.io)