### PR TITLE
ci(ai-validation): revert DB-download `tag:` pin to `latest:true` (critical regression)

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -323,11 +323,17 @@ jobs:
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
           repository: VyOS-Networks/vyos-docs-opus-reviewer
-          # Pin the DB to the same release tag as REVIEWER_REF so a future
-          # reviewer-v1.x.x release with a schema change cannot be silently
-          # picked up while the pinned reviewer code still expects the old
-          # schema. Reproducibility > recency for this artifact.
-          tag: ${{ env.REVIEWER_REF }}
+          # latest: true is correct here. Reference DBs live in their own
+          # `ref-db-<timestamp>` release stream produced by the matrixed
+          # rebuild-reference workflow — NOT attached to the `reviewer-v1.x.x`
+          # release that REVIEWER_REF pins. A `tag: ${{ env.REVIEWER_REF }}`
+          # form would 404 (the reviewer-v1.x.x tag has no GH release with
+          # DB assets). The reference DB schema is intentionally backwards
+          # compatible across reviewer Python releases; the freshest DB is
+          # the right choice. If the DB schema ever changes incompatibly,
+          # bump REVIEWER_REF in the consuming workflow and the new code
+          # will refuse to load an older-format DB at the fail-closed gate.
+          latest: true
           fileName: reference-db-${{ steps.branch.outputs.vyos1x }}.tar.gz
           out-file-path: .reference-db
           token: ${{ steps.app.outputs.token }}


### PR DESCRIPTION
**CRITICAL REGRESSION fix** — found while syncing canonical [VyOS-Networks/vyos-docs-opus-reviewer#15](https://github.com/VyOS-Networks/vyos-docs-opus-reviewer/pull/15).

[#1969](https://github.com/vyos/vyos-documentation/pull/1969) changed the reference-DB download from \`latest: true\` to \`tag: \${{ env.REVIEWER_REF }}\` (set to \`reviewer-v1.0.1\`). Post-merge verification shows:

\`\`\`bash
$ gh api /repos/VyOS-Networks/vyos-docs-opus-reviewer/releases/tags/reviewer-v1.0.1
{"message": "Not Found", "status": "404"}
\`\`\`

The \`reviewer-v1.0.1\` tag exists but has **no GitHub release** with DB assets attached. Reference DBs are published to a separate release stream by the matrixed \`rebuild-reference\` workflow, tagged \`ref-db-<UTC-timestamp>\` (e.g. \`ref-db-20260510-193946\`). The two artifact streams have independent cadences.

\`robinraju/release-downloader\` with \`tag: reviewer-v1.0.1\` therefore 404s. The download step has \`continue-on-error: true\` so the run proceeds, but the fail-closed gate at the next step errors every validate run on a PR with MD changes.

## Why this wasn't caught

Our recent test PRs (#1947 / #1956 / #1957 / #1968 / #1969 / #1970 on rolling, plus the circinus/sagitta backports) were all infrastructure-only changes. \`has_md_changes\` was \`false\`, validate was skipped at the job level, and the DB step was never invoked. The regression would only have surfaced on the next real \`.md\`-changing PR.

## Fix

Revert to \`latest: true\`. The reference DB schema is intentionally backwards-compatible across reviewer Python releases; the freshest DB is always usable. If the schema ever changes incompatibly, the way to opt out is bump \`REVIEWER_REF\` and the new reviewer code will refuse to load an older DB at the fail-closed gate.

Added an explicit inline comment block explaining the release-asset topology so the next reviewer pass doesn't re-introduce this regression.

## Paired PR

[VyOS-Networks/vyos-docs-opus-reviewer#15](https://github.com/VyOS-Networks/vyos-docs-opus-reviewer/pull/15) applies the same revert on the canonical \`scripts/ai-validation.yml\` and bumps the canonical's REVIEWER_REF default to \`reviewer-v1.0.2\` so canonical and deployed stay aligned after the next reviewer tag.

## Circinus + sagitta

Companion PRs will follow against \`circinus\` and \`sagitta\` so the workflow file stays byte-identical across all three release branches (per the recent #1970 / #1960 / #1969 wave).

🤖 Generated by [robots](https://vyos.io)