### PR TITLE
ci(ai-validation): skip prepare on Mergify-authored PRs (sagitta hotfix)

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -46,6 +46,19 @@ jobs:
   #   - GitHub-hosted runners are ephemeral — every run starts on a fresh
   #     VM, so cross-run state leakage is not possible.
   prepare:
+    # Skip the whole pipeline on Mergify-authored PRs (backport PRs, queue
+    # PRs). The underlying change was already reviewed on the source PR;
+    # re-running prepare wastes a runner and — for backports to branches
+    # that have advanced since the merge ref was computed — fails with
+    # `fatal: FETCH_HEAD...HEAD: no merge base` during the shallow-fetch
+    # diff step, leaving a red "prepare" check on every Mergify backport
+    # (proximate symptom: run 25842928620 on PR #2042, the sagitta
+    # backport of #2023). validate already short-circuits on bot authors
+    # via its `secrets-check` step, but that fires too late — guarding at
+    # the job level skips prepare entirely, and `needs: [prepare]` +
+    # `if: needs.prepare.outputs.has_md_changes == 'true'` cascades the
+    # skip to validate as well.
+    if: github.event.pull_request.user.login != 'mergify[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Direct sagitta hotfix of the same change as [vyos-documentation#2043](https://github.com/vyos/vyos-documentation/pull/2043) (which targets rolling).
- Clears the failing \`prepare\` check on [vyos-documentation#2042](https://github.com/vyos/vyos-documentation/pull/2042) ([run 25842928620](https://github.com/vyos/vyos-documentation/actions/runs/25842928620/job/75939332539)) without waiting for the rolling → circinus → sagitta Mergify cascade.
- Same one-line job-level \`if:\` on \`prepare\`. \`pull_request_target\` evaluates the workflow file from the base branch, so the skip only applies once it lands on the branch backports target.
- \`sagitta\` has been dropped from #2043's backport list to avoid a duplicate merge conflict.

## Test plan
- [ ] Merge this PR.
- [ ] Re-run AI Validation on [vyos-documentation#2042](https://github.com/vyos/vyos-documentation/pull/2042) — \`prepare\` + \`validate\` should both report skipped.

🤖 Generated by [robots](https://vyos.io)