### PR TITLE
ci(ai-validation, rolling): merge-ref checkout in validate + retarget origin to fork (claude-code-action git workspace)

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -216,6 +216,34 @@ jobs:
       # by run 25658256103 on PR #1977.
       id-token: write
     steps:
+      # Check out the PR's merge ref into the workspace root. Required by
+      # anthropics/claude-code-action@v1: the action runs
+      # `git fetch origin <head-ref>` and reads files like
+      # `docs/<changed>.md` directly from the working dir during its
+      # setup. Without this checkout it fails with `fatal: not a git
+      # repository` + `could not open <file>`.
+      #
+      # Trust boundary preserved:
+      #   - persist-credentials: false → no token in fork-content
+      #     .git/config (so fork-controlled file contents that the
+      #     LLM tool calls might read can't exfiltrate a token)
+      #   - No shell step in validate executes fork code (no
+      #     `pip install` / `npm install` / `make` against the
+      #     workspace; Pass 1 runs the trusted reviewer CLI from
+      #     reviewer-src/; Pass 2's allowlisted tools are Read /
+      #     Glob / Grep / mcp__github_inline_comment + Bash
+      #     restricted to `gh pr comment|diff|view`).
+      #   - Subsequent steps create their own subdirs (_changed_md/
+      #     via artifact download, .vyos-1x/, reviewer-src/, reviewer/,
+      #     .reference-db/) which coexist with the docs/scripts/.github
+      #     content checked out here.
+      - name: Checkout PR merge ref into workspace (NO credentials)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/pull/${{ github.event.number }}/merge
+          persist-credentials: false
+          fetch-depth: 2
+
       # Pass secrets via env: rather than inlining ${{ secrets.X }} into the
       # shell script. GitHub Actions template-expands ${{ ... }} BEFORE bash
       # parses the script, so a secret containing a single quote, backtick,

--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -295,21 +295,25 @@ jobs:
           persist-credentials: false
           fetch-depth: 2
 
-      # Defense-in-depth: actions/checkout above brings the PR'"'"'s tree
+      # Defense-in-depth: actions/checkout above brings the PR's tree
       # into the workspace root, which means a malicious fork could
       # pre-create files/dirs at the same paths that workflow-producer
       # steps below populate (artifact download, vyos-1x checkout,
-      # reference-DB extract, reviewer install, Pass 1 output). Wiping
-      # the reserved paths guarantees subsequent producer steps start
-      # from a clean slate and the fail-closed gate that checks for
-      # `.reference-db/extracted` reflects workflow state, not PR
-      # content.
+      # reference-DB extract, reviewer install, Pass 1 output, the
+      # uv-managed .venv/). Wiping the reserved paths guarantees the
+      # subsequent producer steps start from a clean slate and that
+      # PATH (which setup-uv prepends with ${{ github.workspace }}/
+      # .venv/bin) is not poisoned by fork-controlled binaries.
+      # Uses `rm -rf` uniformly so that a fork-controlled DIRECTORY
+      # at a path normally holding a regular file (e.g. a malicious
+      # `pass1-findings.json/` directory) is also removed — `rm -f`
+      # silently no-ops on directories.
       - name: Wipe reserved workspace paths (defense-in-depth vs fork-controlled placeholders)
         if: steps.secrets-check.outputs.skip != 'true'
         run: |
           set -euo pipefail
-          rm -rf _changed_md .reference-db .vyos-1x reviewer reviewer-src
-          rm -f changed-md.txt changed-rst.txt diff-md.patch pass1-findings.json
+          rm -rf _changed_md .reference-db .vyos-1x reviewer reviewer-src .venv \
+                 changed-md.txt changed-rst.txt diff-md.patch pass1-findings.json
 
       - name: Download PR input
         if: steps.secrets-check.outputs.skip != 'true'

--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -57,6 +57,14 @@ jobs:
       # validate's working-directory: _changed_md would otherwise fail
       # before any in-step short-circuit can run.
       has_md_changes: ${{ steps.changes.outputs.has_md_changes }}
+      # The exact SHA of the merge commit that prepare bundled. validate
+      # below checks out THIS sha (rather than re-resolving
+      # `refs/pull/<n>/merge`, which GitHub may update between prepare
+      # and validate on rapid pushes — concurrency.cancel-in-progress
+      # narrows the window but does not make the ref immutable). Pass 1
+      # (artifact) and Pass 2 (validate workspace) now operate on the
+      # same revision.
+      merge_sha: ${{ steps.changes.outputs.merge_sha }}
     steps:
       - name: Checkout PR merge ref (NO credentials)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -174,6 +182,11 @@ jobs:
             echo "has_md_changes=false" >> "$GITHUB_OUTPUT"
           fi
 
+          # Pin the merge SHA that prepare bundled, so validate below can
+          # check out the exact same revision and avoid drift if GitHub
+          # advances refs/pull/<n>/merge between jobs.
+          echo "merge_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Upload PR input artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -273,25 +286,28 @@ jobs:
         if: steps.secrets-check.outputs.skip != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: refs/pull/${{ github.event.number }}/merge
+          # Pin to the exact merge SHA prepare bundled so validate's
+          # workspace tree matches Pass 1's artifact even on a PR that
+          # has had additional pushes between prepare and validate.
+          ref: ${{ needs.prepare.outputs.merge_sha }}
           persist-credentials: false
           fetch-depth: 2
 
       # claude-code-action subsequently runs `git fetch origin <head-ref>`
       # internally during its setup. `<head-ref>` is the branch name in
-      # the PR'"'"'s HEAD repo — for fork PRs that branch does NOT exist on
+      # the PR's HEAD repo — for fork PRs that branch does NOT exist on
       # the base repo (which is what `origin` points at after the merge-
       # ref checkout above), so the fetch fails with
       #   fatal: couldn't find remote ref refs/heads/<head-ref>
       #
-      # Re-point origin to the HEAD repo'"'"'s URL so the action'"'"'s fetch
+      # Re-point origin to the HEAD repo's URL so the action's fetch
       # resolves. The workspace tree is unchanged — it remains the merge
       # tree from above. For public forks (the only kind that target
       # vyos/vyos-documentation, since the repo is public) the
       # unauthenticated fetch from the fork succeeds without any credential
       # (persist-credentials:false stripped the extraheader at the end of
       # the previous step).
-      - name: Re-point origin to fork URL for claude-code-action'"'"'s git fetch
+      - name: Re-point origin to fork URL for claude-code-action's git fetch
         if: steps.secrets-check.outputs.skip != 'true'
         env:
           FORK: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -216,34 +216,6 @@ jobs:
       # by run 25658256103 on PR #1977.
       id-token: write
     steps:
-      # Check out the PR's merge ref into the workspace root. Required by
-      # anthropics/claude-code-action@v1: the action runs
-      # `git fetch origin <head-ref>` and reads files like
-      # `docs/<changed>.md` directly from the working dir during its
-      # setup. Without this checkout it fails with `fatal: not a git
-      # repository` + `could not open <file>`.
-      #
-      # Trust boundary preserved:
-      #   - persist-credentials: false → no token in fork-content
-      #     .git/config (so fork-controlled file contents that the
-      #     LLM tool calls might read can't exfiltrate a token)
-      #   - No shell step in validate executes fork code (no
-      #     `pip install` / `npm install` / `make` against the
-      #     workspace; Pass 1 runs the trusted reviewer CLI from
-      #     reviewer-src/; Pass 2's allowlisted tools are Read /
-      #     Glob / Grep / mcp__github_inline_comment + Bash
-      #     restricted to `gh pr comment|diff|view`).
-      #   - Subsequent steps create their own subdirs (_changed_md/
-      #     via artifact download, .vyos-1x/, reviewer-src/, reviewer/,
-      #     .reference-db/) which coexist with the docs/scripts/.github
-      #     content checked out here.
-      - name: Checkout PR merge ref into workspace (NO credentials)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: refs/pull/${{ github.event.number }}/merge
-          persist-credentials: false
-          fetch-depth: 2
-
       # Pass secrets via env: rather than inlining ${{ secrets.X }} into the
       # shell script. GitHub Actions template-expands ${{ ... }} BEFORE bash
       # parses the script, so a secret containing a single quote, backtick,
@@ -283,6 +255,61 @@ jobs:
           gh pr comment "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
             --body "AI Validation skipped — required secrets are not configured on this repo (\`ANTHROPIC_API_KEY\`, \`VYOS_APP_ID\`, \`VYOS_APP_PRIVATE_KEY\`). Maintainers: see the workflow run for details."
+
+      # Check out the PR HEAD into the workspace root. Required by
+      # anthropics/claude-code-action@v1: it runs
+      # `git fetch origin <head-ref>` and reads files like
+      # `docs/<changed>.md` directly from the working dir during its
+      # setup. We check out the PR HEAD repo (which is the fork for
+      # fork PRs) so that the head-ref name resolves locally: doing a
+      # merge-ref checkout from `vyos/vyos-documentation` would leave
+      # origin pointed at the base repo, where `<head-ref>` (e.g.
+      # `contributor/branch`) does not exist and the action's fetch
+      # fails.
+      #
+      # The token is still used to download the tree (this is not an
+      # unauthenticated fetch); `persist-credentials: false` prevents
+      # it from being written into the resulting .git/config — so any
+      # fork-controlled file content that the Pass 2 LLM tools may
+      # read cannot exfiltrate the token.
+      #
+      # Trust boundary preserved:
+      #   - persist-credentials: false (no token in .git/config)
+      #   - No shell step in validate executes fork code (no
+      #     `pip install` / `npm install` / `make` against the
+      #     workspace; Pass 1 runs the trusted reviewer CLI from
+      #     reviewer-src/; Pass 2's allowlisted tools are Read /
+      #     Glob / Grep / mcp__github_inline_comment + Bash
+      #     restricted to `gh pr comment|diff|view`).
+      #   - The "Wipe reserved workspace paths" step below strips any
+      #     fork-controlled placeholders at workflow-reserved paths
+      #     (.reference-db, .vyos-1x, reviewer, reviewer-src,
+      #     _changed_md, pass1-findings.json, diff-md.patch, changed-*
+      #     .txt) before the trusted producer steps re-create them.
+      - name: Checkout PR HEAD (no persisted credentials)
+        if: steps.secrets-check.outputs.skip != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          fetch-depth: 2
+
+      # Defense-in-depth: actions/checkout above brings the PR'"'"'s tree
+      # into the workspace root, which means a malicious fork could
+      # pre-create files/dirs at the same paths that workflow-producer
+      # steps below populate (artifact download, vyos-1x checkout,
+      # reference-DB extract, reviewer install, Pass 1 output). Wiping
+      # the reserved paths guarantees subsequent producer steps start
+      # from a clean slate and the fail-closed gate that checks for
+      # `.reference-db/extracted` reflects workflow state, not PR
+      # content.
+      - name: Wipe reserved workspace paths (defense-in-depth vs fork-controlled placeholders)
+        if: steps.secrets-check.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          rm -rf _changed_md .reference-db .vyos-1x reviewer reviewer-src
+          rm -f changed-md.txt changed-rst.txt diff-md.patch pass1-findings.json
 
       - name: Download PR input
         if: steps.secrets-check.outputs.skip != 'true'

--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -256,63 +256,76 @@ jobs:
             --repo "${{ github.repository }}" \
             --body "AI Validation skipped — required secrets are not configured on this repo (\`ANTHROPIC_API_KEY\`, \`VYOS_APP_ID\`, \`VYOS_APP_PRIVATE_KEY\`). Maintainers: see the workflow run for details."
 
-      # Check out the PR HEAD into the workspace root. Required by
-      # anthropics/claude-code-action@v1: it runs
-      # `git fetch origin <head-ref>` and reads files like
-      # `docs/<changed>.md` directly from the working dir during its
-      # setup. We check out the PR HEAD repo (which is the fork for
-      # fork PRs) so that the head-ref name resolves locally: doing a
-      # merge-ref checkout from `vyos/vyos-documentation` would leave
-      # origin pointed at the base repo, where `<head-ref>` (e.g.
-      # `contributor/branch`) does not exist and the action's fetch
-      # fails.
+      # Check out the PR's MERGE REF into the workspace root. Required by
+      # anthropics/claude-code-action@v1: it runs `git fetch origin
+      # <head-ref>` and reads files from the working dir during setup.
+      # The merge ref is GitHub's auto-computed merge of base + head; the
+      # working tree matches the bundled diff-md.patch + _changed_md/
+      # produced by `prepare`, so Pass 1 (which reads the bundle) and
+      # Pass 2 (which can also Read/Glob/Grep the workspace) operate on
+      # the same tree.
       #
-      # The token is still used to download the tree (this is not an
-      # unauthenticated fetch); `persist-credentials: false` prevents
-      # it from being written into the resulting .git/config — so any
-      # fork-controlled file content that the Pass 2 LLM tools may
-      # read cannot exfiltrate the token.
-      #
-      # Trust boundary preserved:
-      #   - persist-credentials: false (no token in .git/config)
-      #   - No shell step in validate executes fork code (no
-      #     `pip install` / `npm install` / `make` against the
-      #     workspace; Pass 1 runs the trusted reviewer CLI from
-      #     reviewer-src/; Pass 2's allowlisted tools are Read /
-      #     Glob / Grep / mcp__github_inline_comment + Bash
-      #     restricted to `gh pr comment|diff|view`).
-      #   - The "Wipe reserved workspace paths" step below strips any
-      #     fork-controlled placeholders at workflow-reserved paths
-      #     (.reference-db, .vyos-1x, reviewer, reviewer-src,
-      #     _changed_md, pass1-findings.json, diff-md.patch, changed-*
-      #     .txt) before the trusted producer steps re-create them.
-      - name: Checkout PR HEAD (no persisted credentials)
+      # The token is used to download the tree (not an unauthenticated
+      # fetch); persist-credentials:false suppresses writing it into the
+      # resulting .git/config so fork-controlled file content the Pass 2
+      # LLM may read cannot exfiltrate it.
+      - name: Checkout PR merge ref (no persisted credentials)
         if: steps.secrets-check.outputs.skip != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.number }}/merge
           persist-credentials: false
           fetch-depth: 2
 
-      # Defense-in-depth: actions/checkout above brings the PR's tree
-      # into the workspace root, which means a malicious fork could
-      # pre-create files/dirs at the same paths that workflow-producer
+      # claude-code-action subsequently runs `git fetch origin <head-ref>`
+      # internally during its setup. `<head-ref>` is the branch name in
+      # the PR'"'"'s HEAD repo — for fork PRs that branch does NOT exist on
+      # the base repo (which is what `origin` points at after the merge-
+      # ref checkout above), so the fetch fails with
+      #   fatal: couldn't find remote ref refs/heads/<head-ref>
+      #
+      # Re-point origin to the HEAD repo'"'"'s URL so the action'"'"'s fetch
+      # resolves. The workspace tree is unchanged — it remains the merge
+      # tree from above. For public forks (the only kind that target
+      # vyos/vyos-documentation, since the repo is public) the
+      # unauthenticated fetch from the fork succeeds without any credential
+      # (persist-credentials:false stripped the extraheader at the end of
+      # the previous step).
+      - name: Re-point origin to fork URL for claude-code-action'"'"'s git fetch
+        if: steps.secrets-check.outputs.skip != 'true'
+        env:
+          FORK: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+          git remote set-url origin "https://github.com/$FORK"
+
+      # Defense-in-depth: actions/checkout above brings the PR's merge
+      # tree into the workspace root, which means a malicious fork could
+      # pre-create files/dirs at workflow-reserved paths that producer
       # steps below populate (artifact download, vyos-1x checkout,
       # reference-DB extract, reviewer install, Pass 1 output, the
-      # uv-managed .venv/). Wiping the reserved paths guarantees the
-      # subsequent producer steps start from a clean slate and that
-      # PATH (which setup-uv prepends with ${{ github.workspace }}/
-      # .venv/bin) is not poisoned by fork-controlled binaries.
-      # Uses `rm -rf` uniformly so that a fork-controlled DIRECTORY
-      # at a path normally holding a regular file (e.g. a malicious
-      # `pass1-findings.json/` directory) is also removed — `rm -f`
-      # silently no-ops on directories.
+      # uv-managed .venv/, plus CLAUDE.md / .claude/ which the Claude
+      # Code CLI auto-loads as session instructions on startup —
+      # documented at code.claude.com/docs/en/claude-directory.md and
+      # code.claude.com/docs/en/memory).
+      #
+      # Wiping the reserved paths guarantees:
+      #   * subsequent producer steps start from a clean slate
+      #   * PATH (which setup-uv prepends with ${{ github.workspace }}/
+      #     .venv/bin) is not poisoned by fork-controlled binaries
+      #   * Claude Code's auto-discovery of CLAUDE.md / .claude/ does
+      #     not pull fork-controlled prompt-injection instructions into
+      #     the Pass 2 session
+      #
+      # Uses `rm -rf` uniformly so a fork-controlled DIRECTORY at a path
+      # normally holding a regular file (e.g. `pass1-findings.json/`) is
+      # also removed — `rm -f` silently no-ops on directories.
       - name: Wipe reserved workspace paths (defense-in-depth vs fork-controlled placeholders)
         if: steps.secrets-check.outputs.skip != 'true'
         run: |
           set -euo pipefail
           rm -rf _changed_md .reference-db .vyos-1x reviewer reviewer-src .venv \
+                 CLAUDE.md .claude \
                  changed-md.txt changed-rst.txt diff-md.patch pass1-findings.json
 
       - name: Download PR input


### PR DESCRIPTION
Workflow needs to provide a git workspace to `anthropics/claude-code-action@v1` (it runs `git fetch origin <head-ref>` and reads files from the working dir during setup). Original draft of this PR went through several iterations as CR/Copilot surfaced consistency and security concerns. **Current implementation**:

## Steps added to `validate`

1. **Checkout PR merge ref (no persisted credentials)** — `ref: ${{ needs.prepare.outputs.merge_sha }}` (the exact SHA prepare bundled, NOT `refs/pull/<n>/merge` which can advance between jobs). Workspace tree matches Pass 1's `diff-md.patch` + `_changed_md/` artifact bit-for-bit.

2. **Re-point origin to fork URL** — `git remote set-url origin "https://github.com/$FORK"` so the action's subsequent `git fetch origin <head-ref>` resolves against the fork (the head-ref name only exists in the fork, not the base repo). Workspace tree unchanged; only the fetch destination is updated. Unauthenticated fetch from public forks succeeds.

3. **Wipe reserved workspace paths** — `rm -rf` of all paths workflow producer-steps populate (`.reference-db`, `.vyos-1x`, `reviewer`, `reviewer-src`, `_changed_md`, `.venv`, `CLAUDE.md`, `.claude`, `changed-md.txt`, `changed-rst.txt`, `diff-md.patch`, `pass1-findings.json`). Strips fork-controlled placeholders so producer steps start from a clean slate. Also removes `CLAUDE.md` and `.claude/` which the Claude Code CLI auto-loads as session instructions on startup — preventing fork-controlled prompt-injection.

## Prepare-side change

Added a `merge_sha` output to the prepare job (`echo "merge_sha=$(git rev-parse HEAD)"`) so validate above can reference it.

## Trust model preserved

- `persist-credentials: false` on the checkout — token used for download but not written to `.git/config`
- No shell step in validate executes fork code (no `pip install` / `npm install` / `make` against workspace; Pass 1 runs the trusted reviewer CLI from `reviewer-src/`; Pass 2's allowlisted tools are `Read,Glob,Grep,mcp__github_inline_comment + Bash(gh pr comment|diff|view)` — none execute fork content)
- Wipe step closes path-collision and instruction-injection attack vectors

## Companion PRs

| Branch | PR |
|--------|----|
| rolling | **this PR** |
| circinus | [#1991](https://github.com/vyos/vyos-documentation/pull/1991) |
| sagitta | [#1993](https://github.com/vyos/vyos-documentation/pull/1993) (follow-up after #1992 merged early) |
| canonical | follow-up after this wave merges |

🤖 Generated by [robots](https://vyos.io)