### PR TITLE
fix(includes): break the RST `.. include::` chain that pulls need_improvement.txt on sagitta

### DIFF
--- a/docs/_include/interface-vlan-8021ad.txt
+++ b/docs/_include/interface-vlan-8021ad.txt
@@ -1,5 +1,3 @@
-.. include:: /_include/need_improvement.txt
-
 IEEE 802.1ad_ was an Ethernet networking standard informally known as QinQ as
 an amendment to IEEE standard 802.1q VLAN interfaces as described above.
 802.1ad was incorporated into the base 802.1q_ standard in 2011. The technique


### PR DESCRIPTION
## Follow-up to [vyos-documentation#2026](https://github.com/vyos/vyos-documentation/pull/2026)

Copilot inline finding on [#2026 (discussion r3237768394)](https://github.com/vyos/vyos-documentation/pull/2026#discussion_r3237768394) — the fix landed on the branch after #2026 merged, so it needs its own PR.

## Why

`docs/_include/interface-vlan-8021ad.txt` on sagitta starts with:

\`\`\`
.. include:: /_include/need_improvement.txt
\`\`\`

After [vyos-documentation#2008](https://github.com/vyos/vyos-documentation/pull/2008) (9c815d68), \`{cmdincludemd}\` parses included \`.txt\` content as RST. The three MD pages that consume \`interface-vlan-8021ad.txt\`:

- \`docs/configuration/interfaces/ethernet.md:161\`
- \`docs/configuration/interfaces/virtual-ethernet.md:46\`
- \`docs/configuration/interfaces/wireless.md:485\`

…reach \`need_improvement.txt\` through an RST parser. After [#2026](https://github.com/vyos/vyos-documentation/pull/2026), \`need_improvement.txt\` is MyST (\`::::{only} not latex / :::{admonition}\`), so the RST parser renders those directives as literal text on three interface pages.

Rolling does not have this regression — rolling's \`_include/interface-vlan-8021ad.txt\` is already MyST/MD and does not include \`need_improvement.txt\` at all. The sagitta file is mid-migration RST-shape content with the include chain at the top.

## Fix

Strip line 1 (\`.. include:: /_include/need_improvement.txt\`) and the blank line that follows. The QinQ overview RST content below is untouched and still renders correctly through \`{cmdincludemd}\`.

No rolling counterpart needed (already clean). No circinus counterpart needed — circinus's interface-vlan-8021ad.txt does not have the include chain either (only sagitta has the artifact).

## Test plan

- [ ] Wait for RTD PR build
- [ ] Spot-check rendered \`configuration/interfaces/ethernet.html\`, \`virtual-ethernet.html\`, \`wireless.html\` on the preview — QinQ section should render normally with no \`::::{only}\` / \`:::{admonition}\` literal-text leakage at the top

🤖 Generated by [robots](https://vyos.io)