### PR TITLE
ci(mergify): fix T-ID-override rule name to match central baseline

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -34,17 +34,23 @@ pull_request_rules:
   # noise.
   #
   # Per Mergify `extends:` semantics, same-name rules in the child REPLACE
-  # the parent's. The two rules below keep the original names so the parent
-  # versions are dropped; conditions are constructed to never match (a PR
-  # cannot simultaneously be closed and not closed), so the `toggle` action
-  # always falls into the "remove label" branch — cleaning up the labels on
-  # any PR that previously had them.
+  # the parent's. The override below MUST use the parent's exact rule name
+  # — `Flag T-ID format violation in PR title or commit messages` — or the
+  # parent rule keeps firing and `invalid-title` labels every PR. (The
+  # earlier two-rule override shipped in 3d44fe06 used the wrong names
+  # and was a no-op; PR #2014 surfaced the regression.)
+  #
+  # Conditions are constructed to never match (a PR cannot simultaneously
+  # be closed and not closed), so the `toggle` action always falls into
+  # the "remove label" branch — cleaning up `invalid-title` on any PR
+  # that picked it up while the broken override was in place.
   # ------------------------------------------------------------------
 
-  - name: Flag PR title not matching T-ID format
+  - name: Flag T-ID format violation in PR title or commit messages
     description: >
       Disabled in vyos-documentation — this repo does not require Phorge
-      T-IDs in PR titles. Conventional-commits style is acceptable.
+      T-IDs in PR titles or commit message headlines. Conventional-commits
+      style (`fix(ext): …`, `ci(...): …`, `chore(deps): …`) is acceptable.
     conditions:
       - closed
       - '-closed'
@@ -52,16 +58,3 @@ pull_request_rules:
       label:
         toggle:
           - invalid-title
-
-  - name: Flag commit message not matching T-ID format
-    description: >
-      Disabled in vyos-documentation — this repo does not require Phorge
-      T-IDs in commit message headlines. Conventional-commits style is
-      acceptable.
-    conditions:
-      - closed
-      - '-closed'
-    actions:
-      label:
-        toggle:
-          - invalid-commit-title


### PR DESCRIPTION
The override shipped in [3d44fe06](https://github.com/vyos/vyos-documentation/commit/3d44fe06) (PR [vyos-documentation#2009](https://github.com/vyos/vyos-documentation/pull/2009)) was a no-op — it never replaced the inherited T-ID rule from `vyos/mergify`. Every PR without a `T<digits>:` token has been getting auto-labeled `invalid-title` since [vyos-documentation#2005](https://github.com/vyos/vyos-documentation/pull/2005) merged `extends: mergify`.

## Root cause

Per [Mergify `extends:` semantics](https://docs.mergify.com/configuration/sharing/), **same-name** `pull_request_rules` in the child REPLACE the parent's. Different-name rules are added alongside.

The central baseline at [`vyos/mergify:.mergify.yml`](https://github.com/vyos/mergify/blob/production/.mergify.yml) uses a **single rule** named:

> `Flag T-ID format violation in PR title or commit messages`

(PR title regex + commit-message regex `or`'d together, single `toggle: invalid-title` action — done that way deliberately to avoid two rules fighting over the same label.)

Our override defined **two rules** named:

- `Flag PR title not matching T-ID format`
- `Flag commit message not matching T-ID format`

Neither matches the parent's name, so the parent kept firing.

## Fix

Collapse to one rule, rename to match the parent exactly. Conditions (`closed AND -closed`) still never match → `toggle` always removes the label → existing `invalid-title` labels also get cleaned up on next evaluation.

The parent rule does not toggle `invalid-commit-title` — the second child rule was extraneous and is dropped.

## Verification

- Central rule name confirmed via `gh api repos/vyos/mergify/contents/.mergify.yml` → `grep "^  - name:"` shows exactly one T-ID rule, named `Flag T-ID format violation in PR title or commit messages`.
- Symptom observed on [vyos-documentation#2014](https://github.com/vyos/vyos-documentation/pull/2014) (title `docs(readme): reflect completed MyST migration`): `invalid-title` label applied despite override being present.
- Post-merge: Mergify re-evaluates open PRs and the toggle's "remove label" branch fires, clearing the noise label across the open backlog.

## Tracking

- Phorge: [T8861](https://vyos.dev/T8861) (subtask of [T8782](https://vyos.dev/T8782) — Mergify central-config rollout)

🤖 Generated by [robots](https://vyos.io)
