### PR TITLE
fix(includes): rewrite need_improvement.txt as MyST so plain `{include}` renders correctly (backport #2016)

### DIFF
--- a/docs/_include/need_improvement.txt
+++ b/docs/_include/need_improvement.txt
@@ -1,8 +1,9 @@
-:::{error} Call for Contributions
+::::{only} not latex
+:::{admonition} Call for Contributions
+:class: error
 
-This section needs improvements, examples and explanations.
+Help improve this section with additional content, examples, and explanations.
 
-Please take a look at the Contributing Guide for our :ref:`documentation`.
+For contribution guidelines, see {ref}`documentation`.
 :::
-
-    \fi
+::::


### PR DESCRIPTION
Manual backport of [vyos-documentation#2016](https://github.com/vyos/vyos-documentation/pull/2016) to `sagitta`.

## Why manual

Mergify auto-backport failed with a cherry-pick conflict:

```
Unmerged paths:
  both modified:   docs/_include/need_improvement.txt
```

Sagitta's pre-existing version of `_include/need_improvement.txt` is a partial MyST conversion that landed sometime during the migration, but it has:

- Leftover RST garbage at the end (`    \fi` line).
- A stale RST `:ref:` syntax instead of `{ref}` in MyST.
- No PDF builder suppression.

## Fix (same as rolling #2016 + 86de2de9)

Replace the file with the `::::{only} not latex` wrapped MyST admonition, restoring builder-conditional PDF suppression (`.readthedocs.yml` declares `formats: - pdf`).

Sagitta does NOT have the `{eval-rst}` wrapper around the include in `configuration/highavailability/index.md` that rolling had, so the second hunk from #2016 is not needed here.

## Test plan

- [ ] Wait for Read the Docs PR build
- [ ] Spot-check rendered HTML on RTD PR preview for any sagitta page that includes the file (e.g. `vyos-salt`, `webproxy`)
- [ ] No raw `.. raw::` / `\fi` / `:ref:` strings in rendered output

🤖 Generated by [robots](https://vyos.io)