### PR TITLE
ci(ai-validation, sagitta): revert DB-download tag pin to latest:true (backport #1971)

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -331,8 +331,11 @@ jobs:
           # DB assets). The reference DB schema is intentionally backwards
           # compatible across reviewer Python releases; the freshest DB is
           # the right choice. If the DB schema ever changes incompatibly,
-          # bump REVIEWER_REF in the consuming workflow and the new code
-          # will refuse to load an older-format DB at the fail-closed gate.
+          # bump REVIEWER_REF in the consuming workflow — the newer
+          # reviewer code will error at DB-load time inside `Pass 1 —
+          # deterministic checks`. The workflow's own fail-closed gate is
+          # a presence check (`[ -s diff-md.patch ] && [ ! -d
+          # .reference-db/extracted ]`); it does not inspect DB schema.
           latest: true
           fileName: reference-db-${{ steps.branch.outputs.vyos1x }}.tar.gz
           out-file-path: .reference-db

--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -323,11 +323,17 @@ jobs:
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
           repository: VyOS-Networks/vyos-docs-opus-reviewer
-          # Pin the DB to the same release tag as REVIEWER_REF so a future
-          # reviewer-v1.x.x release with a schema change cannot be silently
-          # picked up while the pinned reviewer code still expects the old
-          # schema. Reproducibility > recency for this artifact.
-          tag: ${{ env.REVIEWER_REF }}
+          # latest: true is correct here. Reference DBs live in their own
+          # `ref-db-<timestamp>` release stream produced by the matrixed
+          # rebuild-reference workflow — NOT attached to the `reviewer-v1.x.x`
+          # release that REVIEWER_REF pins. A `tag: ${{ env.REVIEWER_REF }}`
+          # form would 404 (the reviewer-v1.x.x tag has no GH release with
+          # DB assets). The reference DB schema is intentionally backwards
+          # compatible across reviewer Python releases; the freshest DB is
+          # the right choice. If the DB schema ever changes incompatibly,
+          # bump REVIEWER_REF in the consuming workflow and the new code
+          # will refuse to load an older-format DB at the fail-closed gate.
+          latest: true
           fileName: reference-db-${{ steps.branch.outputs.vyos1x }}.tar.gz
           out-file-path: .reference-db
           token: ${{ steps.app.outputs.token }}


### PR DESCRIPTION
Backport of [#1971](https://github.com/vyos/vyos-documentation/pull/1971) to **%BRANCH%** so the workflow file stays byte-identical across rolling/circinus/sagitta.

## Reason — critical regression

[#1969](https://github.com/vyos/vyos-documentation/pull/1969) changed the reference-DB download from `latest: true` to `tag: ${{ env.REVIEWER_REF }}` (set to `reviewer-v1.0.1`). Post-merge verification on the canonical-sync PR ([VyOS-Networks/vyos-docs-opus-reviewer#15](https://github.com/VyOS-Networks/vyos-docs-opus-reviewer/pull/15)) caught:

```bash
$ gh api /repos/VyOS-Networks/vyos-docs-opus-reviewer/releases/tags/reviewer-v1.0.1
{"message": "Not Found", "status": "404"}
```

The `reviewer-v1.0.1` tag exists but has **no GitHub release with DB assets** attached. Reference DBs live in their own release stream (`ref-db-<UTC-timestamp>`), produced by the matrixed `rebuild-reference` workflow on its own schedule. `robinraju/release-downloader` with `tag: reviewer-v1.0.1` therefore 404s. The download step has `continue-on-error: true`, but the fail-closed gate then errors every validate run with MD changes.

## Why this wasn't caught

All 10 PRs in the recent #1947→#1970 wave were infrastructure-only (`has_md_changes=false` → validate skipped at the job level → DB step never invoked). The regression would only have surfaced on the next real `.md`-changing PR.

## Fix

Revert to `latest: true` with an explicit inline comment block explaining the release-asset topology so this is not re-broken on a future review pass.

## Companion PRs

| Repo / Branch | PR | HEAD |
|----|----|----|
| vyos/vyos-documentation / rolling | [#1971](https://github.com/vyos/vyos-documentation/pull/1971) | `b465e3b1` |
| **vyos/vyos-documentation / %BRANCH%** | **this PR** | `%SHA%` |
| VyOS-Networks/vyos-docs-opus-reviewer / main (canonical) | [#15](https://github.com/VyOS-Networks/vyos-docs-opus-reviewer/pull/15) | `4c47d99` |

🤖 Generated by [robots](https://vyos.io)