### PR TITLE
fix(includes): rewrite need_improvement.txt as MyST so plain `{include}` renders correctly

### DIFF
--- a/docs/_include/need_improvement.txt
+++ b/docs/_include/need_improvement.txt
@@ -1,3 +1,4 @@
+::::{only} not latex
 :::{admonition} Call for Contributions
 :class: error
 
@@ -5,3 +6,4 @@ Help improve this section with additional content, examples, and explanations.
 
 For contribution guidelines, see {ref}`documentation`.
 :::
+::::

--- a/docs/_include/need_improvement.txt
+++ b/docs/_include/need_improvement.txt
@@ -1,21 +1,7 @@
-.. raw:: latex
-
-    \iffalse
-
-.. raw:: html
-
-   <div class="admonition error">
-   <p class="admonition-title">Call for Contributions</p>
-
+:::{admonition} Call for Contributions
+:class: error
 
 Help improve this section with additional content, examples, and explanations.
 
-For contribution guidelines, see :ref:`documentation`.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: latex
-
-    \fi
+For contribution guidelines, see {ref}`documentation`.
+:::

--- a/docs/configuration/highavailability/index.md
+++ b/docs/configuration/highavailability/index.md
@@ -414,8 +414,7 @@ To know more about scripting, check the {ref}`command-scripting` section.
 
 ## Virtual-server
 
-```{eval-rst}
-.. include:: /_include/need_improvement.txt
+```{include} /_include/need_improvement.txt
 ```
 
 Virtual Server allows to Load-balance traffic destination virtual-address:port


### PR DESCRIPTION
## Symptom

[`docs.vyos.io/en/rolling/vpp/index.html`](https://docs.vyos.io/en/rolling/vpp/index.html) (and ~44 other pages) render raw RST directives as literal text:

```
.. raw:: latex
\iffalse
.. raw:: html
Call for Contributions
Help improve this section with additional content, examples, and explanations.
For contribution guidelines, see :ref:
documentation
.
.. raw:: html
.. raw:: latex
\fi
```

Reported on `rolling` but present on `circinus` and `sagitta` too (same include file in all branches).

## Root cause

`docs/_include/need_improvement.txt` is RST. ~45 MD pages pull it in via plain ``` ```{include} /_include/need_improvement.txt ``` ```. MyST's built-in `{include}` parses the included content with the *outer* file's parser — i.e. as MyST. RST directives in the `.txt` then render as paragraphs.

Different from PR #2008 (9c815d68): that fix routes `{cmdincludemd}` content through a real RST parser. The plain `{include}` path doesn't go through our custom extension.

One callsite (`docs/configuration/highavailability/index.md:417-419`) wrapped the include in `{eval-rst}` and rendered correctly — that wrapper is removed in this PR since the file is now MyST.

## Affected pages (rolling)

All `vpp/*` pages (incl. the originally reported `vpp/index.html`), plus `haproxy`, `isis`, `bfd`, `policy/index`, `pki/index`, `vyos-salt`, `flowtables`, `webproxy` (3 spots), `highavailability/index`.

## Fix

1. Rewrite `_include/need_improvement.txt` as a native MyST admonition.
2. Drop the now-unnecessary `{eval-rst}` wrapper at the single eval-rst-wrapped callsite.

## Backport

```
## Backport

Mergify will backport on merge:
- [x] circinus (1.5)
- [x] sagitta (1.4)
```

## Test plan

- [ ] Wait for Read the Docs PR build
- [ ] Spot-check rendered HTML on RTD PR preview for `vpp/index`, `haproxy`, `highavailability/index` — admonition box should render with "Call for Contributions" title and a working `documentation` cross-reference
- [ ] No raw `.. raw::` / `\iffalse` / `:ref:` strings in rendered output

🤖 Generated by [robots](https://vyos.io)