### PR TITLE
T8843: Fix conflict markers from Mergify backport of #1994 (sagitta)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -243,6 +243,9 @@ def _copy_md_sources(app, exception):
     src = pathlib.Path(app.srcdir)
     out = pathlib.Path(app.outdir)
     for path in src.rglob("*.md"):
+        # Skip files in excluded directories to prevent recursive nesting
+        if any(part in {'_build', '_rst_legacy'} for part in path.parts):
+            continue
         dest = out / path.relative_to(src)
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(path, dest)
@@ -292,24 +295,6 @@ def _write_llms_txt(app, exception):
     out_path.write_text(rendered, encoding='utf-8')
 
 
-<<<<<<< HEAD
-=======
-def _copy_md_sources(app, exception):
-    """Copy .md source files verbatim into the HTML output tree."""
-    if exception is not None:
-        return
-    src = pathlib.Path(app.srcdir)
-    out = pathlib.Path(app.outdir)
-    for path in src.rglob("*.md"):
-        # Skip files in excluded directories to prevent recursive nesting
-        if any(part in {'_build', '_rst_legacy'} for part in path.parts):
-            continue
-        dest = out / path.relative_to(src)
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(path, dest)
-
-
->>>>>>> ec6f33f3 (Fix recursive _build directory nesting error)
 def setup(app):
     app.connect('builder-inited', _prefer_webp)
     app.connect('build-finished', _copy_md_sources)


### PR DESCRIPTION
## Change Summary

Fix-forward for [#1998](https://github.com/vyos/vyos-documentation/pull/1998) — the Mergify auto-backport of [#1994](https://github.com/vyos/vyos-documentation/pull/1994) committed literal git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) into `docs/conf.py`. RTD build [32648795](https://app.readthedocs.org/projects/vyos/builds/32648795/) failed:

```
SyntaxError: invalid syntax (conf.py)
```

## Root cause

`_copy_md_sources` sits **before** `_write_llms_txt` on `sagitta`, but **after** it on `rolling`. The cherry-pick patch context didn't match, so git's 3-way merge dropped the entire new function as a duplicate below `_write_llms_txt` with conflict markers — and Mergify committed the result anyway. (Documented failure mode; see also [#1999](https://github.com/vyos/vyos-documentation/pull/1999) for circinus.)

## What this PR does

1. Removes the conflict-marker block (no real conflict — both sides just disagreed about *where* the function should sit).
2. Applies the actual 3-line guard to the existing `_copy_md_sources` at line 239.

`python3 -c 'import ast; ast.parse(open("docs/conf.py").read())'` passes locally.

## Related Task(s)
* https://vyos.dev/T8843

## Related PR(s)
* Rolling: [#1994](https://github.com/vyos/vyos-documentation/pull/1994) (merged, correct)
* Bad backport this fixes: [#1998](https://github.com/vyos/vyos-documentation/pull/1998) (merged, broken)
* Companion circinus fix: [#2000](https://github.com/vyos/vyos-documentation/pull/2000)

## Backport

(N/A — fix-forward only for sagitta)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document

🤖 Generated by [robots](https://vyos.io)