### PR TITLE
ci: harden update-version-tags against stale re-runs and silent failures

### DIFF
--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -14,7 +14,10 @@ permissions:
   contents: write
 
 concurrency:
-  group: version-tag-${{ github.ref_name }}
+  # Include github.sha so a stale "Re-run jobs" replay (which carries the
+  # original SHA) cannot cancel an in-progress run for the current branch
+  # HEAD. Same-SHA re-runs still deduplicate.
+  group: version-tag-${{ github.ref_name }}-${{ github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -35,11 +35,29 @@ jobs:
             sagitta)  TAG=1.4 ;;
             *) echo "Unexpected branch: $BRANCH" >&2; exit 1 ;;
           esac
+
+          # Skip stale re-runs: GitHub's "Re-run jobs" replays the original
+          # event SHA, which would move the version tag backward to a stale
+          # commit. Compare event SHA against the current branch HEAD.
+          HEAD_SHA="$(gh api "repos/$REPO/branches/$BRANCH" --jq '.commit.sha')"
+          if [ "$HEAD_SHA" != "$SHA" ]; then
+            echo "Skipping stale run: event SHA=$SHA, current $BRANCH HEAD=$HEAD_SHA"
+            exit 0
+          fi
+
           echo "Pointing tag '$TAG' at $SHA (branch $BRANCH)"
-          if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
-            gh api -X PATCH "repos/$REPO/git/refs/tags/$TAG" \
-              -f sha="$SHA" -F force=true
-          else
-            gh api -X POST "repos/$REPO/git/refs" \
-              -f ref="refs/tags/$TAG" -f sha="$SHA"
+
+          # PATCH the tag if it exists; create on 404; fail loud on any other
+          # gh-api error (auth, rate-limit, 5xx) instead of silently falling
+          # through to POST.
+          patch_err=""
+          if ! patch_err="$(gh api -X PATCH "repos/$REPO/git/refs/tags/$TAG" \
+            -f sha="$SHA" -F force=true 2>&1)"; then
+            if grep -q "HTTP 404" <<<"$patch_err"; then
+              gh api -X POST "repos/$REPO/git/refs" \
+                -f ref="refs/tags/$TAG" -f sha="$SHA"
+            else
+              echo "$patch_err" >&2
+              exit 1
+            fi
           fi


### PR DESCRIPTION
## Summary

Two defense-in-depth improvements to `.github/workflows/update-version-tags.yml`, bundled because they touch the same code block.

### 1. HEAD-equivalence guard (stale re-run protection)

GitHub's "Re-run jobs" UI replays the **original** event SHA — `github.sha` and `github.ref` do not advance to current branch HEAD on a re-run. For this workflow, that means manually re-running an old run can move tag `rolling`/`1.5`/`1.4` **backward** to a stale commit, breaking the invariant that these tags track their respective branch tips.

The Context7 integration spec already calls this out as a maintenance gotcha (operator note: "do NOT use GitHub's Re-run jobs"), but turning the operator-note into a runtime safeguard is strictly better.

New guard, inserted after the `case` block:

```bash
HEAD_SHA="$(gh api "repos/$REPO/branches/$BRANCH" --jq '.commit.sha')"
if [ "$HEAD_SHA" != "$SHA" ]; then
  echo "Skipping stale run: event SHA=$SHA, current $BRANCH HEAD=$HEAD_SHA"
  exit 0
fi
```

### 2. PATCH-first with 404-only fallback (silent-failure protection)

The previous pattern probed with `gh api repos/$REPO/git/ref/tags/$TAG` and fell through to POST on any non-zero exit — including auth failures, rate-limits, and 5xx — which would then attempt to create a tag that already exists and mask the real underlying error.

New shape: `PATCH` is the primary path. Fallback to `POST` only on `HTTP 404`. Any other gh-api error is re-emitted to stderr and fails the job.

```bash
patch_err=""
if ! patch_err="$(gh api -X PATCH "repos/$REPO/git/refs/tags/$TAG" \
  -f sha="$SHA" -F force=true 2>&1)"; then
  if grep -q "HTTP 404" <<<"$patch_err"; then
    gh api -X POST "repos/$REPO/git/refs" \
      -f ref="refs/tags/$TAG" -f sha="$SHA"
  else
    echo "$patch_err" >&2
    exit 1
  fi
fi
```

## Origin

- Stale-rerun guard: deferred from CodeRabbit thread on [vyos-documentation#1949](https://github.com/vyos/vyos-documentation/pull/1949#discussion_r3215460029) (resolved as out-of-scope on the prerequisite PR — that PR was a byte-identical backport per the Context7 integration spec's drift-prevention requirement).
- Silent-failure handling: prior surfacing on [vyos-documentation#1948](https://github.com/vyos/vyos-documentation/pull/1948).

## Backport plan

After merge, post `@Mergifyio backport circinus sagitta` to propagate to LTS branches' copies. Both [vyos-documentation#1948](https://github.com/vyos/vyos-documentation/pull/1948) and [vyos-documentation#1949](https://github.com/vyos/vyos-documentation/pull/1949) have already merged, so the source files on circinus/sagitta are identical to rolling and the cherry-pick will be mechanical.

## Test plan

- [ ] CodeRabbit review clean
- [ ] Manually push a trivial commit to `rolling` and confirm `rolling` tag advances to the new HEAD via the workflow log
- [ ] After backport: same verification on `circinus` (tag `1.5`) and `sagitta` (tag `1.4`)
- [ ] Manually re-run a previous workflow run and confirm it now exits 0 with the "Skipping stale run" message rather than rewinding the tag

🤖 Generated by [robots](https://vyos.io)