### PR TITLE
ci(ai-validation, sagitta): bump REVIEWER_REF to v1.0.2

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REVIEWER_REF: reviewer-v1.0.1
+  REVIEWER_REF: reviewer-v1.0.2
   # Force JavaScript actions to run on Node 24. Some pinned action SHAs
   # we rely on still ship with Node 20 ABI; this env var opts the whole
   # workflow into Node 24 without per-action version churn.

--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -333,9 +333,9 @@ jobs:
           # the right choice. If the DB schema ever changes incompatibly,
           # bump REVIEWER_REF in the consuming workflow — the newer
           # reviewer code will error at DB-load time inside `Pass 1 —
-          # deterministic checks`. The workflow's own fail-closed gate is
-          # a presence check (`[ -s diff-md.patch ] && [ ! -d
-          # .reference-db/extracted ]`); it does not inspect DB schema.
+          # deterministic checks`. The workflow's own fail-closed gate
+          # is a presence check on `.reference-db/extracted`; it does
+          # not load or inspect DB schema.
           latest: true
           fileName: reference-db-${{ steps.branch.outputs.vyos1x }}.tar.gz
           out-file-path: .reference-db


### PR DESCRIPTION
Single-line follow-up. The canonical at `VyOS-Networks/vyos-docs-opus-reviewer/scripts/ai-validation.yml` already defaults to `reviewer-v1.0.2` (since [#15](https://github.com/VyOS-Networks/vyos-docs-opus-reviewer/pull/15) merged and the tag was pushed). v1.0.2 is functionally identical to v1.0.1 — Python package and `branches.json` unchanged; this is hygiene only. The fail-closed-gate comment fix already landed on this branch via [#1973](https://github.com/vyos/vyos-documentation/pull/1973), so this PR is the bump alone.

🤖 Generated by [robots](https://vyos.io)