### PR TITLE
ci(ai-validation): skip Pass 1/2 when PR has no .md changes

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -49,6 +49,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      # Surface whether the PR touched any docs/**/*.md so validate's review
+      # steps can skip on infrastructure-only PRs (workflow/config/README
+      # changes). actions/upload-artifact silently omits empty directories
+      # — when no .md files change, _changed_md/ isn't uploaded, and
+      # validate's working-directory: _changed_md would otherwise fail
+      # before any in-step short-circuit can run.
+      has_md_changes: ${{ steps.changes.outputs.has_md_changes }}
     steps:
       - name: Checkout PR merge ref (NO credentials)
         uses: actions/checkout@v6
@@ -58,6 +66,7 @@ jobs:
           fetch-depth: 2
 
       - name: Compute changed files and bundle .md content
+        id: changes
         run: |
           set -euo pipefail
           git fetch --depth=1 origin "${{ github.event.pull_request.base.ref }}"
@@ -121,6 +130,12 @@ jobs:
             mkdir -p "_changed_md/$(dirname -- "$path")"
             git show "HEAD:$path" > "_changed_md/$path"
           done < changed-md.z
+
+          if [ -s changed-md.txt ]; then
+            echo "has_md_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_md_changes=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Upload PR input artifact
         uses: actions/upload-artifact@v4
@@ -312,7 +327,7 @@ jobs:
       # Pass 1 would emit zero findings — a silent failure mode the
       # §3.6 fail-closed gate cannot catch when the DB is present.
       - name: Pass 1 — deterministic checks
-        if: steps.secrets-check.outputs.skip != 'true' && steps.download-db.outcome == 'success'
+        if: steps.secrets-check.outputs.skip != 'true' && steps.download-db.outcome == 'success' && needs.prepare.outputs.has_md_changes == 'true'
         working-directory: _changed_md
         run: |
           vyos-doc-review pass1 \
@@ -321,7 +336,7 @@ jobs:
             --output ../pass1-findings.json
 
       - name: Pass 2 — Claude review
-        if: steps.secrets-check.outputs.skip != 'true'
+        if: steps.secrets-check.outputs.skip != 'true' && needs.prepare.outputs.has_md_changes == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -133,7 +133,12 @@ jobs:
             git show "HEAD:$path" > "_changed_md/$path"
           done < changed-md.z
 
-          if [ -s changed-md.txt ]; then
+          # Use diff-md.patch (unfiltered git diff) rather than changed-md.txt
+          # (--diff-filter=ACMRT) so deletion-only PRs still trigger validate.
+          # Pass 1 reviews the diff, not just the post-image files in
+          # _changed_md/, so deletes are legitimate review targets even though
+          # they produce no entries in _changed_md/.
+          if [ -s diff-md.patch ]; then
             echo "has_md_changes=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_md_changes=false" >> "$GITHUB_OUTPUT"
@@ -207,6 +212,16 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: pr-input
+
+      - name: Ensure _changed_md exists (handles deletion-only PRs)
+        if: steps.secrets-check.outputs.skip != 'true'
+        # actions/upload-artifact silently omits empty directories. On a
+        # deletion-only PR, prepare's _changed_md/ holds no files and never
+        # makes it across the artifact boundary — Pass 1's
+        # working-directory: _changed_md would then fail. Recreate the
+        # directory unconditionally; Pass 1 still operates on the diff
+        # via --pr-diff ../diff-md.patch, which is the source of truth.
+        run: mkdir -p _changed_md
 
       - name: Generate GitHub App token
         if: steps.secrets-check.outputs.skip != 'true'

--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -151,6 +151,11 @@ jobs:
 
   validate:
     needs: [prepare]
+    # Skip the entire job on infrastructure-only PRs. Otherwise the
+    # expensive setup chain (artifact download, GitHub App token, reviewer
+    # checkout/install, reference-DB download/extract, uv setup) runs even
+    # though Pass 1 + Pass 2 are guaranteed to no-op.
+    if: needs.prepare.outputs.has_md_changes == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -329,7 +334,7 @@ jobs:
       # Pass 1 would emit zero findings — a silent failure mode the
       # §3.6 fail-closed gate cannot catch when the DB is present.
       - name: Pass 1 — deterministic checks
-        if: steps.secrets-check.outputs.skip != 'true' && steps.download-db.outcome == 'success' && needs.prepare.outputs.has_md_changes == 'true'
+        if: steps.secrets-check.outputs.skip != 'true' && steps.download-db.outcome == 'success'
         working-directory: _changed_md
         run: |
           vyos-doc-review pass1 \
@@ -338,7 +343,7 @@ jobs:
             --output ../pass1-findings.json
 
       - name: Pass 2 — Claude review
-        if: steps.secrets-check.outputs.skip != 'true' && needs.prepare.outputs.has_md_changes == 'true'
+        if: steps.secrets-check.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -69,8 +69,10 @@ jobs:
         id: changes
         run: |
           set -euo pipefail
-          git fetch --depth=1 origin "${{ github.event.pull_request.base.ref }}"
-          BASE="origin/${{ github.event.pull_request.base.ref }}"
+          # Fetch the base branch explicitly by refname to avoid ambiguity with
+          # same-named tags (e.g., a `rolling` tag), then diff against FETCH_HEAD.
+          git fetch --no-tags --depth=1 origin "refs/heads/${{ github.event.pull_request.base.ref }}"
+          BASE="FETCH_HEAD"
           # --diff-filter=ACMRT excludes Deleted entries so the bundling
           # loop below (`git show HEAD:<path>`) doesn't try to extract
           # blobs for files that no longer exist in the merge ref.


### PR DESCRIPTION
## Summary

`actions/upload-artifact` silently omits empty directories. On a PR that changes no `docs/**/*.md` files (workflow tweaks, README edits, config changes), the prepare job's `_changed_md/` is empty and is dropped from the artifact. The validate job downloads the artifact, then `Pass 1 — deterministic checks` tries to start with `working-directory: _changed_md`, which doesn't exist:

> `An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/vyos-documentation/vyos-documentation/_changed_md'. No such file or directory`

Bash never reaches any in-step short-circuit, so the job fails red before doing anything.

This affects every infrastructure-only PR. Currently visible on:

- [vyos-documentation#1965](https://github.com/vyos/vyos-documentation/pull/1965) (circinus backport — pure workflow change)
- [vyos-documentation#1966](https://github.com/vyos/vyos-documentation/pull/1966) (sagitta backport — pure workflow change)

Validate isn't a required check, so PRs aren't blocked, but the noise is worth eliminating — and any future infrastructure PR will hit the same wall.

## The fix

Surface a `has_md_changes` output from `prepare` based on whether `changed-md.txt` is non-empty, and gate `Pass 1` + `Pass 2` on it. When the flag is false, both review steps skip cleanly.

```yaml
prepare:
  outputs:
    has_md_changes: ${{ steps.changes.outputs.has_md_changes }}
  steps:
    - name: Compute changed files and bundle .md content
      id: changes  # NEW
      run: |
        ...
        # NEW (at end):
        if [ -s changed-md.txt ]; then
          echo "has_md_changes=true" >> "$GITHUB_OUTPUT"
        else
          echo "has_md_changes=false" >> "$GITHUB_OUTPUT"
        fi

validate:
  steps:
    - name: Pass 1 — deterministic checks
      if: ... && needs.prepare.outputs.has_md_changes == 'true'
      ...
    - name: Pass 2 — Claude review
      if: ... && needs.prepare.outputs.has_md_changes == 'true'
      ...
```

## Why not also recreate `_changed_md/` defensively in validate?

That would mask the underlying signal — a no-MD PR would silently spend CI minutes downloading the reference DB, installing the reviewer package, and running Pass 1 on an empty diff. Gating both passes is cleaner: the work is genuinely unnecessary, so don't do it.

## Why this lives on rolling only

`pull_request_target` workflows always run from the default branch's workflow file regardless of the PR's base. `ai-validation.yml` exists only on rolling and runs on PRs to all three branches via this mechanism — fixing it here automatically fixes it for circinus and sagitta PRs too. No backport needed.

## Process

1. Open as draft.
2. Pre-merge: `@copilot review` on draft → flip to ready → `@coderabbitai review`.
3. After merge, re-trigger validate on [vyos-documentation#1965](https://github.com/vyos/vyos-documentation/pull/1965) and [vyos-documentation#1966](https://github.com/vyos/vyos-documentation/pull/1966) (push a no-op or close/reopen) to confirm validate now skips green.

## Test plan

- [ ] CodeRabbit review clean
- [ ] After merge, observe validate on the next non-MD-changing PR — Pass 1 and Pass 2 should both show as `skipped`, job status overall `success`.
- [ ] Open a no-op PR that touches a `.md` file — confirm both passes still run as before.

🤖 Generated by [robots](https://vyos.io)
