### PR TITLE
ci(ai-validation, circinus): restore id-token: write (claude-code-action uses OIDC)

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -204,6 +204,17 @@ jobs:
       # permissions split issue and PR scopes.
       pull-requests: write
       issues: write
+      # id-token: write is required by anthropics/claude-code-action@v1.
+      # The action calls actions/core's getIDToken() internally to mint
+      # an OIDC token used for the Claude/Anthropic auth federation
+      # path; without this scope it fails with
+      #   `Could not fetch an OIDC token. Did you remember to add
+      #    id-token: write to your workflow permissions?`
+      # An earlier Copilot finding suggested dropping this permission as
+      # "unused" — that was wrong: no shell step in this workflow
+      # invokes OIDC directly, but the third-party action does. Verified
+      # by run 25658256103 on PR #1977.
+      id-token: write
     steps:
       # Pass secrets via env: rather than inlining ${{ secrets.X }} into the
       # shell script. GitHub Actions template-expands ${{ ... }} BEFORE bash


### PR DESCRIPTION
Backport of the rolling-side fix (PR #1981).

`anthropics/claude-code-action@v1` calls `getIDToken()` internally and needs `id-token: write` in the job's permissions. Without it Pass 2 fails with `Could not fetch an OIDC token`. Verified by [run 25658256103 on PR #1977](https://github.com/vyos/vyos-documentation/actions/runs/25658256103).

🤖 Generated by [robots](https://vyos.io)
