### PR TITLE
fix(ext): cmdincludemd parses .txt content as RST to fix broken interface docs

### DIFF
--- a/docs/_ext/vyos.py
+++ b/docs/_ext/vyos.py
@@ -364,18 +364,29 @@ class CmdInclude(SphinxDirective):
                     line = re.sub('{{\s?var' + str(i) + '\s?}}',value,line)
             new_include_lines.append(line)
         
-        if hasattr(self.state, '_renderer'):
-            self.state._renderer.nested_render_text(''.join(new_include_lines), self.lineno)
-            return []
-        from docutils.statemachine import ViewList
-        from docutils import nodes
+        # The _include/*.txt library is written in reStructuredText
+        # (`.. cfgcmd::`, `.. code-block::`, `.. note::`, `.. cmdinclude::`).
+        # When called from a MyST `.md` page, `self.state` is MyST's
+        # MockState whose `nested_parse` just routes back through MyST —
+        # so the RST directives render as literal paragraph text.
+        #
+        # Parse the file as RST directly, mirroring what MyST itself does
+        # for `{eval-rst}` blocks (myst_parser.mocking.MockRSTParser via
+        # render_restructuredtext): build a fresh document that inherits
+        # the parent's settings (so Sphinx env / reporter survive) and
+        # graft its children back into the calling document.
+        from docutils.utils import new_document
+        from myst_parser.mocking import MockRSTParser
+
         content = ''.join(new_include_lines)
-        vl = ViewList()
-        for i, line in enumerate(content.splitlines(keepends=False)):
-            vl.append(line, include_file[1], i)
-        node = nodes.Element()
-        self.state.nested_parse(vl, self.content_offset, node, match_titles=True)
-        return node.children
+        outer_doc = self.state.document
+        newdoc = new_document(include_file[1], outer_doc.settings)
+        newdoc.reporter = outer_doc.reporter
+        MockRSTParser().parse(content, newdoc)
+        for node in newdoc.children:
+            if getattr(node, 'attributes', None) and node.get('names'):
+                outer_doc.note_explicit_target(node, node)
+        return list(newdoc.children)
 
 
 class CfgcmdlistDirective(Directive):


### PR DESCRIPTION
## Change Summary

The `_include/*.txt` library is still written in reStructuredText, but `{cmdincludemd}` was routing its content through MyST's `MockState.nested_parse`, which in myst-parser 2.0 simply replays through the MyST renderer (see [`myst_parser/mocking.py:153-179`](https://github.com/executablebooks/MyST-Parser/blob/v2.0.0/myst_parser/mocking.py#L153-L179)). RST directives in the .txt file rendered as literal paragraph text:

```html
<p>.. cmdinclude:: /_include/interface-description.txt</p>
<p>.. cfgcmd:: set interfaces ethernet ...</p>
<p>.. code-block:: none</p>
```

Users reported this on https://docs.vyos.io/en/rolling/configuration/interfaces/ethernet.html — but it actually affects every page that consumes `_include/*.txt` via `{cmdincludemd}`: at minimum **ethernet, dummy, tunnel, bonding, bridge, macsec, vxlan, l2tpv3, pseudo-ethernet, virtual-ethernet, wireless**.

### Fix

Mirror MyST's own `{eval-rst}` plumbing: build a fresh docutils document that inherits the outer document's settings + reporter, run `MockRSTParser` over the var-substituted include content, and graft the resulting children back into the calling document (with explicit-target registration). The Sphinx env stays available so `cfgcmd`, `opcmd`, and `cmdinclude` continue to work end-to-end.

The previous `nested_render_text`-first fallback (added in 59686997) was guarding against a `MockRSTParser` path that doesn't fire in current myst-parser — every cmdincludemd call lands on `MockState` and hits the no-op path.

### Verification

Local clean build on rolling (Sphinx 7.x, myst-parser 2.0):

- Zero literal `cfgcmd::` / `cmdinclude::` / `code-block::` / `opcmd::` / `note::` / `include::` strings remain in any built HTML under `configuration/`, `automation/`, `installation/`, `operation/`, `vpp/`.
- All 11 affected interface pages render proper `cfgcmd-heading` / `cfgcmd-body` blocks. Counts: ethernet 160, wireless 172, bridge 99, bonding 97, virtual-ethernet 85, pseudo-ethernet 83, macsec 52, vxlan 38, l2tpv3 33, tunnel 25, dummy 4.
- Nested `.. note::` → admonition, nested `.. code-block::` → highlight blocks, nested bullet lists all render correctly inside cfgcmd bodies.
- Unrelated pages unchanged (ipsec_general 62 cfgcmd, firewall 7, operation/information 5).

## Related Task(s)

n/a

## Related PR(s)

n/a

## Backport

- [x] sagitta
- [x] circinus

(Same `_ext/vyos.py` lives on all three branches per the `50a82c12` port — same bug, same fix.)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document

🤖 Generated by [robots](https://vyos.io)