### PR TITLE
Update upstream Git branch to 'rolling' in 'Write Documentation' instructions

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -427,16 +427,17 @@ pull-request. This requires you already have a GitHub account.
 
   ```none
   $ git fetch upstream
-  $ git checkout current
-  $ git merge upstream/current
-```
+  $ git checkout rolling
+  $ git merge upstream/rolling
 
-- If you also want to update your fork on GitHub, use the following: `$ git
-  push origin current`
+  ```
 
-[dockerfile]: https://github.com/vyos/vyos-documentation/blob/current/docker/Dockerfile
+- If you also want to update your fork on GitHub, use the following:
+`$ git push origin rolling`
+
+[dockerfile]: https://github.com/vyos/vyos-documentation/blob/rolling/docker/Dockerfile
 [grammarly]: https://www.grammarly.com/
-[readme.md]: https://github.com/vyos/vyos-documentation/blob/current/README.md
+[readme.md]: https://github.com/vyos/vyos-documentation/blob/rolling/README.md
 [restructuredtext]: http://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 [restructuredtextdirectives]: https://docutils.sourceforge.io/docs/ref/rst/directives.html
 [sphinx-doc]: https://www.sphinx-doc.org


### PR DESCRIPTION


<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Update the upstream Git branch from `current` to `rolling` in the [Write Documentation](https://docs.vyos.io/en/rolling/documentation.html) instructions.

This commit also fixes link rendering errors in `documentation.md` (for example, [README.md]).
<img width="992" height="191" alt="Screenshot 2026-05-18 173213" src="https://github.com/user-attachments/assets/6051dca4-87a3-4a0b-8ab2-957a05f5c998" />


## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document