### PR TITLE
ci(ai-validation): skip prepare on Mergify-authored PRs

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -46,6 +46,19 @@ jobs:
   #   - GitHub-hosted runners are ephemeral — every run starts on a fresh
   #     VM, so cross-run state leakage is not possible.
   prepare:
+    # Skip the whole pipeline on Mergify-authored PRs (backport PRs, queue
+    # PRs). The underlying change was already reviewed on the source PR;
+    # re-running prepare wastes a runner and — for backports to branches
+    # that have advanced since the merge ref was computed — fails with
+    # `fatal: FETCH_HEAD...HEAD: no merge base` during the shallow-fetch
+    # diff step, leaving a red "prepare" check on every Mergify backport
+    # (proximate symptom: run 25842928620 on PR #2042, the sagitta
+    # backport of #2023). validate already short-circuits on bot authors
+    # via its `secrets-check` step, but that fires too late — guarding at
+    # the job level skips prepare entirely, and `needs: [prepare]` +
+    # `if: needs.prepare.outputs.has_md_changes == 'true'` cascades the
+    # skip to validate as well.
+    if: github.event.pull_request.user.login != 'mergify[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Lifts the existing Mergify-author short-circuit to a job-level `if:` on `prepare`, so the whole AI Validation pipeline skips for Mergify backport/queue PRs.
- Fixes the `fatal: FETCH_HEAD...HEAD: no merge base` crash that occurs when a backport's merge ref shares no shallow ancestor with the (advanced) base branch — concrete example: [run 25842928620](https://github.com/vyos/vyos-documentation/actions/runs/25842928620/job/75939332539) on [vyos-documentation#2042](https://github.com/vyos/vyos-documentation/pull/2042) (sagitta backport of [vyos-documentation#2023](https://github.com/vyos/vyos-documentation/pull/2023)).

The validate-level skip in [vyos-documentation@0e8a2956](https://github.com/vyos/vyos-documentation/commit/0e8a2956) was correct for the upstream `claude-code-action` rejecting bot-initiated runs, but fires too late — `prepare` has already run and crashed before validate's `if: needs.prepare.outputs.has_md_changes == 'true'` even evaluates.

## Backport
- circinus

(sagitta covered by direct hotfix [vyos-documentation#2046](https://github.com/vyos/vyos-documentation/pull/2046) to unblock [vyos-documentation#2042](https://github.com/vyos/vyos-documentation/pull/2042) immediately.)

## Test plan
- [ ] Once merged + auto-backported to circinus, future Mergify backports on circinus show `prepare` and `validate` skipped (not failing).
- [ ] Human-authored PR on rolling still triggers prepare + validate normally.

🤖 Generated by [robots](https://vyos.io)