### PR TITLE
ci(ai-validation, rolling): align fail-closed-gate comment + bump REVIEWER_REF to v1.0.2

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REVIEWER_REF: reviewer-v1.0.1
+  REVIEWER_REF: reviewer-v1.0.2
   # Force JavaScript actions to run on Node 24. Some pinned action SHAs
   # we rely on still ship with Node 20 ABI; this env var opts the whole
   # workflow into Node 24 without per-action version churn.
@@ -331,8 +331,11 @@ jobs:
           # DB assets). The reference DB schema is intentionally backwards
           # compatible across reviewer Python releases; the freshest DB is
           # the right choice. If the DB schema ever changes incompatibly,
-          # bump REVIEWER_REF in the consuming workflow and the new code
-          # will refuse to load an older-format DB at the fail-closed gate.
+          # bump REVIEWER_REF in the consuming workflow — the newer
+          # reviewer code will error at DB-load time inside `Pass 1 —
+          # deterministic checks`. The workflow's own fail-closed gate is
+          # a presence check (`[ -s diff-md.patch ] && [ ! -d
+          # .reference-db/extracted ]`); it does not inspect DB schema.
           latest: true
           fileName: reference-db-${{ steps.branch.outputs.vyos1x }}.tar.gz
           out-file-path: .reference-db

--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -333,9 +333,9 @@ jobs:
           # the right choice. If the DB schema ever changes incompatibly,
           # bump REVIEWER_REF in the consuming workflow — the newer
           # reviewer code will error at DB-load time inside `Pass 1 —
-          # deterministic checks`. The workflow's own fail-closed gate is
-          # a presence check (`[ -s diff-md.patch ] && [ ! -d
-          # .reference-db/extracted ]`); it does not inspect DB schema.
+          # deterministic checks`. The workflow's own fail-closed gate
+          # is a presence check on `.reference-db/extracted`; it does
+          # not load or inspect DB schema.
           latest: true
           fileName: reference-db-${{ steps.branch.outputs.vyos1x }}.tar.gz
           out-file-path: .reference-db


### PR DESCRIPTION
Two small follow-ups now that the DB-pin revert wave ([#1971](https://github.com/vyos/vyos-documentation/pull/1971) / [#1972](https://github.com/vyos/vyos-documentation/pull/1972) / [#1973](https://github.com/vyos/vyos-documentation/pull/1973) + canonical [VyOS-Networks/vyos-docs-opus-reviewer#15](https://github.com/VyOS-Networks/vyos-docs-opus-reviewer/pull/15)) has settled and `reviewer-v1.0.2` is tagged.

## 1. Comment alignment

The fail-closed-gate rationale comment that landed in [#1971](https://github.com/vyos/vyos-documentation/pull/1971) said the new reviewer code would *"refuse to load an older-format DB at the fail-closed gate"*. A Copilot finding on [#1973](https://github.com/vyos/vyos-documentation/pull/1973) pointed out this is imprecise — the workflow's fail-closed gate is a presence check (`[ ! -d .reference-db/extracted ]`) that doesn't load or inspect the DB. The actual schema-mismatch protection lives inside the pinned reviewer Python code at `Pass 1 — deterministic checks` (loaded via `uv pip install ./reviewer-src` from `env.REVIEWER_REF`). The fix landed on sagitta in [#1973](https://github.com/vyos/vyos-documentation/pull/1973) (`b09ea673`). This PR ports the same wording so the workflow file is byte-identical across rolling/circinus/sagitta again.

## 2. REVIEWER_REF bump v1.0.1 → v1.0.2

The canonical at `VyOS-Networks/vyos-docs-opus-reviewer/scripts/ai-validation.yml` already defaults to v1.0.2 (since [#15](https://github.com/VyOS-Networks/vyos-docs-opus-reviewer/pull/15) merged and `reviewer-v1.0.2` was pushed). `reviewer-v1.0.2` is functionally identical to `reviewer-v1.0.1` — the Python package and `branches.json` are unchanged; the bump aligns this deployed copy with the canonical default for hygiene. No behavioral change.

## Companion PRs

| Branch | PR |
|--------|----|
| rolling | **this PR** |
| circinus | (companion will be linked) |
| sagitta | (companion — bump-only since the comment fix already landed on sagitta) |

🤖 Generated by [robots](https://vyos.io)