### PR TITLE
ci(ai-validation): stop retargeting origin to fork URL

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -293,27 +293,13 @@ jobs:
           persist-credentials: false
           fetch-depth: 2
 
-      # claude-code-action subsequently runs `git fetch origin <head-ref>`
-      # internally during its setup. `<head-ref>` is the branch name in
-      # the PR's HEAD repo — for fork PRs that branch does NOT exist on
-      # the base repo (which is what `origin` points at after the merge-
-      # ref checkout above), so the fetch fails with
-      #   fatal: couldn't find remote ref refs/heads/<head-ref>
-      #
-      # Re-point origin to the HEAD repo's URL so the action's fetch
-      # resolves. The workspace tree is unchanged — it remains the merge
-      # tree from above. For public forks (the only kind that target
-      # vyos/vyos-documentation, since the repo is public) the
-      # unauthenticated fetch from the fork succeeds without any credential
-      # (persist-credentials:false stripped the extraheader at the end of
-      # the previous step).
-      - name: Re-point origin to fork URL for claude-code-action's git fetch
-        if: steps.secrets-check.outputs.skip != 'true'
-        env:
-          FORK: ${{ github.event.pull_request.head.repo.full_name }}
-        run: |
-          set -euo pipefail
-          git remote set-url origin "https://github.com/$FORK"
+      # Note: claude-code-action runs `git fetch origin pull/<n>/head` for
+      # fork PRs during its setup. Those refs only exist on the base repo,
+      # so `origin` must remain pointed at vyos/vyos-documentation (which
+      # is where actions/checkout above left it). Do NOT retarget origin
+      # to the fork URL — that breaks the fork-PR fetch path with
+      #   fatal: couldn't find remote ref pull/<n>/head
+      # (verified on run 25689321499, PR #1891).
 
       # Defense-in-depth: actions/checkout above brings the PR's merge
       # tree into the workspace root, which means a malicious fork could


### PR DESCRIPTION
## Summary

The previous fix (`7a7a8002`) re-pointed `origin` to the PR's HEAD fork on the assumption that `claude-code-action` calls `git fetch origin <head-branch>`. Wrong for fork PRs.

For fork PRs the action detects the fork and fetches `pull/<n>/head` instead. Those refs only exist on the **base** repo, so retargeting `origin` to the fork breaks the fetch:

```
PR #1891 is from a fork, fetching via refs/pull/1891/head...
fatal: couldn't find remote ref pull/1891/head
##[error]Action failed with error: Command failed: git fetch origin --depth=20 pull/1891/head:T8607
```

Observed on [run 25689321499](https://github.com/vyos/vyos-documentation/actions/runs/25689321499/job/75421281158) (PR [vyos-documentation#1891](https://github.com/vyos/vyos-documentation/pull/1891) from `natali-rs1985/vyos-documentation`).

This PR removes the retarget step. `actions/checkout` already leaves `origin` pointed at `vyos/vyos-documentation`, which is where `pull/<n>/head` resolves.

## Test plan

- [ ] Workflow file passes YAML validation
- [ ] After merge, AI Validation triggers on the next fork-originated PR and reaches Pass 2 without `couldn't find remote ref pull/<n>/head`

🤖 Generated by [robots](https://vyos.io)