### PR TITLE
ci(update-version-tags): surface PATCH errors instead of masking them

### DIFF
--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -36,10 +36,14 @@ jobs:
             *) echo "Unexpected branch: $BRANCH" >&2; exit 1 ;;
           esac
           echo "Pointing tag '$TAG' at $SHA (branch $BRANCH)"
-          if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
-            gh api -X PATCH "repos/$REPO/git/refs/tags/$TAG" \
-              -f sha="$SHA" -F force=true
-          else
-            gh api -X POST "repos/$REPO/git/refs" \
-              -f ref="refs/tags/$TAG" -f sha="$SHA"
+          patch_err=""
+          if ! patch_err="$(gh api -X PATCH "repos/$REPO/git/refs/tags/$TAG" \
+            -f sha="$SHA" -F force=true 2>&1)"; then
+            if grep -q "HTTP 404" <<<"$patch_err"; then
+              gh api -X POST "repos/$REPO/git/refs" \
+                -f ref="refs/tags/$TAG" -f sha="$SHA"
+            else
+              echo "$patch_err" >&2
+              exit 1
+            fi
           fi


### PR DESCRIPTION
## Summary

Hardens `gh api` error handling in `.github/workflows/update-version-tags.yml` so that auth failures, rate-limiting (429), and 5xx server errors are no longer silently swallowed and treated as "tag missing".

## Problem

The previous probe-then-mutate flow ran:

```bash
if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
  gh api -X PATCH ...   # tag exists → move it
else
  gh api -X POST ...    # tag missing → create it
fi
```

`>/dev/null 2>&1` suppresses *all* errors on the GET probe. Any non-zero exit — auth failure, 429, 5xx, network blip — was treated identically to a 404, causing the workflow to attempt a POST that would then fail with a misleading message (or, worse, succeed against an unintended state).

Surfaced by CodeRabbit on [vyos-documentation#1948](https://github.com/vyos/vyos-documentation/pull/1948#discussion_r3215460746) (resolved as out-of-scope for that PR).

## Fix

Drop the probe, try PATCH first, capture stderr, and only fall back to POST on a confirmed `HTTP 404`. Any other failure prints the captured error and exits non-zero.

```bash
patch_err=""
if ! patch_err="$(gh api -X PATCH "repos/$REPO/git/refs/tags/$TAG" \
  -f sha="$SHA" -F force=true 2>&1)"; then
  if grep -q "HTTP 404" <<<"$patch_err"; then
    gh api -X POST "repos/$REPO/git/refs" \
      -f ref="refs/tags/$TAG" -f sha="$SHA"
  else
    echo "$patch_err" >&2
    exit 1
  fi
fi
```

Side benefits:
- One round-trip instead of two on the common (tag-exists) path.
- No GET/PATCH race window where the tag could be deleted between the probe and the mutation.

## Why this is its own PR (not bundled with #1948/#1949/#1950)

The Context7 integration design mandates that the `circinus`/`sagitta` prerequisite PRs be byte-identical to `rolling`'s copy of `update-version-tags.yml` plus only a 3-line sync-reminder comment. Bundling this hardening would have violated that drift-prevention requirement and entangled two unrelated concerns.

This PR lands cleanly on `rolling` first, then propagates to the prerequisite branches via Mergify backport once #1948 / #1949 are merged.

## Test plan

- [ ] Copilot review pass on draft
- [ ] Flip to ready-for-review, CodeRabbit review pass
- [ ] After merge, comment `@Mergifyio backport circinus sagitta` on this PR (deferred until prerequisite branches have merged #1948 / #1949 so the file exists with identical context to apply onto)
- [ ] On rolling: confirm next push to rolling fires the workflow and moves the `rolling` tag without error
- [ ] On circinus / sagitta after backport merges: same check against `1.5` / `1.4` tags

🤖 Generated by [robots](https://vyos.io)