### PR TITLE
ci: drop leading slash in Context7 libraryName

### DIFF
--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -74,5 +74,5 @@ jobs:
             "https://context7.com/api/v1/refresh" \
             -H "Authorization: Bearer $CONTEXT7_API_KEY" \
             -H "Content-Type: application/json" \
-            -d "$(jq -nc --arg lib "/${{ github.repository }}" --arg br "$VARIANT" \
+            -d "$(jq -nc --arg lib "${{ github.repository }}" --arg br "$VARIANT" \
                   '{libraryName: $lib, branch: $br}')"


### PR DESCRIPTION
## Summary

The Context7 refresh workflow added in [#1950](https://github.com/vyos/vyos-documentation/pull/1950) sent `libraryName: /vyos/vyos-documentation` (leading slash). The first three auto-fired runs after #1950/#1948/#1949 merged all returned `curl: (22) HTTP 404`. Context7's canonical identifier is the bare `vyos/vyos-documentation` (verified at https://context7.com/vyos/vyos-documentation), and the API docs confirm `libraryName` resolves directly from `${{ github.repository }}`.

One-character fix: drop the leading slash from the `--arg lib` argument.

## Test plan

- [ ] Copilot review iteration on the draft until silent
- [ ] Mark ready-for-review
- [ ] Manually invoke `@coderabbitai review`; iterate until silent
- [ ] Merge
- [ ] After merge: `gh workflow run "Context7 refresh" --ref rolling -f version=rolling` and confirm green; repeat for `1.5` and `1.4`
- [ ] End-to-end: push a doc fix to `circinus`, confirm Context7 refresh fires and succeeds for variant `1.5`

## Background

The auto-fired runs after the trio merged are visible in the Actions tab — three failures at 20:28:32/41/47 UTC, all `curl: (22) The requested URL returned error: 404`. The variant mapping itself was correct (e.g. `circinus → 1.5`); the URL path was the problem.

🤖 Generated by [robots](https://vyos.io)