### PR TITLE
ci: backport update-version-tags hardening to circinus (rolls up #1953 + #1958)

### DIFF
--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -14,19 +14,16 @@ on:
 permissions:
   contents: write
 
-concurrency:
-  group: version-tag-${{ github.ref_name }}
-  cancel-in-progress: true
-
 jobs:
-  retag:
+  check_head:
     runs-on: ubuntu-latest
+    outputs:
+      is_current: ${{ steps.head_check.outputs.is_current }}
+      tag: ${{ steps.branch_tag.outputs.tag }}
     steps:
-      - name: Move version tag to pushed SHA
+      - name: Resolve version tag for branch
+        id: branch_tag
         env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ github.sha }}
           BRANCH: ${{ github.ref_name }}
         run: |
           set -euo pipefail
@@ -36,11 +33,70 @@ jobs:
             sagitta)  TAG=1.4 ;;
             *) echo "Unexpected branch: $BRANCH" >&2; exit 1 ;;
           esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Check event SHA matches current branch HEAD
+        id: head_check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          HEAD_SHA="$(gh api "repos/$REPO/branches/$BRANCH" --jq '.commit.sha')"
+          if [ "$HEAD_SHA" != "$SHA" ]; then
+            echo "Skipping stale run: event SHA=$SHA, current $BRANCH HEAD=$HEAD_SHA"
+            echo "is_current=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "is_current=true" >> "$GITHUB_OUTPUT"
+
+  retag:
+    needs: check_head
+    if: needs.check_head.outputs.is_current == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      # Per-branch job concurrency serializes tag moves while letting stale
+      # re-runs exit before they contend for the single pending slot.
+      group: version-tag-${{ github.ref_name }}
+      cancel-in-progress: false
+    steps:
+      - name: Move version tag to pushed SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
+          TAG: ${{ needs.check_head.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # Re-validate HEAD inside retag too: GitHub's "Re-run failed jobs"
+          # can re-execute retag in isolation without re-running check_head,
+          # and the branch HEAD may have advanced since the original run.
+          # Without this guard, a re-run of just retag would PATCH the tag
+          # to a stale github.sha.
+          HEAD_SHA="$(gh api "repos/$REPO/branches/$BRANCH" --jq '.commit.sha')"
+          if [ "$HEAD_SHA" != "$SHA" ]; then
+            echo "Skipping stale retag: event SHA=$SHA, current $BRANCH HEAD=$HEAD_SHA"
+            exit 0
+          fi
+
           echo "Pointing tag '$TAG' at $SHA (branch $BRANCH)"
-          if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
-            gh api -X PATCH "repos/$REPO/git/refs/tags/$TAG" \
-              -f sha="$SHA" -F force=true
-          else
-            gh api -X POST "repos/$REPO/git/refs" \
-              -f ref="refs/tags/$TAG" -f sha="$SHA"
+
+          # PATCH the tag if it exists; create on 404; fail loud on any other
+          # gh-api error (auth, rate-limit, 5xx) instead of silently falling
+          # through to POST.
+          patch_err=""
+          if ! patch_err="$(gh api -X PATCH "repos/$REPO/git/refs/tags/$TAG" \
+            -f sha="$SHA" -F force=true 2>&1)"; then
+            if grep -q "HTTP 404" <<<"$patch_err"; then
+              gh api -X POST "repos/$REPO/git/refs" \
+                -f ref="refs/tags/$TAG" -f sha="$SHA"
+            else
+              echo "$patch_err" >&2
+              exit 1
+            fi
           fi


### PR DESCRIPTION
## Summary

Manual backport of [vyos-documentation#1958](https://github.com/vyos/vyos-documentation/pull/1958) (the rolling-side fix that itself superseded #1953). Mergify's per-PR backport [vyos-documentation#1963](https://github.com/vyos/vyos-documentation/pull/1963) failed mechanically — Mergify cherry-picked #1958's three commits onto a circinus base that never received #1953, producing a file with literal `<<<<<<< HEAD` / `=======` / `>>>>>>>` markers that could not be merged.

This PR rolls up the entire hardening series in one shot. The workflow file is a verbatim copy of `origin/rolling:.github/workflows/update-version-tags.yml` (substantive content), with the LTS branch's "keep all three copies in sync" header preserved (rolling has a context7-refresh-specific header because `context7-refresh.yml` is rolling-only).

## What the workflow does (final state)

Two-job pipeline:

- **`check_head`** — no concurrency control. Resolves the per-branch tag name (`circinus → 1.5`), fetches the live branch HEAD via `gh api repos/$REPO/branches/$BRANCH`, and sets `is_current=true` only when `github.sha` matches HEAD. Stale "Re-run jobs" replays exit with `is_current=false` immediately and never enter the queue.
- **`retag`** — depends on `check_head`, runs only when `is_current == 'true'`. Carries job-level `concurrency: {group: version-tag-${{ github.ref_name }}, cancel-in-progress: false}` so back-to-back pushes serialize in commit order. Re-validates HEAD inside its own job before PATCH (defense-in-depth against GitHub's "Re-run failed jobs" which can re-execute `retag` in isolation). Tag mutation: PATCH-first, fallback to POST only on `HTTP 404`, fail loud on any other `gh api` error.

## Race coverage (all closed)

| Scenario | Caught by |
|----------|-----------|
| Stale "Re-run jobs" replay | `check_head` HEAD guard |
| Stale re-run displacing pending fresh push from queue | `check_head` runs without concurrency, filters before queue contention |
| Back-to-back pushes A then B running in parallel | per-branch concurrency group + `cancel-in-progress: false` serializes |
| "Re-run failed jobs" re-executing only `retag` on a stale SHA | second HEAD guard inside `retag` |
| Silent fall-through to POST on auth/rate-limit/5xx errors | PATCH-first / 404-only-fallback / fail-loud-on-other |

## Process

1. Open as draft.
2. Pre-merge: `@copilot review` on draft → flip to ready → `@coderabbitai review` (per the standard PR workflow).

## Test plan

- [ ] CodeRabbit review clean
- [ ] After merge, push a trivial commit to `circinus` and confirm tag `1.5` advances to the new HEAD via the workflow log
- [ ] Manually re-run a previous workflow run and confirm `check_head` exits with `is_current=false`, `retag` is skipped

🤖 Generated by [robots](https://vyos.io)
