### PR TITLE
ci(ai-validation): pathspec :(glob) magic — top-level docs/*.md were silently bypassed

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -78,8 +78,8 @@ jobs:
           # blobs for files that no longer exist in the merge ref.
           # Deletions still appear in diff-md.patch (full diff) but not
           # in changed-md.txt (which drives the bundling step).
-          git diff "$BASE...HEAD" --name-only --diff-filter=ACMRT -z -- 'docs/**/*.md'  > changed-md.z
-          git diff "$BASE...HEAD" --name-only --diff-filter=ACMRT -z -- 'docs/**/*.rst' > changed-rst.z
+          git diff "$BASE...HEAD" --name-only --diff-filter=ACMRT -z -- ':(glob)docs/**/*.md'  > changed-md.z
+          git diff "$BASE...HEAD" --name-only --diff-filter=ACMRT -z -- ':(glob)docs/**/*.rst' > changed-rst.z
           # Reject paths containing line-disrupting control bytes (LF, CR,
           # other 0x01-0x1F + 0x7F) before generating the newline-delimited
           # *.txt manifests. NUL itself can't appear in a git pathname
@@ -106,7 +106,7 @@ jobs:
           done
           tr '\0' '\n' < changed-md.z  > changed-md.txt
           tr '\0' '\n' < changed-rst.z > changed-rst.txt
-          git diff "$BASE...HEAD" -- 'docs/**/*.md' > diff-md.patch
+          git diff "$BASE...HEAD" -- ':(glob)docs/**/*.md' > diff-md.patch
           # Bundle .md files via git's blob store (NOT the filesystem).
           # The fork's merge ref can contain symlinks (mode 120000) committed
           # to docs/**/*.md that resolve to absolute paths on the runner.


### PR DESCRIPTION
**CRITICAL BUG** discovered during smoke verify of [#1977](https://github.com/vyos/vyos-documentation/pull/1977) (draft PR touching `docs/quick-start.md`). The prepare job ran SUCCESS but validate SKIPPED because `has_md_changes` was false:

```bash
$ git diff origin/rolling...HEAD --name-only -- "docs/**/*.md"
(empty)

$ git diff origin/rolling...HEAD --name-only -- ":(glob)docs/**/*.md"
docs/quick-start.md
```

## Root cause

Git's default pathspec uses fnmatch with FNM_PATHNAME (slashes are not crossed by `*`). The `**` glob is **not** recognized in default pathspec — it's treated as two consecutive `*` chars. For `docs/**/*.md` this means git requires at least one `/` between `docs/` and `*.md`, so:

| Path | Default `docs/**/*.md` | `:(glob)docs/**/*.md` |
|------|------------------------|-----------------------|
| `docs/configuration/service/foo.md` | ✅ matches (1+ subdir) | ✅ matches |
| `docs/quick-start.md` | ❌ no match (0 subdirs) | ✅ matches |
| `docs/cli.md` | ❌ no match | ✅ matches |
| `docs/404.md` | ❌ no match | ✅ matches |

7 top-level files silently bypass validation on every PR that touches them: `404.md`, `cli.md`, `copyright.md`, `coverage.md`, `documentation.md`, `index.md`, `quick-start.md`.

## Fix

Add `:(glob)` magic prefix to the three pathspec usages in the prepare job to opt in to true gitignore-style `**` semantics. Three usages updated:

- Line 81: `changed-md.z` diff
- Line 82: `changed-rst.z` diff
- Line 109: `diff-md.patch` diff

Comment-only references to `docs/**/*.md` are left unchanged (read as informal shorthand).

## Companion PRs (byte-identity across rolling/circinus/sagitta + canonical)

| Branch | PR |
|--------|----|
| rolling | **this PR** |
| circinus | (companion) |
| sagitta | (companion) |
| canonical (`VyOS-Networks/vyos-docs-opus-reviewer/main`) | (companion) |

🤖 Generated by [robots](https://vyos.io)