### PR TITLE
ci: serialize update-version-tags runs to close back-to-back-push race

### DIFF
--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -71,6 +71,18 @@ jobs:
           TAG: ${{ needs.check_head.outputs.tag }}
         run: |
           set -euo pipefail
+
+          # Re-validate HEAD inside retag too: GitHub's "Re-run failed jobs"
+          # can re-execute retag in isolation without re-running check_head,
+          # and the branch HEAD may have advanced since the original run.
+          # Without this guard, a re-run of just retag would PATCH the tag
+          # to a stale github.sha.
+          HEAD_SHA="$(gh api "repos/$REPO/branches/$BRANCH" --jq '.commit.sha')"
+          if [ "$HEAD_SHA" != "$SHA" ]; then
+            echo "Skipping stale retag: event SHA=$SHA, current $BRANCH HEAD=$HEAD_SHA"
+            exit 0
+          fi
+
           echo "Pointing tag '$TAG' at $SHA (branch $BRANCH)"
 
           # PATCH the tag if it exists; create on 404; fail loud on any other

--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -14,11 +14,13 @@ permissions:
   contents: write
 
 concurrency:
-  # Include github.sha so a stale "Re-run jobs" replay (which carries the
-  # original SHA) cannot cancel an in-progress run for the current branch
-  # HEAD. Same-SHA re-runs still deduplicate.
-  group: version-tag-${{ github.ref_name }}-${{ github.sha }}
-  cancel-in-progress: true
+  # Per-branch group so concurrent runs serialize: back-to-back pushes
+  # land their tag-moves in commit order rather than racing.
+  # cancel-in-progress: false because a stale "Re-run jobs" replay would
+  # otherwise cancel the in-progress current-HEAD run; the HEAD-equivalence
+  # guard in the job body handles stale re-runs by exiting 0.
+  group: version-tag-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   retag:

--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -13,24 +13,16 @@ on:
 permissions:
   contents: write
 
-concurrency:
-  # Per-branch group so concurrent runs serialize: back-to-back pushes
-  # land their tag-moves in commit order rather than racing.
-  # cancel-in-progress: false because a stale "Re-run jobs" replay would
-  # otherwise cancel the in-progress current-HEAD run; the HEAD-equivalence
-  # guard in the job body handles stale re-runs by exiting 0.
-  group: version-tag-${{ github.ref_name }}
-  cancel-in-progress: false
-
 jobs:
-  retag:
+  check_head:
     runs-on: ubuntu-latest
+    outputs:
+      is_current: ${{ steps.head_check.outputs.is_current }}
+      tag: ${{ steps.branch_tag.outputs.tag }}
     steps:
-      - name: Move version tag to pushed SHA
+      - name: Resolve version tag for branch
+        id: branch_tag
         env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ github.sha }}
           BRANCH: ${{ github.ref_name }}
         run: |
           set -euo pipefail
@@ -40,16 +32,45 @@ jobs:
             sagitta)  TAG=1.4 ;;
             *) echo "Unexpected branch: $BRANCH" >&2; exit 1 ;;
           esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-          # Skip stale re-runs: GitHub's "Re-run jobs" replays the original
-          # event SHA, which would move the version tag backward to a stale
-          # commit. Compare event SHA against the current branch HEAD.
+      - name: Check event SHA matches current branch HEAD
+        id: head_check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
           HEAD_SHA="$(gh api "repos/$REPO/branches/$BRANCH" --jq '.commit.sha')"
           if [ "$HEAD_SHA" != "$SHA" ]; then
             echo "Skipping stale run: event SHA=$SHA, current $BRANCH HEAD=$HEAD_SHA"
+            echo "is_current=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          echo "is_current=true" >> "$GITHUB_OUTPUT"
+
+  retag:
+    needs: check_head
+    if: needs.check_head.outputs.is_current == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      # Per-branch job concurrency serializes tag moves while letting stale
+      # re-runs exit before they contend for the single pending slot.
+      group: version-tag-${{ github.ref_name }}
+      cancel-in-progress: false
+    steps:
+      - name: Move version tag to pushed SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
+          TAG: ${{ needs.check_head.outputs.tag }}
+        run: |
+          set -euo pipefail
           echo "Pointing tag '$TAG' at $SHA (branch $BRANCH)"
 
           # PATCH the tag if it exists; create on 404; fail loud on any other


### PR DESCRIPTION
## Summary

Follow-up to [vyos-documentation#1953](https://github.com/vyos/vyos-documentation/pull/1953). That PR added `${{ github.sha }}` to the `concurrency.group` key to prevent a stale "Re-run jobs" replay from cancelling the in-progress current-HEAD run. Copilot's review of the sagitta backport [vyos-documentation#1955](https://github.com/vyos/vyos-documentation/pull/1955) caught a regression that introduced — back-to-back pushes A then B could end up parallel, with run-A's force-PATCH potentially landing after run-B's and rewinding the tag. Copilot's review of the initial fix on this PR caught a further edge case where a stale re-run could displace a queued fresh push from the concurrency slot.

## The races to close

**Race 1 — back-to-back pushes (introduced by #1953):**
1. Push commit A → run-A starts (group `version-tag-rolling-A`), HEAD-check sees A, passes guard.
2. Push commit B before run-A finishes → run-B starts (group `version-tag-rolling-B`, **distinct group**, no cancellation), HEAD-check sees B, passes guard.
3. Both runs `PATCH /git/refs/tags/<TAG>` with `force=true`. If run-A's PATCH lands last, the tag rewinds to A.

**Race 2 — stale re-run displacing a queued push:**
With workflow-level concurrency `cancel-in-progress: false`, the queue holds one running + one pending. If push A is running, push B is pending, and a stale re-run C arrives:
1. run-C tries to enter the queue → it cancels the pending run-B (queue depth is 1) and takes the slot.
2. run-A completes; run-C starts; in-job HEAD-check sees C ≠ HEAD, exits 0.
3. Tag stays at A — push B's tag-move was lost.

The HEAD-equivalence guard from #1953 doesn't catch race 1 (both runs see a valid HEAD at the time they check), and an in-job HEAD check doesn't catch race 2 (the cancellation happens before the check runs).

## The fix

Split into two jobs so the HEAD check filters stale re-runs *before* they can contend for the concurrency slot:

- `check_head` — no concurrency control. Resolves the per-branch tag name, fetches branch HEAD, sets `is_current` output. Stale re-runs set `is_current=false` and exit 0 immediately.
- `retag` — depends on `check_head`, runs only when `is_current == 'true'`, carries job-level `concurrency: {group: version-tag-<ref>, cancel-in-progress: false}` so back-to-back pushes serialize.

Result:
- **Back-to-back pushes** queue serially in commit order; A's PATCH then B's PATCH; final tag = B. ✓
- **Stale re-runs** filter out at `check_head` and never enter the `retag` queue. ✓
- **HEAD-equivalence guard** from #1953 is preserved (now in `check_head`) as the runtime safeguard.

## Process

1. Open as draft against `rolling`.
2. Pre-merge: `@copilot review` on draft → flip to ready → `@coderabbitai review` (per the standard PR workflow).
3. After merge, post `@Mergifyio backport circinus sagitta`.
4. The two prior backports [vyos-documentation#1954](https://github.com/vyos/vyos-documentation/pull/1954) and [vyos-documentation#1955](https://github.com/vyos/vyos-documentation/pull/1955) were closed; fresh re-cuts after this merges will be byte-identical to the corrected rolling-side, preserving the drift-prevention requirement from the Context7 integration spec.

## Test plan

- [ ] CodeRabbit review clean
- [ ] Push two commits to `rolling` in quick succession; confirm tag `rolling` ends up at the second SHA, not the first
- [ ] Manually re-run a previous workflow run; confirm `check_head` exits with `is_current=false`, `retag` is skipped, and the tag stays at HEAD
- [ ] After backport: same checks on `circinus` (tag `1.5`) and `sagitta` (tag `1.4`)

🤖 Generated by [robots](https://vyos.io)
