### PR TITLE
ci(ai-validation): restore id-token: write (claude-code-action@v1 uses OIDC)

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -204,6 +204,17 @@ jobs:
       # permissions split issue and PR scopes.
       pull-requests: write
       issues: write
+      # id-token: write is required by anthropics/claude-code-action@v1.
+      # The action calls actions/core's getIDToken() internally to mint
+      # an OIDC token used for the Claude/Anthropic auth federation
+      # path; without this scope it fails with
+      #   `Could not fetch an OIDC token. Did you remember to add
+      #    id-token: write to your workflow permissions?`
+      # An earlier Copilot finding suggested dropping this permission as
+      # "unused" — that was wrong: no shell step in this workflow
+      # invokes OIDC directly, but the third-party action does. Verified
+      # by run 25658256103 on PR #1977.
+      id-token: write
     steps:
       # Pass secrets via env: rather than inlining ${{ secrets.X }} into the
       # shell script. GitHub Actions template-expands ${{ ... }} BEFORE bash


### PR DESCRIPTION
**Critical fix:** restore `id-token: write` on the validate job. Discovered via smoke verify on [#1977](https://github.com/vyos/vyos-documentation/pull/1977) (empty-commit retrigger run [25658256103](https://github.com/vyos/vyos-documentation/actions/runs/25658256103)):

```
Action failed with error: Could not fetch an OIDC token.
Did you remember to add `id-token: write` to your workflow permissions?
```

## What went wrong

[#1969](https://github.com/vyos/vyos-documentation/pull/1969) dropped `id-token: write` from validate's permissions, following a Copilot finding that said the workflow has "no step that uses OIDC". That's technically true for the *shell steps* — but **`anthropics/claude-code-action@v1` itself calls `actions/core`'s `getIDToken()` internally**, likely for the Claude/Anthropic auth federation flow. The required permission is the third-party action's, not the workflow body's.

The bug went undetected for 4 days because every PR merged in the post-#1969 wave was infrastructure-only (`has_md_changes=false`), so validate was always SKIPPED at the job level. The first real `.md`-changing PR (#1977 after the pathspec fix exposed it) immediately hit the OIDC error.

## Fix

Restore `id-token: write` with an explicit inline comment block citing the specific failure mode + the run ID, so it can't be re-dropped on a future review pass.

## Companion PRs

| Branch | PR |
|--------|----|
| rolling | **this PR** |
| circinus | (companion) |
| sagitta | (companion) |
| canonical (`VyOS-Networks/vyos-docs-opus-reviewer`) | folded into [#17](https://github.com/VyOS-Networks/vyos-docs-opus-reviewer/pull/17) (still open) |

🤖 Generated by [robots](https://vyos.io)