### PR TITLE
T8843: Fix recursive _build directory nesting error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -300,6 +300,9 @@ def _copy_md_sources(app, exception):
     src = pathlib.Path(app.srcdir)
     out = pathlib.Path(app.outdir)
     for path in src.rglob("*.md"):
+        # Skip files in excluded directories to prevent recursive nesting
+        if any(part in {'_build', '_rst_legacy'} for part in path.parts):
+            continue
         dest = out / path.relative_to(src)
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(path, dest)


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix recursive `_build` directory nesting in `_copy_md_sources`.

The `_copy_md_sources` function was recursively copying all `.md` files, including those in `/_build` and `/_rst_legacy` directories from previous builds. This caused the build output to be copied back into itself on each build, resulting in deeply nested paths like `_build/_build/_build/...` and eventually a "File name too long" error.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T8843

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document