### PR TITLE
ntp: T8882: add ntp polling options

### DIFF
--- a/docs/configuration/service/ntp.md
+++ b/docs/configuration/service/ntp.md
@@ -51,7 +51,7 @@ the `allow-client` directive.
 ```
 
 
-```{cfgcmd} set service ntp server \<address\> \<noselect | nts | pool | prefer | ptp | interleave\>
+```{cfgcmd} set service ntp server \<address\> \<noselect | nts | pool | prefer | ptp | interleave | minpoll N | maxpoll N | presend N | extfield-f323 \>
 
 Configure one or more attributes to the given NTP server.
 
@@ -72,6 +72,21 @@ operating hosts.
 
 * ``interleave`` enables NTP interleaved mode (see [draft-ntp-interleaved-modes]), which can improve
 synchronization accuracy and stability when supported by both parties.
+
+* ``minpoll N`` sets the minimum delay between NTP pools of this
+server.  The configured delay is 2^N seconds; the default of 6 is 2^6
+or 64 seconds. 
+
+* ``maxpoll N`` sets the maximum delay between NTP polls of this
+server.  The configured delay is 2^N seconds; the default of 10 is
+2^10 or 1024 seconds. 
+
+* ``presend N`` enables pre-sending additional NTP packets if more
+than 2^N seconds have passed since the last NTP request was sent to
+this server.  This can help warm up ARP caches and reduce variability. 
+
+* ``extfield-f323`` enables the F323 NTP extension field, which may
+slightly increase accuracy when talking to Chrony servers.
 ```
 
 


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Add documentation for T8882, adding additional NTP server configuration options.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T8882

## Related PR(s)

https://github.com/vyos/vyos-1x/pull/5204

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document