### PR TITLE
mlxsw T8878: add noudpcsum vxlan option

### DIFF
--- a/docs/configuration/interfaces/vxlan.md
+++ b/docs/configuration/interfaces/vxlan.md
@@ -107,6 +107,13 @@ Disable {abbr}`SLLA (Source Link-Layer Address)` and IP address learning on
 the VXLAN interface.
 ```
 
+```{cfgcmd} set interfaces vxlan \<interface\> parameters noudpcsum
+
+Disable UDP checksums on the VXLAN interface.  Some devices include
+hardware-accelerated VXLAN offloading and require that VyOS's checksums be
+disabled.
+```
+
 ```{cfgcmd} set interfaces vxlan \<interface\> parameters vni-filter
 
 **Enable** {abbr}`VNI (VXLAN Network Identifier)` **filtering on the VXLAN


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Apply documentation updates for T8878, adding `set interfaces vxlan <interface> parameters noudpcsum`.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T8878

## Related PR(s)

https://github.com/vyos/vyos-1x/pull/5201

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document