### PR TITLE
ci: add Context7 refresh workflow

### DIFF
--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -1,0 +1,70 @@
+name: Context7 refresh
+
+# Listens for completion of "Update version tags" via workflow_run, then
+# refreshes the corresponding Context7 variant. The upstream workflow is
+# matched by name — DO NOT rename `Update version tags` without updating
+# the `workflows:` field below.
+#
+# OPERATOR NOTE: do NOT use GitHub's "Re-run jobs" on `Update version tags`.
+# Re-runs replay the original SHA, which would move the version tag
+# BACKWARD and trigger this workflow to refresh Context7 against stale
+# content. To force a Context7 refresh, use the workflow_dispatch input
+# below — it calls Context7 directly without touching any tag.
+
+on:
+  workflow_run:
+    workflows: ["Update version tags"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Context7 variant to refresh"
+        type: choice
+        options: [rolling, "1.5", "1.4"]
+        default: rolling
+
+permissions: {}
+
+concurrency:
+  group: >-
+    context7-refresh-${{
+      inputs.version
+      || (github.event.workflow_run.head_branch == 'circinus' && '1.5')
+      || (github.event.workflow_run.head_branch == 'sagitta' && '1.4')
+      || github.event.workflow_run.head_branch
+    }}
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       contains(fromJSON('["rolling","circinus","sagitta"]'), github.event.workflow_run.head_branch))
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Refresh Context7 library
+        env:
+          CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          DISPATCH_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            VARIANT="$DISPATCH_VERSION"
+          else
+            case "$HEAD_BRANCH" in
+              rolling)  VARIANT=rolling ;;
+              circinus) VARIANT=1.5 ;;
+              sagitta)  VARIANT=1.4 ;;
+              *) echo "Unexpected head_branch: $HEAD_BRANCH" >&2; exit 1 ;;
+            esac
+          fi
+          echo "Refreshing Context7 variant: $VARIANT"
+          curl -fsSL --retry 2 --retry-delay 10 -X POST \
+            "https://context7.com/api/v1/refresh" \
+            -H "Authorization: Bearer $CONTEXT7_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc --arg lib "/${{ github.repository }}" --arg br "$VARIANT" \
+                  '{libraryName: $lib, branch: $br}')"

--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -51,6 +51,10 @@ jobs:
           DISPATCH_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          if [[ -z "${CONTEXT7_API_KEY:-}" ]]; then
+            echo "ERROR: CONTEXT7_API_KEY is unset or empty" >&2
+            exit 1
+          fi
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             VARIANT="$DISPATCH_VERSION"
           else

--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -66,7 +66,11 @@ jobs:
             esac
           fi
           echo "Refreshing Context7 variant: $VARIANT"
-          curl -fsSL --retry 2 --retry-delay 10 -X POST \
+          curl -fsSL \
+            --connect-timeout 10 \
+            --max-time 60 \
+            --retry 2 --retry-delay 10 \
+            -X POST \
             "https://context7.com/api/v1/refresh" \
             -H "Authorization: Bearer $CONTEXT7_API_KEY" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -1,5 +1,8 @@
 name: Update version tags
 
+# context7-refresh.yml triggers via workflow_run on this workflow's name.
+# DO NOT rename the `name:` field above without updating context7-refresh.yml.
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/context7-refresh.yml\`. On completion of \`Update version tags\`, refreshes the corresponding Context7 variant (\`rolling\` / \`1.5\` / \`1.4\`) by POSTing to \`https://context7.com/api/v1/refresh\` with the \`CONTEXT7_API_KEY\` repo secret.

Why \`workflow_run\` and not a tag-push trigger: GITHUB_TOKEN-driven ref-mutations (which is how \`update-version-tags.yml\` re-points the version tags) do NOT fan out to downstream workflows per [GitHub policy](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow). \`workflow_run\` is the documented escape hatch.

Includes a two-line cross-coupling note in \`update-version-tags.yml\` so future renames of its \`name:\` field don't silently break the chain.

Spec: [\`~/.claude/specs/2026-05-10-context7-github-actions-integration-design.md\`](file:///Users/syncer/.claude/specs/2026-05-10-context7-github-actions-integration-design.md).

## Test plan

- [ ] Copilot review iteration on the draft until silent
- [ ] Mark ready-for-review
- [ ] Manually invoke \`@coderabbitai review\`; iterate until silent
- [ ] Merge
- [ ] Bootstrap each variant via \`workflow_dispatch\` from the Actions UI
- [ ] End-to-end: push a doc fix to \`circinus\`, confirm chain fires (Update version tags → tag 1.5 advances → Context7 refresh runs for variant 1.5)
- [ ] Repeat E2E test for \`sagitta\` / variant 1.4

## Related

- Prerequisite PRs (open in draft, must merge before E2E test on LTS branches works): [vyos-documentation#1948](https://github.com/vyos/vyos-documentation/pull/1948) (circinus) and [vyos-documentation#1949](https://github.com/vyos/vyos-documentation/pull/1949) (sagitta).

🤖 Generated by [robots](https://vyos.io)