### PR TITLE
ci(workflows): remove conflict markers from update-version-tags.yml (circinus)

### DIFF
--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -1,10 +1,5 @@
 name: Update version tags
 
-<<<<<<< HEAD
-# This workflow exists on rolling, circinus, and sagitta.
-# Keep all three copies in sync — backport edits via Mergify
-# (`@Mergifyio backport circinus sagitta`) or cherry-pick.
-=======
 # context7-refresh.yml triggers via workflow_run on this workflow's name.
 # DO NOT rename the `name:` field above without updating context7-refresh.yml.
 #
@@ -16,7 +11,6 @@ name: Update version tags
 # semantically correct — the tag still represents the latest docs state.
 # `context7.json` is included because changes to its `rules`, `folders`, or
 # `excludeFolders` affect what Context7 returns even when no .md files moved.
->>>>>>> 800acbfd (ci(context7): gate version-tag move + refresh on docs-only changes)
 
 on:
   push:


### PR DESCRIPTION
## Diagnosis

`.github/workflows/update-version-tags.yml` on this branch has literal git conflict markers in the YAML header, dating back to Mergify auto-backport [vyos-documentation#1988](https://github.com/vyos/vyos-documentation/pull/1988) (cherry-pick of [#1984](https://github.com/vyos/vyos-documentation/pull/1984) → circinus).

The cherry-pick conflicted on the workflow's header comment block. Mergify's `ignore_conflicts: true` default at the time committed the markers verbatim:

```yaml
name: Update version tags

<<<<<<< HEAD
# This workflow exists on rolling, circinus, and sagitta.
# Keep all three copies in sync — backport edits via Mergify
# (`@Mergifyio backport circinus sagitta`) or cherry-pick.
=======
# context7-refresh.yml triggers via workflow_run on this workflow's name.
...
>>>>>>> 800acbfd (ci(context7): gate version-tag move + refresh on docs-only changes)
```

The central Mergify config was switched to `ignore_conflicts: false` shortly afterward as a direct response to this class of incident — but #1988 had already merged with the markers baked in.

## Impact

Every push to circinus touching `docs/**` or `context7.json` since #1988 merged has reported **"this run likely failed because of a workflow file issue"** with 0 jobs. GitHub's YAML parser fails on `<<<<<<<` / `=======` / `>>>>>>>` and refuses to schedule anything.

Cascading: `context7-refresh.yml` triggers via `workflow_run` on this workflow's name. Since `Update version tags` never ran, Context7 refresh also never ran, so the **`1.5` Context7 index has been stale on every docs push** since #1988.

Concrete failing run: [actions/runs/25833390251](https://github.com/vyos/vyos-documentation/actions/runs/25833390251) (one of many).

## Fix

Replace the file with rolling's verbatim content. The post-marker content on circinus was already byte-identical to rolling — only the marker block + the obsolete comment block above it differ.

Verified with:
- `diff <(git show origin/rolling:.../update-version-tags.yml) <(git show origin/circinus:.../update-version-tags.yml)` → exactly the 6 marker/comment lines
- `python3 -c "import yaml; yaml.safe_load(open('.../update-version-tags.yml'))"` → parses clean, all expected jobs (`check_head`, `retag`) present after fix

## After merge

- `Update version tags` will run on every docs-affecting push to circinus, moving the `1.5` tag to HEAD.
- `Context7 refresh` will fire via `workflow_run` on the next docs push.

## Cross-branch

The exact same fix is queued for sagitta in a parallel PR.

🤖 Generated by [robots](https://vyos.io)