### PR TITLE
Fix URL for AMD64 Rolling Release updates

### DIFF
--- a/docs/installation/update.md
+++ b/docs/installation/update.md
@@ -91,7 +91,7 @@ configured appropriately for your installed release.
 For updates to the Rolling Release for AMD64, the following URL may be
 used:
 
-<https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/current/version.json>
+<https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/rolling/version.json>
 :::
 
 :::{hint}


### PR DESCRIPTION
## Change Summary
Updated URL for the Rolling Release version.json file.


## Checklist:
- [x ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document