### PR TITLE
ipsec: T7555: Documentation of `ikev2-reauth` option for site-to-site peers

### DIFF
--- a/docs/configuration/vpn/ipsec/site2site_ipsec.md
+++ b/docs/configuration/vpn/ipsec/site2site_ipsec.md
@@ -352,6 +352,24 @@ allows passing plain ESP packets between them.
 Name of IKE group to use for key exchanges.
 ```
 
+```{cfgcmd} set vpn ipsec site-to-site peer \<name\> ikev2-reauth \<yes|no|inherit\>
+
+**Configure IKEv2 reauthentication behavior for the specified IPsec
+site-to-site peer.**
+
+The following options are available:
+
+* ``yes``: The active IKE SA channel between the two peers is terminated and
+  re-established at each rekeying interval, explicitly re-verifying each
+  peer's identity.
+* ``no`` (default): Reauthentication (identity re-verification) is disabled
+  for this peer. The active IKE SA channel is seamlessly renewed at each
+  rekeying interval without termination.
+* ``inherit``: The peer inherits reauthentication behavior from the assigned
+  IKE group. Reauthentication is applied only if it is explicitly enabled in
+  that group's configuration.
+```
+
 ```{cfgcmd} set vpn ipsec site-to-site peer \<name\> local-address \<address\>
 
 Local IP address for IPsec connection with this peer.


### PR DESCRIPTION
## Change Summary
IKEv2 reauthentication was configurable via CLI but never translated into real configuration of strongSwan.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T7555

## Related PR(s)
* https://github.com/vyos/vyos-1x/pull/5197


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document