### PR TITLE
ci(ai-validation): allow Pass 2 review on external-contributor PRs

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -566,6 +566,41 @@ jobs:
           # source / vyos-1x checkouts above, and has no write access
           # on vyos/vyos-documentation PRs.
           github_token: ${{ github.token }}
+          # Bypass the upstream action's actor write-permission check. The
+          # check (src/github/validation/permissions.ts in claude-code-action)
+          # calls getCollaboratorPermissionLevel on github.actor and fails
+          # with `Actor does not have write permissions to the repository`
+          # when an external contributor opens a PR, because the actor on
+          # pull_request_target is the PR author and forks resolve to
+          # `read`. That kills validation on every fork PR before any of
+          # our own skip logic runs — defeating the workflow's entire
+          # purpose (catching CLI/default-value drift in contributions
+          # from non-maintainers). Failure mode reproduced on run
+          # 26541079685 (PR #2061 from LiudmylaNad); same pattern hit
+          # every external contributor PR in the prior 4 weeks.
+          #
+          # Setting '*' is safe in THIS workflow specifically because the
+          # surrounding defense-in-depth bounds what Pass 2 can do with
+          # untrusted PR content:
+          #   - allowedTools is restricted to inline-comment + read-only
+          #     surfaces (no Bash arbitrary, no Write, no Edit — see the
+          #     claude_args block below)
+          #   - github_token is the workflow's PR-scoped default token
+          #     (pull-requests:write + issues:write + contents:read) —
+          #     NOT the broader VYOS_APP_ID token, which is only used for
+          #     the vyos-1x / reviewer-source checkouts
+          #   - the prompt explicitly marks PR content as untrusted with
+          #     <UNTRUSTED-PR-CONTENT> markers and tells Claude to treat
+          #     it as data, not instructions
+          #   - the workspace-wipe step removes CLAUDE.md / .claude/
+          #     before this step runs, so fork-controlled session
+          #     instructions can't be auto-loaded
+          #   - prepare bundles MD files via `git show HEAD:<path>` (blob
+          #     extraction, not `cp`) — symlinks resolve to their target
+          #     paths, not their content
+          #   - the action auto-scrubs Anthropic / cloud / GHA secrets
+          #     from subprocess envs when this input is set
+          allowed_non_write_users: '*'
           # claude-code-action@v1 removed the top-level `model` input; CLI
           # flags including --model now travel via `claude_args` (see the
           # claude_args: block at the bottom of this step).


### PR DESCRIPTION
## Change Summary

Set `allowed_non_write_users: '*'` on the Pass 2 step of the AI Validation workflow so the review actually runs on PRs from external contributors.

## Root cause

`anthropics/claude-code-action@v1.0.119` performs a write-permission check on `github.actor` before our skip logic runs ([permissions.ts](https://github.com/anthropics/claude-code-action/blob/main/src/github/validation/permissions.ts)). On `pull_request_target` the actor is the PR author; forks resolve to `read` and the action exits 1 with:

```
Checking permissions for actor: <login>
Permission level retrieved: read
Action failed with error: Actor does not have write permissions to the repository
```

Failure mode reproduced on [run 26541079685](https://github.com/vyos/vyos-documentation/actions/runs/26541079685) ([vyos-documentation#2061](https://github.com/vyos/vyos-documentation/pull/2061)). Cross-referencing recent runs of workflow id `259251949`: every external-contributor PR has been failing this way over the last 4+ weeks (`LiudmylaNad`, `teslazonda`, `scottlaird`), while internal members succeed. AI validation is currently dead for non-maintainer contributions — the workflow's entire purpose.

## Fix

The upstream action exposes `allowed_non_write_users` for exactly this case. When set with `github_token` provided (both true after this change), `checkWritePermissions` bypasses `getCollaboratorPermissionLevel` and the action proceeds. The action also auto-scrubs Anthropic / cloud / GHA secrets from subprocess envs when this input is set (per the upstream `action.yml` input description).

## Why `*` is safe in this workflow

The action's docs warn this should only be used "for workflows with very limited permissions." This workflow already satisfies that profile — full rationale inlined in the comment block above the new input. Summary:

- `allowedTools` restricted to inline-comment + read-only surfaces (no Bash arbitrary, no Write, no Edit)
- `github_token` is the workflow's PR-scoped default (pull-requests:write + issues:write + contents:read), NOT the broader `VYOS_APP_ID` token used for `vyos-1x` / reviewer-source checkouts
- Prompt marks PR content as untrusted via `<UNTRUSTED-PR-CONTENT>` markers and instructs Claude to treat it as data, not instructions
- Workspace-wipe step removes `CLAUDE.md` / `.claude/` before Pass 2 so fork-controlled session instructions can't be auto-loaded
- `prepare` bundles MD via `git show HEAD:<path>` (blob extraction, not `cp`) — symlinks resolve to their target path, never their content
- `persist-credentials: false` on every checkout

## Related Task(s)

n/a — surfaced via /superpowers:systematic-debugging on the [WD-1326](https://vyos.atlassian.net/browse/WD-1326)-adjacent CI failure in [vyos-documentation#2061](https://github.com/vyos/vyos-documentation/pull/2061).

## Related PR(s)

n/a

## Backport

Mergify backport to `circinus` and `sagitta` after merge — `ai-validation.yml` is fleet-synced across branches (see prior memory `session-2026-05-10-ai-validation-fleet-sync.md`).

## Checklist

- [x] Phase 0 local CodeRabbit review: 0 findings
- [x] Verified upstream action behavior via source code ([permissions.ts](https://github.com/anthropics/claude-code-action/blob/main/src/github/validation/permissions.ts) + [action.yml](https://github.com/anthropics/claude-code-action/blob/main/action.yml))
- [x] Verified failure mode + scope across last 30 workflow runs

🤖 Generated by [robots](https://vyos.io)

[WD-1326]: https://vyos.atlassian.net/browse/WD-1326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ