### PR TITLE
ci(ai-validation): skip Pass 1/2 when PR has no docs/ changes

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Compute changed files and bundle .md content
         run: |
           set -euo pipefail
-          git fetch --depth=1 origin "${{ github.event.pull_request.base.ref }}"
+          git fetch --depth=1 origin "${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}"
           BASE="origin/${{ github.event.pull_request.base.ref }}"
           # --diff-filter=ACMRT excludes Deleted entries so the bundling
           # loop below (`git show HEAD:<path>`) doesn't try to extract

--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -71,7 +71,8 @@ jobs:
           git diff "$BASE...HEAD" --name-only --diff-filter=ACMRT -z -- 'docs/**/*.rst' > changed-rst.z
           tr '\0' '\n' < changed-md.z  > changed-md.txt
           tr '\0' '\n' < changed-rst.z > changed-rst.txt
-          git diff "$BASE...HEAD" -- 'docs/**/*.md' > diff-md.patch
+          git diff "$BASE...HEAD" -- 'docs/**/*.md'  > diff-md.patch
+          git diff "$BASE...HEAD" -- 'docs/**/*.rst' > diff-rst.patch
           # Bundle .md files via git's blob store (NOT the filesystem).
           # The fork's merge ref can contain symlinks (mode 120000) committed
           # to docs/**/*.md that resolve to absolute paths on the runner.
@@ -130,6 +131,7 @@ jobs:
             changed-md.txt
             changed-rst.txt
             diff-md.patch
+            diff-rst.patch
             _changed_md/
 
   validate:
@@ -279,6 +281,13 @@ jobs:
       # burn an API call. Both are gated on this step's outputs below.
       # This step reads only the artifact files from the trusted prepare job
       # — no fork-controlled string interpolation.
+      #
+      # has_md  uses changed-md.txt because Pass 1 needs MD content present
+      #         in HEAD to validate (changed-md.txt is built with
+      #         --diff-filter=ACMRT, deletions excluded).
+      # has_doc uses diff-md.patch / diff-rst.patch (full diffs, deletions
+      #         included) so a delete-only PR still routes through Pass 2 —
+      #         Claude can flag accidental or unexplained removals.
       - name: Compute change flags
         if: steps.secrets-check.outputs.skip != 'true'
         id: changes
@@ -289,7 +298,7 @@ jobs:
           else
             echo "has_md=false" >> "$GITHUB_OUTPUT"
           fi
-          if [ -s changed-md.txt ] || [ -s changed-rst.txt ]; then
+          if [ -s diff-md.patch ] || [ -s diff-rst.patch ]; then
             echo "has_doc=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_doc=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -188,97 +188,18 @@ jobs:
         with:
           name: pr-input
 
-      - name: Generate GitHub App token
-        if: steps.secrets-check.outputs.skip != 'true'
-        id: app
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
-        with:
-          app-id: ${{ secrets.VYOS_APP_ID }}
-          private-key: ${{ secrets.VYOS_APP_PRIVATE_KEY }}
-          owner: VyOS-Networks
-          repositories: vyos-1x,vyos-docs-opus-reviewer
-
-      - name: Sparse-checkout branches.json from reviewer
-        if: steps.secrets-check.outputs.skip != 'true'
-        uses: actions/checkout@v6
-        with:
-          repository: VyOS-Networks/vyos-docs-opus-reviewer
-          ref: ${{ env.REVIEWER_REF }}
-          token: ${{ steps.app.outputs.token }}
-          # persist-credentials:false stops actions/checkout from writing the
-          # App token into reviewer/.git/config as an http extraheader. Without
-          # this the token would be readable from the workspace by the Pass 2
-          # claude-code-action step (which has Read/Glob/Grep allowed), so a
-          # prompt-injection attempt could exfiltrate it.
-          persist-credentials: false
-          path: reviewer
-          sparse-checkout: |
-            branches.json
-
-      - name: Resolve docs-branch to vyos-1x branch
-        if: steps.secrets-check.outputs.skip != 'true'
-        id: branch
-        run: |
-          set -euo pipefail
-          TARGET="${{ github.event.pull_request.base.ref }}"
-          MAPPED=$(jq -r --arg b "$TARGET" '.[$b] // empty' reviewer/branches.json)
-          if [ -z "$MAPPED" ]; then
-            echo "::error::Docs branch '$TARGET' is not configured for AI validation. Add it to branches.json in vyos-docs-opus-reviewer (known: $(jq -c 'keys' reviewer/branches.json))."
-            exit 1
-          fi
-          echo "docs=$TARGET" >> "$GITHUB_OUTPUT"
-          echo "vyos1x=$MAPPED" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout vyos-1x at mapped branch
-        if: steps.secrets-check.outputs.skip != 'true'
-        uses: actions/checkout@v6
-        with:
-          repository: vyos-networks/vyos-1x
-          ref: ${{ steps.branch.outputs.vyos1x }}
-          path: .vyos-1x
-          fetch-depth: 1
-          token: ${{ steps.app.outputs.token }}
-          # Same rationale as the reviewer sparse-checkout above: prevent the
-          # App token from being readable in .vyos-1x/.git/config by the
-          # claude-code-action Pass 2 step.
-          persist-credentials: false
-
-      - name: Download reference DB (best-effort)
-        if: steps.secrets-check.outputs.skip != 'true'
-        id: download-db
-        continue-on-error: true
-        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
-        with:
-          repository: VyOS-Networks/vyos-docs-opus-reviewer
-          latest: true
-          fileName: reference-db-${{ steps.branch.outputs.vyos1x }}.tar.gz
-          out-file-path: .reference-db
-          token: ${{ steps.app.outputs.token }}
-
-      - name: Extract reference DB
-        if: steps.secrets-check.outputs.skip != 'true' && steps.download-db.outcome == 'success'
-        run: |
-          mkdir -p .reference-db/extracted
-          tar -xzf .reference-db/reference-db-${{ steps.branch.outputs.vyos1x }}.tar.gz -C .reference-db/extracted
-
-      - name: Fail-closed gate
-        if: steps.secrets-check.outputs.skip != 'true'
-        run: |
-          set -euo pipefail
-          if [ -s changed-md.txt ] && [ ! -d .reference-db/extracted ]; then
-            echo "::error::Reference DB missing for vyos-1x branch '${{ steps.branch.outputs.vyos1x }}'. Pass 1 cannot run. Re-trigger rebuild-reference.yml in the reviewer repo and re-run."
-            exit 1
-          fi
-
-      # Skip Pass 1 / Pass 2 entirely when the PR touches no docs/ content.
-      # actions/upload-artifact@v4 silently drops empty directories from the
-      # uploaded archive, so a PR with no docs/**/*.md changes (workflow-only
-      # PR, RST-only PR, .gitignore edit, etc.) leaves the validate job
-      # without a _changed_md/ directory after download-artifact. Pass 1
-      # then fails immediately because `working-directory: _changed_md`
-      # errors with "No such file or directory" before its `run:` block can
-      # execute. Pass 2 (Claude) would otherwise produce an empty review and
-      # burn an API call. Both are gated on this step's outputs below.
+      # Compute the has_md / has_doc gates as early as possible so that
+      # workflow-only / non-doc PRs short-circuit BEFORE the privileged
+      # setup steps below (App-token mint, vyos-1x checkout, reviewer
+      # source checkout, reference-DB download, uv install). Those steps
+      # mint and use VYOS_APP_* secrets to pull private repos and would
+      # otherwise burn ~30s on every workflow-only PR for no purpose.
+      # actions/upload-artifact@v4 silently drops empty directories from
+      # the uploaded archive, so a PR with no docs/**/*.md changes
+      # (workflow-only PR, RST-only PR, .gitignore edit, etc.) leaves the
+      # validate job without a _changed_md/ directory after download —
+      # without this guard, Pass 1 fails immediately on `working-directory:
+      # _changed_md` and Pass 2 burns an API call producing an empty review.
       # This step reads only the artifact files from the trusted prepare job
       # — no fork-controlled string interpolation.
       #
@@ -305,6 +226,88 @@ jobs:
             echo "::notice::PR touches no docs/**/*.md or docs/**/*.rst files; skipping Pass 1 and Pass 2."
           fi
 
+      - name: Generate GitHub App token
+        if: steps.secrets-check.outputs.skip != 'true' && steps.changes.outputs.has_doc == 'true'
+        id: app
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.VYOS_APP_ID }}
+          private-key: ${{ secrets.VYOS_APP_PRIVATE_KEY }}
+          owner: VyOS-Networks
+          repositories: vyos-1x,vyos-docs-opus-reviewer
+
+      - name: Sparse-checkout branches.json from reviewer
+        if: steps.secrets-check.outputs.skip != 'true' && steps.changes.outputs.has_doc == 'true'
+        uses: actions/checkout@v6
+        with:
+          repository: VyOS-Networks/vyos-docs-opus-reviewer
+          ref: ${{ env.REVIEWER_REF }}
+          token: ${{ steps.app.outputs.token }}
+          # persist-credentials:false stops actions/checkout from writing the
+          # App token into reviewer/.git/config as an http extraheader. Without
+          # this the token would be readable from the workspace by the Pass 2
+          # claude-code-action step (which has Read/Glob/Grep allowed), so a
+          # prompt-injection attempt could exfiltrate it.
+          persist-credentials: false
+          path: reviewer
+          sparse-checkout: |
+            branches.json
+
+      - name: Resolve docs-branch to vyos-1x branch
+        if: steps.secrets-check.outputs.skip != 'true' && steps.changes.outputs.has_doc == 'true'
+        id: branch
+        run: |
+          set -euo pipefail
+          TARGET="${{ github.event.pull_request.base.ref }}"
+          MAPPED=$(jq -r --arg b "$TARGET" '.[$b] // empty' reviewer/branches.json)
+          if [ -z "$MAPPED" ]; then
+            echo "::error::Docs branch '$TARGET' is not configured for AI validation. Add it to branches.json in vyos-docs-opus-reviewer (known: $(jq -c 'keys' reviewer/branches.json))."
+            exit 1
+          fi
+          echo "docs=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "vyos1x=$MAPPED" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout vyos-1x at mapped branch
+        if: steps.secrets-check.outputs.skip != 'true' && steps.changes.outputs.has_doc == 'true'
+        uses: actions/checkout@v6
+        with:
+          repository: vyos-networks/vyos-1x
+          ref: ${{ steps.branch.outputs.vyos1x }}
+          path: .vyos-1x
+          fetch-depth: 1
+          token: ${{ steps.app.outputs.token }}
+          # Same rationale as the reviewer sparse-checkout above: prevent the
+          # App token from being readable in .vyos-1x/.git/config by the
+          # claude-code-action Pass 2 step.
+          persist-credentials: false
+
+      - name: Download reference DB (best-effort)
+        if: steps.secrets-check.outputs.skip != 'true' && steps.changes.outputs.has_doc == 'true'
+        id: download-db
+        continue-on-error: true
+        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
+        with:
+          repository: VyOS-Networks/vyos-docs-opus-reviewer
+          latest: true
+          fileName: reference-db-${{ steps.branch.outputs.vyos1x }}.tar.gz
+          out-file-path: .reference-db
+          token: ${{ steps.app.outputs.token }}
+
+      - name: Extract reference DB
+        if: steps.secrets-check.outputs.skip != 'true' && steps.changes.outputs.has_doc == 'true' && steps.download-db.outcome == 'success'
+        run: |
+          mkdir -p .reference-db/extracted
+          tar -xzf .reference-db/reference-db-${{ steps.branch.outputs.vyos1x }}.tar.gz -C .reference-db/extracted
+
+      - name: Fail-closed gate
+        if: steps.secrets-check.outputs.skip != 'true' && steps.changes.outputs.has_doc == 'true'
+        run: |
+          set -euo pipefail
+          if [ -s changed-md.txt ] && [ ! -d .reference-db/extracted ]; then
+            echo "::error::Reference DB missing for vyos-1x branch '${{ steps.branch.outputs.vyos1x }}'. Pass 1 cannot run. Re-trigger rebuild-reference.yml in the reviewer repo and re-run."
+            exit 1
+          fi
+
       # astral-sh/setup-uv is used instead of actions/setup-python: uv
       # provisions Python interpreters from Astral's standalone builds in a
       # few seconds (no apt cache, no compile), and the same recipe works
@@ -315,7 +318,7 @@ jobs:
       # ${{ github.workspace }}/.venv and prepends its bin/ to PATH so the
       # `vyos-doc-review` CLI script is callable in subsequent steps.
       - name: Setup uv + Python 3.12
-        if: steps.secrets-check.outputs.skip != 'true'
+        if: steps.secrets-check.outputs.skip != 'true' && steps.changes.outputs.has_doc == 'true'
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: '3.12'
@@ -329,7 +332,7 @@ jobs:
       # instead, and persist-credentials:false ensures it does not linger in
       # reviewer-src/.git/config where the Pass 2 LLM step could read it.
       - name: Checkout reviewer package source (pinned to REVIEWER_REF)
-        if: steps.secrets-check.outputs.skip != 'true'
+        if: steps.secrets-check.outputs.skip != 'true' && steps.changes.outputs.has_doc == 'true'
         uses: actions/checkout@v6
         with:
           repository: VyOS-Networks/vyos-docs-opus-reviewer
@@ -339,7 +342,7 @@ jobs:
           path: reviewer-src
 
       - name: Install reviewer (from local checkout)
-        if: steps.secrets-check.outputs.skip != 'true'
+        if: steps.secrets-check.outputs.skip != 'true' && steps.changes.outputs.has_doc == 'true'
         run: |
           uv pip install ./reviewer-src
 

--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -268,6 +268,34 @@ jobs:
             exit 1
           fi
 
+      # Skip Pass 1 / Pass 2 entirely when the PR touches no docs/ content.
+      # actions/upload-artifact@v4 silently drops empty directories from the
+      # uploaded archive, so a PR with no docs/**/*.md changes (workflow-only
+      # PR, RST-only PR, .gitignore edit, etc.) leaves the validate job
+      # without a _changed_md/ directory after download-artifact. Pass 1
+      # then fails immediately because `working-directory: _changed_md`
+      # errors with "No such file or directory" before its `run:` block can
+      # execute. Pass 2 (Claude) would otherwise produce an empty review and
+      # burn an API call. Both are gated on this step's outputs below.
+      # This step reads only the artifact files from the trusted prepare job
+      # — no fork-controlled string interpolation.
+      - name: Compute change flags
+        if: steps.secrets-check.outputs.skip != 'true'
+        id: changes
+        run: |
+          set -euo pipefail
+          if [ -s changed-md.txt ]; then
+            echo "has_md=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_md=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -s changed-md.txt ] || [ -s changed-rst.txt ]; then
+            echo "has_doc=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_doc=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::PR touches no docs/**/*.md or docs/**/*.rst files; skipping Pass 1 and Pass 2."
+          fi
+
       # astral-sh/setup-uv is used instead of actions/setup-python: uv
       # provisions Python interpreters from Astral's standalone builds in a
       # few seconds (no apt cache, no compile), and the same recipe works
@@ -312,7 +340,7 @@ jobs:
       # Pass 1 would emit zero findings — a silent failure mode the
       # §3.6 fail-closed gate cannot catch when the DB is present.
       - name: Pass 1 — deterministic checks
-        if: steps.secrets-check.outputs.skip != 'true' && steps.download-db.outcome == 'success'
+        if: steps.secrets-check.outputs.skip != 'true' && steps.download-db.outcome == 'success' && steps.changes.outputs.has_md == 'true'
         working-directory: _changed_md
         run: |
           vyos-doc-review pass1 \
@@ -321,7 +349,7 @@ jobs:
             --output ../pass1-findings.json
 
       - name: Pass 2 — Claude review
-        if: steps.secrets-check.outputs.skip != 'true'
+        if: steps.secrets-check.outputs.skip != 'true' && steps.changes.outputs.has_doc == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

`actions/upload-artifact@v4` silently drops empty directories from the uploaded archive. On a PR that touches no `docs/**/*.md` files (workflow-only, RST-only, `.gitignore` edit, etc.), `prepare` creates an empty `_changed_md/` directory, upload-artifact omits it, and the `validate` job's Pass 1 step errors with `No such file or directory` on `working-directory: _changed_md` before any of its own `run:` logic executes.

Observed: [Mergify sagitta backport #1964](https://github.com/vyos/vyos-documentation/pull/1964) (which only edits `update-version-tags.yml`) — [failing run](https://github.com/vyos/vyos-documentation/actions/runs/25640893989/job/75261013117).

## Fix

Add a `Compute change flags` step after the fail-closed gate that reads the trusted prepare-job artifacts (`changed-md.txt`, `changed-rst.txt`) and emits two outputs:

- `has_md` — gates Pass 1 (deterministic checks need MD content to validate)
- `has_doc` — gates Pass 2 (Claude still runs on RST-only PRs so it surfaces the "Skipped N RST awaiting MyST migration" line)

Workflow-only / non-doc PRs now skip both passes with a `::notice::` annotation instead of failing.

## Trust boundary

The new step reads only artifact files produced by the trusted `prepare` job. No fork-controlled string interpolation; `${{ github.event.* }}` is not referenced.

## Test plan

- [ ] Self-review the diff on the draft PR.
- [ ] `@copilot review` once the draft compiles and the YAML is syntactically valid (validated locally with `python -c "import yaml; yaml.safe_load(...)"`).
- [ ] On `pull_request_target` for this PR itself: validate triggers, fail-closed gate stays green, `Compute change flags` reports `has_md=true` because this PR edits a workflow file but is itself in `.github/` (not `docs/`) — actually `has_md=false, has_doc=false`, so Pass 1 and Pass 2 both skip via the new notice. Confirm the run succeeds.
- [ ] After the workflow-only run succeeds, flip to ready and invoke `@coderabbitai review`.

## Out of scope

- Empty-`_changed_md/` survival via a `.keep` sentinel — would also fix the symptom but adds an artifact file with no purpose for the consumer.
- Skipping the entire `validate` job (vs. individual steps) — needs a job-level conditional that depends on `prepare`'s artifact contents, which complicates the trust-boundary handoff.

🤖 Generated by [robots](https://vyos.io)