### PR TITLE
ci(ai-validation): gate skip-notice comment on opened/reopened only

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -172,8 +172,13 @@ jobs:
       # addition to the workflow ::notice:: annotation (which only appears
       # on the run page). This way a maintainer reviewing the PR sees the
       # skip in the same place as other automated review feedback.
+      # Gate on opened/reopened only — without this guard every push (a
+      # `synchronize` event) would post a fresh duplicate skip notice,
+      # flooding the PR conversation on rapid push sequences while the
+      # secrets stay missing. Open/reopen is the right moment to inform
+      # the PR author once; further pushes don't add new information.
       - name: Notify on PR (when skipping)
-        if: steps.secrets-check.outputs.skip == 'true'
+        if: steps.secrets-check.outputs.skip == 'true' && (github.event.action == 'opened' || github.event.action == 'reopened')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
Addresses a [CodeRabbit minor finding](https://github.com/VyOS-Networks/vyos-docs-opus-reviewer/pull/14#discussion_r3215496129) on the paired canonical PR ([VyOS-Networks/vyos-docs-opus-reviewer#14](https://github.com/VyOS-Networks/vyos-docs-opus-reviewer/pull/14)).

## Problem

The `Notify on PR (when skipping)` step (added in [`a22df7d8`](https://github.com/vyos/vyos-documentation/commit/a22df7d8) and merged to `rolling` as part of [#1947](https://github.com/vyos/vyos-documentation/pull/1947)) currently fires on every workflow run where the secrets-check resolves to `skip=true`. Because the workflow trigger is `pull_request_target` with types `[opened, synchronize, reopened]`, every push to a fork PR also triggers a run — and on a fork PR to a repo without `ANTHROPIC_API_KEY` / `VYOS_APP_ID` / `VYOS_APP_PRIVATE_KEY`, every push would post a fresh duplicate skip notice. Rapid iteration on such a PR would flood the conversation tab.

## Fix

Gate the step on `github.event.action == 'opened' || github.event.action == 'reopened'`. The PR author benefits from being told once when they open/reopen the PR; further `synchronize` events add no new information.

The workflow-run-page `::notice::` annotation is still emitted on every run, so maintainers retain run-by-run visibility.

## Why concurrency alone isn't enough

`concurrency.cancel-in-progress: true` cancels most superseded synchronize events before the notify step runs, but if a previous run reaches the notify step before the next push, the comment is still posted. The action-type gate is the deterministic fix.

## Paired canonical commit

[VyOS-Networks/vyos-docs-opus-reviewer@ea88567](https://github.com/VyOS-Networks/vyos-docs-opus-reviewer/commit/ea88567) applies the same change to `scripts/ai-validation.yml` on PR #14 — keeping canonical byte-identical (sans header) with the deployed file.

## Risk

Behavioral change only on the skip path; the on-secrets-present path is unaffected. Trivially reversible.

🤖 Generated by [robots](https://vyos.io)