### PR TITLE
docs: Update RIP page to VyOS 1.5 standards

### DIFF
--- a/docs/configuration/protocols/rip.md
+++ b/docs/configuration/protocols/rip.md
@@ -73,8 +73,9 @@ set protocols rip neighbor 192.0.2.2
 
 **Enable passive mode for the specified interface.**
 
-A passive interface receives and processes incoming RIP updates as usual,
-but sends RIP updates only to explicitly configured unicast neighbors.
+This prevents the router from sending outgoing RIP updates on the
+interface, except to explicitly configured neighbors. Incoming RIP updates
+are still accepted and processed.
 ```
 
 Example:
@@ -85,7 +86,11 @@ set protocols rip passive-interface eth0
 
 ```{cfgcmd} set protocols rip passive-interface default
 
-**Enable passive mode for all RIP-enabled interfaces.**
+**Enable passive mode for all interfaces.**
+
+This prevents the router from sending outgoing RIP updates on all
+interfaces, except to explicitly configured neighbors. The router still
+receives and processes incoming RIP updates normally.
 ```
 
 Example:

--- a/docs/configuration/protocols/rip.md
+++ b/docs/configuration/protocols/rip.md
@@ -1,257 +1,449 @@
 ---
-lastproofread: '2021-10-04'
+myst:
+  html_meta:
+    description: |
+      RIP is a distance-vector routing protocol based on the Bellman-Ford
+      algorithm. It determines the best route based on hop count and
+      periodically advertises the routing table to neighbors.
+    keywords: rip, ripv1, ripv2, distance-vector, bellman-ford,
+      redistribute
 ---
 
 (rip)=
 
 # RIP
 
-{abbr}`RIP (Routing Information Protocol)` is a widely deployed interior gateway
-protocol. RIP was developed in the 1970s at Xerox Labs as part of the XNS
-routing protocol. RIP is a distance-vector protocol and is based on the
-Bellman-Ford algorithms. As a distance-vector protocol, RIP router send updates
-to its neighbors periodically, thus allowing the convergence to a known
-topology. In each update, the distance to any given network will be broadcast
-to its neighboring router.
+Developed in the 1970s at Xerox Labs, RIP is a distance-vector routing
+protocol based on the Bellman-Ford algorithm.
 
-Supported versions of RIP are:
+RIP determines the best route based on hop count (number of routers
+traversed). RIP-enabled routers periodically advertise their entire routing
+table to neighbors, along with the metric (hop count) for each destination.
 
-> - RIPv1 as described in {rfc}`1058`
-> - RIPv2 as described in {rfc}`2453`
+Supported versions:
 
-## General Configuration
+- RIPv1: As described in
+  [RFC 1058](https://datatracker.ietf.org/doc/html/rfc1058)
+- RIPv2: As described in
+  [RFC 2453](https://datatracker.ietf.org/doc/html/rfc2453)
+
+## General configuration
 
 ```{cfgcmd} set protocols rip network \<A.B.C.D/M\>
 
-This command enables RIP and sets the RIP enable interface by NETWORK.
-The interfaces which have addresses matching with NETWORK are enabled.
+**Enable RIP on all interfaces whose IP addresses fall within the specified
+network.**
 ```
 
+Example:
+
+```none
+set protocols rip network 192.0.2.0/24
+```
 
 ```{cfgcmd} set protocols rip interface \<interface\>
 
-This command specifies a RIP enabled interface by interface name. Both
-the sending and receiving of RIP packets will be enabled on the port
-specified in this command.
+**Enable RIP on the specified interface.**
+
+Once applied, the interface sends and receives RIP packets.
 ```
 
+Example:
+
+```none
+set protocols rip interface eth0
+```
 
 ```{cfgcmd} set protocols rip neighbor \<A.B.C.D\>
 
-This command specifies a RIP neighbor. When a neighbor doesn’t understand
-multicast, this command is used to specify neighbors. In some cases, not
-all routers will be able to understand multicasting, where packets are
-sent to a network or a group of addresses. In a situation where a neighbor
-cannot process multicast packets, it is necessary to establish a direct
-link between routers.
+**Configure a RIP neighbor using its IP address.**
+
+Use this command when a neighbor cannot process multicast RIP updates. Once
+configured, the local router sends updates directly to the specified
+neighbor as unicast packets.
 ```
 
+Example:
 
-```{cfgcmd} set protocols rip passive-interface interface \<interface\>
-
-This command sets the specified interface to passive mode. On passive mode
-interface, all receiving packets are processed as normal and VyOS does not
-send either multicast or unicast RIP packets except to RIP neighbors
-specified with neighbor command.
+```none
+set protocols rip neighbor 192.0.2.2
 ```
 
+```{cfgcmd} set protocols rip passive-interface \<interface\>
 
-```{cfgcmd} set protocols rip passive-interface interface default
+**Enable passive mode for the specified interface.**
 
-This command specifies all interfaces to passive mode.
+A passive interface receives and processes incoming RIP updates as usual,
+but sends RIP updates only to explicitly configured unicast neighbors.
 ```
 
-## Optional Configuration
+Example:
 
-```{cfgcmd} set protocols rip default-distance \<distance\>
-
-This command change the distance value of RIP. The distance range is 1 to 255.
-
-> :::{note}
-> Routes with a distance of 255 are effectively disabled and not
-> installed into the kernel.
-> :::
+```none
+set protocols rip passive-interface eth0
 ```
 
+```{cfgcmd} set protocols rip passive-interface default
 
-```{cfgcmd} set protocols rip network-distance \<A.B.C.D/M\> distance \<distance\>
-
-This command sets default RIP distance to a specified value when the routes
-source IP address matches the specified prefix.
+**Enable passive mode for all RIP-enabled interfaces.**
 ```
 
+Example:
+
+```none
+set protocols rip passive-interface default
+```
+
+## Optional configuration
+
+```{cfgcmd} set protocols rip default-distance \<1-255\>
+
+**Configure the administrative distance for all RIP-learned routes.**
+
+The administrative distance determines how RIP-learned routes are
+prioritized against routes learned from other sources (such as BGP, OSPF,
+or static routes) when multiple paths to the same destination exist.
+```
+
+```{note}
+Routes assigned a distance of 255 are disabled and will not be installed
+in the kernel forwarding table.
+```
+
+Example:
+
+```none
+set protocols rip default-distance 100
+```
+
+```{cfgcmd} set protocols rip network-distance \<A.B.C.D/M\> distance \<1-255\>
+
+**Configure an administrative distance for RIP routes whose source IP
+address falls within the specified network.**
+```
+
+Example:
+
+```none
+set protocols rip network-distance 192.0.2.0/24 distance 80
+```
 
 ```{cfgcmd} set protocols rip network-distance \<A.B.C.D/M\> access-list \<name\>
 
-This command can be used with previous command to sets default RIP distance
-to specified value when the route source IP address matches the specified
-prefix and the specified access-list.
+**Restrict administrative distance assignments to RIP routes whose source
+IP address matches the specified network and the route itself matches the
+specified access-list.**
 ```
 
+Example:
+
+```none
+set protocols rip network-distance 192.0.2.0/24 distance 80
+set protocols rip network-distance 192.0.2.0/24 access-list 10
+```
 
 ```{cfgcmd} set protocols rip default-information originate
 
-This command generate a default route into the RIP.
+**Generate and advertise a default route (`0.0.0.0/0`) to all RIP
+neighbors.**
 ```
 
+Example:
 
-```{cfgcmd} set protocols rip distribute-list access-list \<in|out\> \<number\>
-
-This command can be used to filter the RIP path using access lists.
-{cfgcmd}`in` and {cfgcmd}`out` this is the direction in which the access
-lists are applied.
+```none
+set protocols rip default-information originate
 ```
 
+```{cfgcmd} set protocols rip distribute-list access-list \<in|out\> \<0-4294967295\>
 
-```{cfgcmd} set protocols rip distribute-list interface \<interface\> access-list \<in|out\> \<number\>
+**Apply an access-list to filter RIP routes in the inbound or outbound
+direction.**
 
-This command allows you apply access lists to a chosen interface to
-filter the RIP path.
+- `in`: Filters routes received from RIP neighbors.
+- `out`: Filters routes advertised to RIP neighbors.
 ```
 
+Example:
+
+```none
+set protocols rip distribute-list access-list in 20
+```
+
+```{cfgcmd} set protocols rip distribute-list interface \<interface\> access-list \<in|out\> \<0-4294967295\>
+
+**Apply an access-list to filter RIP routes in the inbound or outbound
+direction on the specified interface.**
+
+- `in`: Filters routes received from RIP neighbors on this interface.
+- `out`: Filters routes advertised to RIP neighbors on this interface.
+```
+
+Example:
+
+```none
+set protocols rip distribute-list interface eth0 access-list in 20
+```
 
 ```{cfgcmd} set protocols rip distribute-list prefix-list \<in|out\> \<name\>
 
-This command can be used to filter the RIP path using prefix lists.
-{cfgcmd}`in` and {cfgcmd}`out` this is the direction in which the prefix
-lists are applied.
+**Apply a prefix-list to filter RIP routes in the inbound or outbound
+direction.**
+
+- `in`: Filters routes received from RIP neighbors.
+- `out`: Filters routes advertised to RIP neighbors.
 ```
 
+Example:
+
+```none
+set protocols rip distribute-list prefix-list in INBOUND-FILTER
+```
 
 ```{cfgcmd} set protocols rip distribute-list interface \<interface\> prefix-list \<in|out\> \<name\>
 
-This command allows you apply prefix lists to a chosen interface to
-filter the RIP path.
+**Apply a prefix-list to filter RIP routes on the specified interface in
+the inbound or outbound direction.**
+
+- `in`: Filters routes received from RIP neighbors on this interface.
+- `out`: Filters routes advertised to RIP neighbors on this interface.
 ```
 
+Example:
+
+```none
+set protocols rip distribute-list interface eth0 prefix-list in RIP-IN
+```
 
 ```{cfgcmd} set protocols rip route \<A.B.C.D/M\>
 
-This command is specific to FRR and VyOS. The route command makes a static
-route only inside RIP. This command should be used only by advanced users
-who are particularly knowledgeable about the RIP protocol. In most cases,
-we recommend creating a static route in VyOS and redistributing it in RIP
-using {cfgcmd}`redistribute static`.
+**Add a static route to the RIP routing process.**
+
+The route is created only inside RIP.
+
+This command is specific to FRR and VyOS and should only be used by
+advanced users with a strong understanding of the RIP protocol.
+
+For most deployments, the recommended approach is to create a standard
+static route and redistribute it into RIP using
+`set protocols rip redistribute static`.
 ```
 
+Example:
 
-```{cfgcmd} set protocols rip timers update \<seconds\>
-
-This command specifies the update timer. Every update timer seconds, the
-RIP process is awakened to send an unsolicited response message containing
-the complete routing table to all neighboring RIP routers. The time range
-is 5 to 2147483647. The default value is 30 seconds.
+```none
+set protocols rip route 192.0.2.0/24
 ```
 
+```{cfgcmd} set protocols rip timers update \<5-2147483647\>
 
-```{cfgcmd} set protocols rip timers timeout \<seconds\>
+**Configure the RIP update timer, in seconds.**
 
-This command specifies the timeout timer. Upon expiration of the timeout,
-the route is no longer valid; however, it is retained in the routing table
-for a short time so that neighbors can be notified that the route has been
-dropped. The time range is 5 to 2147483647. The default value is 180
-seconds.
+The update timer defines how often the router sends unsolicited Response
+messages to its RIP neighbors. Each Response contains the complete RIP
+routing table.
+
+The default value is 30 seconds.
 ```
 
+Example:
 
-```{cfgcmd} set protocols rip timers garbage-collection \<seconds\>
-
-This command specifies the garbage-collection timer. Upon expiration of
-the garbage-collection timer, the route is finally removed from the
-routing table. The time range is 5 to 2147483647. The default value is 120
-seconds.
+```none
+set protocols rip timers update 60
 ```
 
-## Redistribution Configuration
+```{cfgcmd} set protocols rip timers timeout \<5-2147483647\>
 
-```{cfgcmd} set protocols rip redistribute \<route source\>
+**Configure the RIP route timeout, in seconds.**
 
-This command redistributes routing information from the given route source
-into the RIP tables. There are five modes available for route source: bgp,
-connected, kernel, ospf, static.
+If a route is not refreshed by an incoming update within this interval, it
+becomes invalid. The router temporarily retains the invalid route in the
+RIP routing table so that neighbors learn the route has been dropped.
+
+The default value is 180 seconds.
 ```
 
+Example:
 
-```{cfgcmd} set protocols rip redistribute \<route source\> metric \<metric\>
-
-This command specifies metric for redistributed routes from the given route
-source. There are five modes available for route source: bgp, connected,
-kernel, ospf, static. The metric range is 1 to 16.
+```none
+set protocols rip timers timeout 300
 ```
 
+```{cfgcmd} set protocols rip timers garbage-collection \<5-2147483647\>
 
-```{cfgcmd} set protocols rip redistribute \<route source\> route-map \<name\>
+**Configure the RIP garbage-collection timer, in seconds.**
 
-This command allows to use route map to filter redistributed routes from
-the given route source. There are five modes available for route source:
-bgp, connected, kernel, ospf, static.
+This timer starts when a route becomes invalid. When the timer expires,
+the route is removed from the routing table.
+
+The default value is 120 seconds.
 ```
 
+Example:
 
-```{cfgcmd} set protocols rip default-metric \<metric\>
-
-This command modifies the default metric (hop count) value for redistributed
-routes. The metric range is 1 to 16. The default value is 1. This command
-does not affect connected route even if it is redistributed by
-{cfgcmd}`redistribute connected`. To modify connected routes metric
-value, please use {cfgcmd}`redistribute connected metric`.
+```none
+set protocols rip timers garbage-collection 60
 ```
 
-## Interfaces Configuration
+## Redistribution configuration
 
-```{cfgcmd} set interfaces \<inttype\> \<intname\> ip rip authentication plaintext-password \<text\>
+```{cfgcmd} set protocols rip redistribute \<babel|bgp|connected|isis|kernel|nhrp|ospf|static\>
 
-This command sets the interface with RIP simple password authentication.
-This command also sets authentication string. The string must be shorter
-than 16 characters.
+**Redistribute routes from the specified source into RIP.**
+
+Routes learned from the chosen source are imported into the RIP routing
+table and advertised to RIP neighbors as if they had been learned through
+RIP itself.
+
+The supported sources are:
+
+- `babel`: Routes learned via Babel.
+- `bgp`: Routes learned via BGP.
+- `connected`: Directly connected routes.
+- `isis`: Routes learned via IS-IS.
+- `kernel`: Routes installed in the kernel routing table.
+- `nhrp`: Routes learned via NHRP.
+- `ospf`: Routes learned via OSPF.
+- `static`: Routes configured statically.
 ```
 
+Example:
 
-```{cfgcmd} set interfaces \<inttype\> \<intname\> ip rip authentication md5 \<id\> password \<text\>
-
-This command sets the interface with RIP MD5 authentication. This command
-also sets MD5 Key. The key must be shorter than 16 characters.
+```none
+set protocols rip redistribute static
 ```
 
+```{cfgcmd} set protocols rip redistribute \<babel|bgp|connected|isis|kernel|nhrp|ospf|static\> metric \<1-16\>
 
-```{cfgcmd} set interfaces \<inttype\> \<intname\> ip rip split-horizon disable
-
-This command disables split-horizon on the interface. By default, VyOS does
-not advertise RIP routes out the interface over which they were learned
-(split horizon).3
+**Configure the metric for routes redistributed from the specified
+source.**
 ```
 
+Example:
 
-```{cfgcmd} set interfaces \<inttype\> \<intname\> ip rip split-horizon poison-reverse
-
-This command enables poison-reverse on the interface. If both poison reverse
-and split horizon are enabled, then VyOS advertises the learned routes
-as unreachable over the interface on which the route was learned.
+```none
+set protocols rip redistribute static metric 5
 ```
 
-## Operational Mode Commands
+```{cfgcmd} set protocols rip redistribute \<babel|bgp|connected|isis|kernel|nhrp|ospf|static\> route-map \<name\>
+
+**Apply a route-map to filter routes redistributed from the specified
+source.**
+```
+
+Example:
+
+```none
+set protocols rip redistribute static route-map RIP-REDISTRIBUTE
+```
+
+```{cfgcmd} set protocols rip default-metric \<1-16\>
+
+**Configure the default metric (hop count) applied to redistributed
+routes.**
+
+The default value is 1.
+```
+
+```{note}
+This command does not affect connected routes redistributed via
+`set protocols rip redistribute connected`. To configure the metric for
+connected routes, use `set protocols rip redistribute connected metric`
+explicitly.
+```
+
+Example:
+
+```none
+set protocols rip default-metric 5
+```
+
+## Interfaces configuration
+
+```{cfgcmd} set protocols rip interface \<interface\> authentication plaintext-password \<text\>
+
+**Enable simple password authentication for RIPv2 on the specified
+interface and set a password.**
+
+The password must not exceed 16 characters.
+```
+
+Example:
+
+```none
+set protocols rip interface eth0 authentication plaintext-password vyos-secret
+```
+
+```{cfgcmd} set protocols rip interface \<interface\> authentication md5 \<id\> password \<text\>
+
+**Enable {abbr}`MD5 (Message-Digest Algorithm 5)` authentication for RIPv2
+on the specified interface and set the MD5 key.**
+
+The MD5 key must not exceed 16 characters.
+```
+
+Example:
+
+```none
+set protocols rip interface eth0 authentication md5 1 password vyos-secret
+```
+
+```{cfgcmd} set protocols rip interface \<interface\> split-horizon disable
+
+**Disable split-horizon on the specified interface.**
+
+By default, VyOS does not advertise RIP routes back through the interface
+on which they were learned (split horizon). This command turns off that
+default.
+```
+
+Example:
+
+```none
+set protocols rip interface eth0 split-horizon disable
+```
+
+```{cfgcmd} set protocols rip interface \<interface\> split-horizon poison-reverse
+
+**Enable split horizon with poison reverse on the specified interface.**
+
+If enabled, the router advertises the learned routes as unreachable on the
+interface where they were learned.
+```
+
+Example:
+
+```none
+set protocols rip interface eth0 split-horizon poison-reverse
+```
+
+## Operational mode commands
 
 ```{opcmd} show ip rip
 
-This command displays RIP routes.
+**Show all RIP routes.**
 ```
+
 ```none
-Codes: R - RIP, C - connected, S - Static, O - OSPF, B - BGP
+vyos@vyos-1:~$ show ip rip
+Codes: K - kernel route, C - connected, L - local, S - static,
+       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
+       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
+       f - OpenFabric, t - Table-Direct
 Sub-codes:
       (n) - normal, (s) - static, (d) - default, (r) - redistribute,
       (i) - interface
 
-     Network            Next Hop         Metric From            Tag Time
-C(i) 10.0.12.0/24       0.0.0.0               1 self              0
-C(i) 10.0.13.0/24       0.0.0.0               1 self              0
-R(n) 10.0.23.0/24       10.0.12.2             2 10.0.12.2         0 02:53
+Network            Next Hop         Metric From            Tag Time
+C(i) 192.0.2.0/24       0.0.0.0               1 self              0
+C(i) 198.51.100.0/24    0.0.0.0               1 self              0
+R(n) 203.0.113.0/24     192.0.2.2             2 192.0.2.2         0 02:53
 ```
 
 ```{opcmd} show ip rip status
 
-The command displays current RIP status. It includes RIP timer, filtering,
-version, RIP enabled interface and RIP peer information.
+**Show the current RIP status.**
 ```
+
 ```none
 Routing Protocol is "rip"
   Sending updates every 30 seconds with +/-50%, next due in 11 seconds
@@ -265,30 +457,33 @@ Routing Protocol is "rip"
     eth0             2     1 2
     eth2             2     1 2
   Routing for Networks:
-    10.0.12.0/24
+    192.0.2.0/24
     eth0
   Routing Information Sources:
     Gateway          BadPackets BadRoutes  Distance Last Update
-    10.0.12.2                0         0       120   00:00:11
+    192.0.2.2               0         0       120   00:00:11
   Distance: (default is 120)
 ```
 
-## Configuration Example
+## Example
 
-Simple RIP configuration using 2 nodes and redistributing connected interfaces.
+The following example demonstrates a basic RIP configuration between two
+routers, where directly connected networks are redistributed into RIP.
 
 **Node 1:**
 
 ```none
-set interfaces loopback address 10.1.1.1/32
-set protocols rip network 192.168.0.0/24
+set interfaces ethernet eth0 address '198.51.100.1/24'
+set interfaces loopback lo address '192.0.2.1/32'
+set protocols rip network 198.51.100.0/24
 set protocols rip redistribute connected
 ```
 
 **Node 2:**
 
 ```none
-set interfaces loopback address 10.2.2.2/32
-set protocols rip network 192.168.0.0/24
+set interfaces ethernet eth0 address '198.51.100.2/24'
+set interfaces loopback lo address '192.0.2.2/32'
+set protocols rip network 198.51.100.0/24
 set protocols rip redistribute connected
 ```


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
This PR refactors the RIP page to comply with the current VyOS documentation style guide.

Changes:

* AI & SEO Context: Added :description: and :keywords: metadata tags.
* Content: Proofread and improved.
* Technical accuracy: Verified commands against VyOS 1.5.
* Added examples for all commands. 

Corrected syntax for:

* set protocols rip passive-interface interface <interface>
* set protocols rip passive-interface interface default
* set protocols rip distribute-list access-list <in|out>
* set protocols rip distribute-list interface  access-list <in|out> 
* set protocols rip distribute-list prefix-list <in|out>
* set protocols rip distribute-list interface  prefix-list <in|out> 
* set interfaces <inttype> <intname> ip rip authentication plaintext-password <text>
* set interfaces <inttype> <intname> ip rip authentication md5 <id> password <text>
* set interfaces <inttype> <intname> ip rip split-horizon disable
* set interfaces <inttype> <intname> ip rip split-horizon poison-reverse

Added value range for:

* set protocols rip network-distance <A.B.C.D/M> distance <1-255>
* set protocols rip distribute-list access-list <in|out> <0-4294967295> 

Added available values for:

* set protocols rip redistribute <route source>

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->


## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document
- [x] The style guide checklist was applied