### PR TITLE
ci(context7): gate version-tag move + refresh on docs-only changes

### DIFF
--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -17,6 +17,11 @@ name: Context7 refresh
 # BACKWARD and trigger this workflow to refresh Context7 against stale
 # content. To force a Context7 refresh, use the workflow_dispatch input
 # below — it calls Context7 directly without touching any tag.
+#
+# Docs-only gating is enforced upstream: `Update version tags` has a
+# `paths:` filter scoped to `docs/**` and `context7.json`, so infra-only
+# pushes (workflows, scripts, README, etc.) never fire that workflow and
+# this one never sees a workflow_run event for them.
 
 on:
   workflow_run:

--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -2,6 +2,15 @@ name: Update version tags
 
 # context7-refresh.yml triggers via workflow_run on this workflow's name.
 # DO NOT rename the `name:` field above without updating context7-refresh.yml.
+#
+# The `paths` filter gates BOTH this tag-move AND the downstream Context7
+# refresh: Context7 only ingests `docs/**` (per context7.json `folders`), so
+# infra-only pushes (workflows, scripts, Docker, CODEOWNERS, README, etc.)
+# don't need a version-tag move and don't need a Context7 refresh. The tag's
+# only consumer is Context7, so skipping the move on infra-only pushes is
+# semantically correct — the tag still represents the latest docs state.
+# `context7.json` is included because changes to its `rules`, `folders`, or
+# `excludeFolders` affect what Context7 returns even when no .md files moved.
 
 on:
   push:
@@ -9,6 +18,9 @@ on:
       - rolling
       - circinus
       - sagitta
+    paths:
+      - 'docs/**'
+      - 'context7.json'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Change Summary

Add a `paths:` filter to the `Update version tags` push trigger so infra-only pushes (workflows, scripts, Docker, README, etc.) skip the tag move and therefore skip the downstream Context7 refresh.

**Why:** Context7 only ingests `docs/**` (per `context7.json` `folders`), so refreshing on infra commits wasted API calls and gave no benefit. The version tag's only consumer is Context7, so skipping the move on infra-only pushes is semantically correct — the tag still represents the latest docs state.

**What changes:**
- `.github/workflows/update-version-tags.yml` — push trigger now only fires when `docs/**` or `context7.json` change.
- `.github/workflows/context7-refresh.yml` — documentation-only note added that gating happens upstream.

**Out-of-band:** `workflow_dispatch` on `context7-refresh.yml` remains available to force a refresh manually for any variant.

## Related Task(s)
N/A

## Related PR(s)
Follows up the Context7 GitHub Actions integration trio (#1948 / #1949 / #1950) and follow-ups (#1951 / #1961 / #1962).

## Backport

@Mergifyio backport circinus sagitta

## Checklist:
- [x] I have read the **CONTRIBUTING** document

🤖 Generated by [robots](https://vyos.io)