### PR TITLE
docs: fix sagitta interface include text cleanup

### DIFF
--- a/docs/_include/interface-disable-link-detect.txt
+++ b/docs/_include/interface-disable-link-detect.txt
@@ -5,7 +5,7 @@
   Use this command to direct an interface to not detect any physical state
   changes on a link, for example, when the cable is unplugged.
 
-  Default is to detects physical link state changes.
+  Default is to detect physical link state changes.
 
   Example:
 

--- a/docs/_include/interface-ipv6.txt
+++ b/docs/_include/interface-ipv6.txt
@@ -78,7 +78,6 @@
   .. hint::
 
      MSS value = MTU - 40 (IPv6 header) - 20 (TCP header), resulting in
-
      1432 bytes on a 1492 byte MTU.
 
   Instead of a numerical MSS value ``clamp-mss-to-pmtu`` can be used to


### PR DESCRIPTION
## Summary
- fix grammar in the disable-link-detect include
- remove a spurious blank line in the IPv6 MSS hint

## Context
Follow-up to #2035, which merged before these review findings could be added to the same PR.

## Verification
- `make -C docs SPHINXBUILD=/Users/syncer/GitHub/vyos-documentation/.docs-venv/bin/sphinx-build clean html` from a clean git archive: build succeeded, 332 warnings
- rendered HTML scan: `custom_directive_paragraph_leaks=0`
- rendered HTML scan: `visible_linter_marker_paragraphs=22` (pre-existing/deferred common-references issue)