### PR TITLE
ci(mergify): disable inherited T-ID title/commit-message checks in this repo

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -17,3 +17,51 @@
 # configuration per Mergify's `extends:` semantics.
 
 extends: mergify
+
+pull_request_rules:
+  # ------------------------------------------------------------------
+  # Override: disable T-ID-format checks for PR title and commit messages.
+  #
+  # The central baseline in vyos/mergify enforces `T<digits>: <text>` (with
+  # optional `scope: ` prefix) on both the PR title and every commit's first
+  # line. That matches the convention in vyos/vyos-1x and other code repos
+  # where engineering work tracks against a Phorge task.
+  #
+  # vyos-documentation does not require a Phorge T-ID per PR — much of the
+  # work here is conventional-commits style (`fix(ext): …`, `ci(...): …`,
+  # `chore(deps): …`) with no upstream ticket. Inheriting the central rules
+  # labels every such PR `invalid-title` / `invalid-commit-title`, which is
+  # noise.
+  #
+  # Per Mergify `extends:` semantics, same-name rules in the child REPLACE
+  # the parent's. The two rules below keep the original names so the parent
+  # versions are dropped; conditions are constructed to never match (a PR
+  # cannot simultaneously be closed and not closed), so the `toggle` action
+  # always falls into the "remove label" branch — cleaning up the labels on
+  # any PR that previously had them.
+  # ------------------------------------------------------------------
+
+  - name: Flag PR title not matching T-ID format
+    description: >
+      Disabled in vyos-documentation — this repo does not require Phorge
+      T-IDs in PR titles. Conventional-commits style is acceptable.
+    conditions:
+      - closed
+      - '-closed'
+    actions:
+      label:
+        toggle:
+          - invalid-title
+
+  - name: Flag commit message not matching T-ID format
+    description: >
+      Disabled in vyos-documentation — this repo does not require Phorge
+      T-IDs in commit message headlines. Conventional-commits style is
+      acceptable.
+    conditions:
+      - closed
+      - '-closed'
+    actions:
+      label:
+        toggle:
+          - invalid-commit-title


### PR DESCRIPTION
## Change Summary

The central baseline at [`vyos/mergify:.mergify.yml`](https://github.com/vyos/mergify/blob/production/.mergify.yml) enforces `T<digits>: <text>` (with optional `scope: ` prefix) on both PR titles and every commit's first line. That convention comes from vyos/vyos-1x and the other code repos where engineering work tracks against a Phorge task.

vyos-documentation has never enforced T-IDs. Recent merged PRs are conventional-commits style (`fix(ext): …`, `ci(...): …`, `chore(deps): …`) without an upstream ticket. After `extends: mergify` landed in [vyos-documentation#2005](https://github.com/vyos/vyos-documentation/pull/2005), the inherited rules started labeling every such PR `invalid-title` and `invalid-commit-title` — currently visible on [vyos-documentation#2008](https://github.com/vyos/vyos-documentation/pull/2008).

This PR overrides the two rules in `.github/mergify.yml`. Per Mergify [`extends:` semantics](https://docs.mergify.com/configuration/sharing/), same-name rules in the child REPLACE the parent's. The override keeps the original rule names so the parent versions drop out; conditions are constructed to never match (`closed and -closed`), so the `toggle` action always falls into the "remove label" branch and clears the labels from any PR that picked them up since #2005.

## Related Task(s)

* https://vyos.dev/T8782 — central Mergify rollout master

## Related PR(s)

* [vyos-documentation#2005](https://github.com/vyos/vyos-documentation/pull/2005) — the `extends: mergify` adoption that introduced the inherited rules
* [vyos-documentation#2008](https://github.com/vyos/vyos-documentation/pull/2008) — example PR that picked up the labels

## Backport

- [x] sagitta
- [x] circinus

(`.github/mergify.yml` exists byte-identical on all three branches; same override is desired everywhere.)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document

🤖 Generated by [robots](https://vyos.io)