### PR TITLE
ci(ai-validation): pass github_token to claude-code-action (skip OIDC exchange)

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -431,6 +431,25 @@ jobs:
         uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Pass the workflow's default GITHUB_TOKEN explicitly. Without
+          # this the action mints an OIDC token (audience
+          # `claude-code-github-action`) and exchanges it at
+          # api.anthropic.com/api/github/github-app-token-exchange for
+          # an Anthropic-managed App token — which fails with "Invalid
+          # OIDC token" on repos where Anthropic-side federation isn't
+          # configured. Providing github_token bypasses the exchange
+          # entirely (the action checks process.env.OVERRIDE_GITHUB_TOKEN
+          # first; see anthropics/claude-code-action src/github/token.ts
+          # setupGitHubToken()). github.token here is auto-scoped to the
+          # current PR repo with the validate job's permissions block
+          # (pull-requests: write + issues: write + contents: read),
+          # which is exactly what the action needs to post inline review
+          # comments and a summary comment. steps.app.outputs.token is
+          # NOT suitable here: that token is scoped to the VyOS-Networks
+          # org repos (vyos-1x, vyos-docs-opus-reviewer) for the reviewer-
+          # source / vyos-1x checkouts above, and has no write access
+          # on vyos/vyos-documentation PRs.
+          github_token: ${{ github.token }}
           # claude-code-action@v1 removed the top-level `model` input; CLI
           # flags including --model now travel via `claude_args` (see the
           # claude_args: block at the bottom of this step).


### PR DESCRIPTION
Third (hopefully final) bug surfaced by the smoke verify on [#1977](https://github.com/vyos/vyos-documentation/pull/1977). Second retrigger run [25658927427](https://github.com/vyos/vyos-documentation/actions/runs/25658927427) reached Pass 2 but failed with:

```
Action failed with error: Invalid OIDC token
```

## Root cause

`anthropics/claude-code-action@v1` mints an OIDC token with audience `claude-code-github-action` and POSTs it to `api.anthropic.com/api/github/github-app-token-exchange` to get an Anthropic-managed GitHub App token for posting comments. The endpoint validated our OIDC token and rejected it — Anthropic-side OIDC federation isn't provisioned for the `vyos` org.

## Fix

Provide `github_token: ${{ github.token }}` to the action. `setupGitHubToken()` in [src/github/token.ts](https://github.com/anthropics/claude-code-action/blob/v1.0.119/src/github/token.ts) checks `process.env.OVERRIDE_GITHUB_TOKEN` first and uses it directly when set, skipping the OIDC exchange entirely.

`github.token` is auto-scoped to the current PR repo with the validate job's `permissions:` block (`pull-requests: write` + `issues: write` + `contents: read`) — exactly what the action needs to post inline review comments and a summary comment.

`steps.app.outputs.token` (our existing App token) is NOT suitable: it's scoped to the `VyOS-Networks` org (`vyos-1x`, `vyos-docs-opus-reviewer`) for the earlier reviewer-source / vyos-1x checkouts, and has no write access on `vyos/vyos-documentation` PRs.

## Side effect

PR comments will now post as `github-actions[bot]` (the workflow's own bot identity) rather than as `claude[bot]` (the Anthropic-managed App). Acceptable / arguably preferable — the inline-review identity becomes visibly the VyOS workflow rather than an external bot.

## Companion PRs

| Branch | PR |
|--------|----|
| rolling | **this PR** |
| circinus | (companion) |
| sagitta | (companion) |
| canonical | folded into still-open [VyOS-Networks/vyos-docs-opus-reviewer#17](https://github.com/VyOS-Networks/vyos-docs-opus-reviewer/pull/17) |

🤖 Generated by [robots](https://vyos.io)
