### PR TITLE
docs: convert `:abbr:` RST role to MyST `{abbr}` syntax

### DIFF
--- a/docs/configuration/interfaces/bonding.md
+++ b/docs/configuration/interfaces/bonding.md
@@ -63,7 +63,7 @@ The available modes are:
        settings are not included in the active bond.
 
        Provides load balancing and fault tolerance. Uses the
-       :abbr:`LACP (Link Aggregation Control Protocol)` to
+       {abbr}`LACP (Link Aggregation Control Protocol)` to
        negotiate the bond with the switch.
    * - **Traffic distribution:**
      - Traffic is distributed according to the **transmit hash
@@ -175,7 +175,7 @@ The available modes are:
 * ``xor-hash``: Provides load balancing and fault tolerance
   based on a hash formula. Distributes traffic and handles
   failover identically to ``802.3ad``, but operates without
-  the :abbr:`LACP (Link Aggregation Control Protocol)`.
+  the {abbr}`LACP (Link Aggregation Control Protocol)`.
 ```
 
 ````

--- a/docs/configuration/system/syslog.md
+++ b/docs/configuration/system/syslog.md
@@ -305,8 +305,8 @@ set system syslog remote graylog.example.com tls permitted-peers 'graylog.exampl
 This section lists facilities used by syslog. Most facility names are self-
 explanatory. The local0–local7 facilities are used for custom purposes, such as
 logging from network nodes and equipment. Facility assignment is flexible and
-should be tailored to your company's needs. Consider facilities as categorization
-tools, rather than strict directives.
+should be tailored to your company's needs. Consider facilities as
+categorization tools, rather than strict directives.
 
 ```{eval-rst}
 +----------+----------+----------------------------------------------------+

--- a/docs/configuration/system/syslog.md
+++ b/docs/configuration/system/syslog.md
@@ -214,7 +214,7 @@ The following authentication modes are available:
 ```{eval-rst}
 * ``anon`` **(default)**: Allows encrypted connections without verifying the syslog
   server's identity. This mode is **not recommended**, as it is vulnerable to
-  :abbr:`MITM (Man-in-the-Middle)` attacks.
+  {abbr}`MITM (Man-in-the-Middle)` attacks.
 * ``fingerprint``: Verifies the server’s certificate fingerprint against the
   value preconfigured with:
 
@@ -223,12 +223,12 @@ The following authentication modes are available:
      set system syslog remote <address> tls permitted-peer <peer>
 
 * ``certvalid``: Verifies the server certificate is signed by a trusted
-  :abbr:`CA (Certificate Authority)`, skipping :abbr:`CN (Common Name)` check.
+  {abbr}`CA (Certificate Authority)`, skipping {abbr}`CN (Common Name)` check.
 * ``name``: Verifies that:
 
-  * The server’s certificate is signed by a trusted :abbr:`CA (Certificate
+  * The server’s certificate is signed by a trusted {abbr}`CA (Certificate
     Authority)`.
-  * The :abbr:`CN (Common Name)` in the certificate matches the value
+  * The {abbr}`CN (Common Name)` in the certificate matches the value
     preconfigured with:
 
   .. code-block:: none


### PR DESCRIPTION
## Problem

Six `:abbr:` RST roles in `bonding.md` and `syslog.md` survived the RST→MyST migration. MyST doesn't process inline RST roles, so they currently render as literal text (e.g. ``:abbr:`LACP (Link Aggregation Control Protocol)```) on docs.vyos.io instead of the intended dotted-underline tooltip.

Spotted by RST-leftovers scan 2026-05-14 (Category 2).

## Fix

Convert the role prefix `:abbr:` → `{abbr}` (RST → MyST role syntax). Argument inside backticks unchanged.

| File | Lines |
|---|---|
| `docs/configuration/interfaces/bonding.md` | 66, 178 |
| `docs/configuration/system/syslog.md` | 217, 226, 229, 231 |

Three `:cfgcmd:` / `:opcmd:` / `:defaultvalue:` occurrences in `docs/documentation.md` are inside double-backtick literal markers — they document the syntax. Out of scope.

## Backport

Mergify will backport on merge:
- [x] circinus (1.5)

Sagitta is not affected — its `bonding.md` and `syslog.md` use plain text for those abbreviations.

## Test plan

- [ ] RTD PR preview build succeeds
- [ ] `configuration/interfaces/bonding.html` — search for "LACP"; renders as dotted-underline tooltip, not `:abbr:` literal
- [ ] `configuration/system/syslog.html` — same check for "MITM", "CA", "CN"

🤖 Generated by [robots](https://vyos.io)