### PR TITLE
docs: Update MPLS page to VyOS 1.5 standards

### DIFF
--- a/docs/configuration/protocols/mpls.md
+++ b/docs/configuration/protocols/mpls.md
@@ -1,285 +1,773 @@
+---
+myst:
+  html_meta:
+    description: |
+      Multiprotocol Label Switching (MPLS) is a packet-forwarding method
+      that forwards traffic using exact-match lookups on MPLS labels
+      rather than IP address lookups.
+    keywords: mpls, ldp, label distribution protocol, lsp, label switching
+---
+
 (mpls)=
 
 # MPLS
 
-{abbr}`MPLS (Multi-Protocol Label Switching)` is a packet forwarding paradigm
-which differs from regular IP forwarding. Instead of IP addresses being used to
-make the decision on finding the exit interface, a router will instead use an
-exact match on a 32 bit/4 byte header called the MPLS label. This label is
-inserted between the ethernet (layer 2) header and the IP (layer 3) header.
-One can statically or dynamically assign label allocations, but we will focus
-on dynamic allocation of labels using some sort of label distribution protocol
-(such as the aptly named Label Distribution Protocol / LDP, Resource Reservation
-Protocol / RSVP, or Segment Routing through OSPF/ISIS). These protocols allow
-for the creation of a unidirectional/unicast path called a labeled switched
-path (initialized as LSP) throughout the network that operates very much like
-a tunnel through the network. An easy way of thinking about how an MPLS LSP
-actually forwards traffic throughout a network is to think of a GRE tunnel.
-They are not the same in how they operate, but they are the same in how they
-handle the tunneled packet. It would be good to think of MPLS as a tunneling
-technology that can be used to transport many different types of packets, to
-aid in traffic engineering by allowing one to specify paths throughout the
-network (using RSVP or SR), and to generally allow for easier intra/inter
-network transport of data packets.
+{abbr}`MPLS (Multiprotocol Label Switching)` is a packet-forwarding method
+that differs from traditional IP forwarding. Instead of performing IP address
+lookups, MPLS routers forward traffic using exact-match lookups on MPLS labels
+inserted between the Layer 2 (Ethernet) and Layer 3 (IP) headers.
 
-For more information on how MPLS label switching works, please go visit
-[Wikipedia (MPLS)].
+MPLS labels can be assigned statically or dynamically. This section focuses on
+dynamic label allocation using label distribution protocols such as the
+{abbr}`LDP (Label Distribution Protocol)` and
+{abbr}`RSVP-TE (Resource Reservation Protocol for Traffic Engineering)`, or
+via {abbr}`SR (Segment Routing)` extensions to OSPF or IS-IS.
 
-:::{note}
-MPLS support in VyOS is not finished yet, and therefore its
-functionality is limited. Currently there is no support for MPLS enabled VPN
-services such as L2VPNs and mVPNs. RSVP support is also not present as the
-underlying routing stack (FRR) does not implement it. Currently VyOS
-implements LDP as described in RFC 5036; other LDP standard are the
-following ones: RFC 6720, RFC 6667, RFC 5919, RFC 5561, RFC 7552, RFC 4447.
-Because MPLS is already available (FRR also supports RFC 3031).
-:::
+These protocols establish a unidirectional path called a
+{abbr}`LSP (Label-Switched Path)` across the network. When a packet enters
+the MPLS network, the ingress router pushes an MPLS label onto it based on
+the destination and forwards the packet along the LSP. Each intermediate
+router uses the incoming label to look up the outgoing interface and next
+label value, swaps the label, and forwards the packet on that interface. The
+egress router pops the label and forwards the original packet using normal
+IP routing.
 
-## Label Distribution Protocol
+## MPLS support in VyOS
 
-The {abbr}`MPLS (Multi-Protocol Label Switching)` architecture does not assume
-a single protocol to create MPLS paths. VyOS supports the Label Distribution
-Protocol (LDP) as implemented by FRR, based on {rfc}`5036`.
+MPLS support in VyOS is under development, so its feature set is currently
+limited. Basic MPLS forwarding is functional, as the underlying FRR routing
+stack supports [RFC 3031](https://datatracker.ietf.org/doc/html/rfc3031).
 
-{abbr}`LDP (Label Distribution Protocol)` is a TCP based MPLS signaling protocol
-that distributes labels creating MPLS label switched paths in a dynamic manner.
-LDP is not a routing protocol, as it relies on other routing protocols for
-forwarding decisions. LDP cannot bootstrap itself, and therefore relies on said
-routing protocols for communication with other routers that use LDP.
+Supported features:
 
-In order to allow for LDP on the local router to exchange label advertisements
-with other routers, a TCP session will be established between automatically
-discovered and statically assigned routers. LDP will try to establish a TCP
-session to the **transport address** of other routers. Therefore for LDP to
-function properly please make sure the transport address is shown in the
-routing table and reachable to traffic at all times.
+- **LDP**: Implemented according to
+  [RFC 5036](https://datatracker.ietf.org/doc/html/rfc5036).
 
-It is highly recommended to use the same address for both the LDP router-id and
-the discovery transport address, but for VyOS MPLS LDP to work both parameters
-must be explicitly set in the configuration.
+```{note}
+Other related LDP standards include RFCs
+[6720](https://datatracker.ietf.org/doc/html/rfc6720),
+[6667](https://datatracker.ietf.org/doc/html/rfc6667),
+[5919](https://datatracker.ietf.org/doc/html/rfc5919),
+[5561](https://datatracker.ietf.org/doc/html/rfc5561), and
+[7552](https://datatracker.ietf.org/doc/html/rfc7552).
+```
 
-Another thing to keep in mind with LDP is that much like BGP, it is a protocol
-that runs on top of TCP. It however does not have an ability to do something
-like a refresh capability like BGPs route refresh capability. Therefore one
-might have to reset the neighbor for a capability change or a configuration
-change to work.
+Current limitations:
 
-## Configuration Options
+- **MPLS VPNs**: No support yet for MPLS-enabled VPN services, such as
+  L2VPNs and mVPNs.
+- **RSVP-TE**: Not supported, as the underlying FRR stack does not currently
+  implement it.
+
+## Label Distribution Protocol (LDP)
+
+MPLS supports various protocols for path creation. VyOS implements LDP via
+the underlying FRR routing stack, per
+[RFC 5036](https://datatracker.ietf.org/doc/html/rfc5036).
+
+LDP is a TCP-based MPLS signaling protocol that dynamically distributes
+labels to create label-switched paths. It is not a routing protocol and
+depends on existing routing protocols for forwarding decisions and
+communication with other LDP-enabled routers.
+
+To exchange label advertisements, LDP establishes TCP sessions with
+automatically discovered or statically configured neighbors. Each session is
+formed using the peer's transport address, which must be present in the routing
+table and continuously reachable.
+
+```{note}
+It is recommended to use the same address for both the LDP router
+ID and the discovery transport address. For MPLS LDP to function in VyOS,
+both parameters must be explicitly configured.
+```
+
+```{note}
+LDP has no mechanism to refresh an existing session. To apply a
+configuration change or a change to negotiated session capabilities, the
+LDP neighbor must be reset on the local router.
+```
+
+## Configuration
 
 ```{cfgcmd} set protocols mpls interface \<interface\>
 
-Use this command to enable MPLS processing on the interface you define.
+**Enable MPLS on the specified interface.**
 ```
 
+Example:
+
+```none
+set protocols mpls interface eth1
+```
+
+```{cfgcmd} set protocols mpls parameters no-propagate-ttl
+
+**Disable propagation of the IP TTL into the MPLS header at label
+imposition.**
+```
+
+Example:
+
+```none
+set protocols mpls parameters no-propagate-ttl
+```
+
+```{cfgcmd} set protocols mpls parameters maximum-ttl \<1-255\>
+
+**Configure the maximum TTL value for MPLS packets.**
+
+This value is used when the TTL is not propagated from the IP header.
+The default is 255.
+```
+
+Example:
+
+```none
+set protocols mpls parameters maximum-ttl 15
+```
 
 ```{cfgcmd} set protocols mpls ldp interface \<interface\>
 
-Use this command to enable LDP on the interface you define.
+**Enable LDP on the specified interface.**
 ```
 
+Example:
+
+```none
+set protocols mpls ldp interface eth1
+```
+
+```{cfgcmd} set protocols mpls ldp interface \<interface\> disable-establish-hello
+
+**Disable the triggered Hello that the router sends on the specified
+interface in response to receiving an LDP Hello from a peer.**
+```
+
+Example:
+
+```none
+set protocols mpls ldp interface eth0 disable-establish-hello
+```
 
 ```{cfgcmd} set protocols mpls ldp router-id \<address\>
 
-Use this command to configure the IP address used as the LDP router-id of the
-local device.
+**Configure the IP address used as the LDP router ID for the local device.**
 ```
 
+Example:
+
+```none
+set protocols mpls ldp router-id 192.0.2.1
+```
 
 ```{cfgcmd} set protocols mpls ldp discovery transport-ipv4-address \<address\>
 
+**Configure the IPv4 transport address for IPv4 LDP connections.**
 ```
+
+Example:
+
+```none
+set protocols mpls ldp discovery transport-ipv4-address 192.0.2.1
+```
+
 ```{cfgcmd} set protocols mpls ldp discovery transport-ipv6-address \<address\>
 
-Use this command to set the IPv4 or IPv6 transport-address used by LDP.
+**Configure the IPv6 transport address for IPv6 LDP connections.**
 ```
 
-```{cfgcmd} set protocols mpls ldp neighbor \<address\> password \<password\>
+Example:
 
-Use this command to configure authentication for LDP peers. Set the
-IP address of the LDP peer and a password that should be shared in
-order to become neighbors.
+```none
+set protocols mpls ldp discovery transport-ipv6-address 2001:db8::1
 ```
 
-```{cfgcmd} set protocols mpls ldp neighbor \<address\> session-holdtime \<seconds\>
+```{cfgcmd} set protocols mpls ldp neighbor \<ipv4-address\> password \<password\>
 
-Use this command to configure a specific session hold time for LDP peers.
-Set the IP address of the LDP peer and a session hold time that should be
-configured for it. You may have to reset the neighbor for this to work.
+**Configure authentication for the LDP session with the specified
+neighbor.**
 ```
 
-```{cfgcmd} set protocols mpls ldp neighbor \<address\> ttl-security \<disable | hop count\>
-
-Use this command to enable, disable, or specify hop count for TTL security
-for LDP peers. By default the value is set to 255 (or max TTL).
+```{note}
+For the session to establish successfully, both peers must be configured
+with the same password.
 ```
 
-```{eval-rst}
-.. cfgcmd:: set protocols mpls ldp discovery hello-ipv4-interval <seconds>
-.. cfgcmd:: set protocols mpls ldp discovery hello-ipv4-holdtime <seconds>
-.. cfgcmd:: set protocols mpls ldp discovery hello-ipv6-interval <seconds>
-.. cfgcmd:: set protocols mpls ldp discovery hello-ipv6-holdtime <seconds>
+Example:
 
-  Use these commands if you would like to set the discovery hello and hold time
-  parameters.
+```none
+set protocols mpls ldp neighbor 192.0.2.2 password mysharedsecret
 ```
 
-```{eval-rst}
-.. cfgcmd:: set protocols mpls ldp discovery session-ipv4-holdtime <seconds>
-.. cfgcmd:: set protocols mpls ldp discovery session-ipv6-holdtime <seconds>
+```{cfgcmd} set protocols mpls ldp neighbor \<ipv4-address\> session-holdtime \<15-65535\>
 
-  Use this command if you would like to set the TCP session hold time intervals.
+**Configure the LDP session hold time, in seconds, advertised to the
+specified neighbor.**
+
+The neighbor must be reset for this change to take effect.
 ```
 
-```{eval-rst}
-.. cfgcmd:: set protocols mpls ldp import ipv4 import-filter filter-access-list
-   <access list number>
-.. cfgcmd:: set protocols mpls ldp import ipv6 import-filter filter-access-list6
-   <access list number>
+Example:
 
-  Use these commands to control the importing of forwarding equivalence classes
-  (FECs) for LDP from neighbors. This would be useful for example on only
-  accepting the labeled routes that are needed and not ones that are not
-  needed, such as accepting loopback interfaces and rejecting all others.
+```none
+set protocols mpls ldp neighbor 192.0.2.2 session-holdtime 180
 ```
 
-```{eval-rst}
-.. cfgcmd:: set protocols mpls ldp export ipv4 export-filter filter-access-list
-   <access list number>
-.. cfgcmd:: set protocols mpls ldp export ipv6 export-filter filter-access-list6
-   <access list number>
+```{cfgcmd} set protocols mpls ldp neighbor \<ipv4-address\> ttl-security \<disable | hop-count\>
 
-  Use these commands to control the exporting of forwarding equivalence classes
-  (FECs) for LDP to neighbors. This would be useful for example on only
-  announcing the labeled routes that are needed and not ones that are not
-  needed, such as announcing loopback interfaces and no others.
+**Configure TTL security ({abbr}`GTSM (Generalized TTL Security Mechanism)`)
+for the LDP session with the specified neighbor.**
+
+Use `disable` to turn off TTL security, or set a hop-count value (1-254) to
+restrict which incoming packets are accepted based on their TTL.
 ```
 
-```{eval-rst}
-.. cfgcmd:: set protocols mpls ldp export ipv4 explicit-null
-.. cfgcmd:: set protocols mpls ldp export ipv6 explicit-null
+Example:
 
-  Use this command if you would like for the router to advertise FECs with a
-  label of 0 for explicit null operations.
+```none
+set protocols mpls ldp neighbor 192.0.2.2 ttl-security 5
 ```
 
-```{eval-rst}
-.. cfgcmd:: set protocols mpls ldp allocation ipv4 access-list <access list number>
-.. cfgcmd:: set protocols mpls ldp allocation ipv6 access-list6 <access list number>
+```{cfgcmd} set protocols mpls ldp discovery hello-ipv4-interval \<1-65535\>
 
-  Use this command if you would like to control the local FEC allocations for
-  LDP. A good example would be for your local router to not allocate a label for
-  everything. Just a label for what it's useful. A good example would be just a
-  loopback label.
+**Configure the interval, in seconds, at which the router sends IPv4 LDP
+Hello messages.**
+```
+
+Example:
+
+```none
+set protocols mpls ldp discovery hello-ipv4-interval 5
+```
+
+```{cfgcmd} set protocols mpls ldp discovery hello-ipv4-holdtime \<1-65535\>
+
+**Configure the hold time, in seconds, advertised in IPv4 LDP Hello
+messages.**
+```
+
+Example:
+
+```none
+set protocols mpls ldp discovery hello-ipv4-holdtime 15
+```
+
+```{cfgcmd} set protocols mpls ldp discovery hello-ipv6-interval \<1-65535\>
+
+**Configure the interval, in seconds, at which the router sends IPv6 LDP
+Hello messages.**
+```
+
+Example:
+
+```none
+set protocols mpls ldp discovery hello-ipv6-interval 5
+```
+
+```{cfgcmd} set protocols mpls ldp discovery hello-ipv6-holdtime \<1-65535\>
+
+**Configure the hold time, in seconds, advertised in IPv6 LDP Hello
+messages.**
+```
+
+Example:
+
+```none
+set protocols mpls ldp discovery hello-ipv6-holdtime 15
+```
+
+```{cfgcmd} set protocols mpls ldp discovery session-ipv4-holdtime \<15-65535\>
+
+**Configure the LDP session hold time, in seconds, advertised in IPv4 LDP
+Initialization messages.**
+```
+
+Example:
+
+```none
+set protocols mpls ldp discovery session-ipv4-holdtime 180
+```
+
+```{cfgcmd} set protocols mpls ldp discovery session-ipv6-holdtime \<15-65535\>
+
+**Configure the LDP session hold time, in seconds, advertised in IPv6 LDP
+Initialization messages.**
+```
+
+Example:
+
+```none
+set protocols mpls ldp discovery session-ipv6-holdtime 180
+```
+
+```{cfgcmd} set protocols mpls ldp import ipv4 import-filter filter-access-list \<1-2699\>
+
+**Filter the IPv4 label bindings (associations between an IPv4 prefix and
+an MPLS label) from LDP peers using the specified access list.**
+
+Only label bindings whose prefix is permitted by the access list are
+accepted.
+```
+
+Example:
+
+```none
+set protocols mpls ldp import ipv4 import-filter filter-access-list 10
+```
+
+```{cfgcmd} set protocols mpls ldp import ipv4 import-filter neighbor-access-list \<1-2699\>
+
+**Filter the IPv4 label bindings (associations between an IPv4 prefix
+and an MPLS label) from LDP peers using the specified access list.**
+
+Only label bindings received from a peer whose IPv4 address is permitted
+by the access list are accepted.
+```
+
+Example:
+
+```none
+set protocols mpls ldp import ipv4 import-filter neighbor-access-list 20
+```
+
+```{cfgcmd} set protocols mpls ldp import ipv6 import-filter filter-access-list6 \<1-2699\>
+
+**Filter the IPv6 label bindings (associations between an IPv6 prefix and
+an MPLS label) from LDP peers using the specified access list.**
+
+Only label bindings whose prefix is permitted by the access list are
+accepted.
+```
+
+Example:
+
+```none
+set protocols mpls ldp import ipv6 import-filter filter-access-list6 10
+```
+
+```{cfgcmd} set protocols mpls ldp import ipv6 import-filter neighbor-access-list6 \<1-2699\>
+
+**Filter the IPv6 label bindings (associations between an IPv6 prefix
+and an MPLS label) from LDP peers using the specified access list.**
+
+Only label bindings received from a peer whose IPv6 address is permitted
+by the access list are accepted.
+```
+
+Example:
+
+```none
+set protocols mpls ldp import ipv6 import-filter neighbor-access-list6 20
+```
+
+```{cfgcmd} set protocols mpls ldp export ipv4 export-filter filter-access-list \<1-2699\>
+
+**Filter the IPv4 label bindings (associations between an IPv4 prefix and
+an MPLS label) advertised to LDP peers using the specified access list.**
+
+Only label bindings whose prefix is permitted by the access list are
+advertised.
+```
+
+Example:
+
+```none
+set protocols mpls ldp export ipv4 export-filter filter-access-list 10
+```
+
+```{cfgcmd} set protocols mpls ldp export ipv4 export-filter neighbor-access-list \<1-2699\>
+
+**Filter the IPv4 label bindings (associations between an IPv4 prefix
+and an MPLS label) advertised to LDP peers using the specified access
+list.**
+
+Label bindings are advertised only to peers whose IPv4 address is
+permitted by the access list.
+```
+
+Example:
+
+```none
+set protocols mpls ldp export ipv4 export-filter neighbor-access-list 20
+```
+
+```{cfgcmd} set protocols mpls ldp export ipv6 export-filter filter-access-list6 \<1-2699\>
+
+**Filter the IPv6 label bindings (associations between an IPv6 prefix and
+an MPLS label) advertised to LDP peers using the specified access list.**
+
+Only label bindings whose prefix is permitted by the access list are
+advertised.
+```
+
+Example:
+
+```none
+set protocols mpls ldp export ipv6 export-filter filter-access-list6 10
+```
+
+```{cfgcmd} set protocols mpls ldp export ipv6 export-filter neighbor-access-list6 \<1-2699\>
+
+**Filter the IPv6 label bindings (associations between an IPv6 prefix
+and an MPLS label) advertised to LDP peers using the specified access
+list.**
+
+Label bindings are advertised only to peers whose IPv6 address is
+permitted by the access list.
+```
+
+Example:
+
+```none
+set protocols mpls ldp export ipv6 export-filter neighbor-access-list6 20
+```
+
+```{cfgcmd} set protocols mpls ldp export ipv4 explicit-null
+
+**Configure the router to advertise the Explicit Null label for its
+directly connected IPv4 prefixes to LDP neighbors.**
+
+This instructs the penultimate-hop router to forward labeled packets
+unchanged without removing the MPLS label.
+```
+
+Example:
+
+```none
+set protocols mpls ldp export ipv4 explicit-null
+```
+
+```{cfgcmd} set protocols mpls ldp export ipv6 explicit-null
+
+**Configure the router to advertise the Explicit Null label for its
+directly connected IPv6 prefixes to LDP neighbors.**
+
+This instructs the penultimate-hop router to forward labeled packets
+unchanged without removing the MPLS label.
+```
+
+Example:
+
+```none
+set protocols mpls ldp export ipv6 explicit-null
+```
+
+```{cfgcmd} set protocols mpls ldp allocation ipv4 access-list \<1-2699\>
+
+**Restrict MPLS label allocation to IPv4 prefixes permitted by the
+specified access list.**
+
+By default, LDP allocates a label for every IPv4 prefix in the routing
+table. A common best practice is to limit allocation to loopback
+addresses.
+```
+
+Example:
+
+```none
+set protocols mpls ldp allocation ipv4 access-list 10
+```
+
+```{cfgcmd} set protocols mpls ldp allocation ipv6 access-list6 \<1-2699\>
+
+**Restrict MPLS label allocation to IPv6 prefixes permitted by the
+specified access list.**
+
+By default, LDP allocates a label for every IPv6 prefix in the routing
+table. A common best practice is to limit allocation to loopback
+addresses.
+```
+
+Example:
+
+```none
+set protocols mpls ldp allocation ipv6 access-list6 10
 ```
 
 ```{cfgcmd} set protocols mpls ldp parameters cisco-interop-tlv
 
-Use this command to use a Cisco non-compliant format to send and interpret
-the Dual-Stack capability TLV for IPv6 LDP communications. This is related to
-{rfc}`7552`.
+**Configure the router to negotiate the Dual-Stack capability
+{abbr}`TLV (Type-Length-Value)`
+([RFC 7552](https://datatracker.ietf.org/doc/html/rfc7552)) using a Cisco
+non-compliant format for dual-stack LDP sessions.**
+```
+
+Example:
+
+```none
+set protocols mpls ldp parameters cisco-interop-tlv
 ```
 
 ```{cfgcmd} set protocols mpls ldp parameters ordered-control
 
-Use this command to use ordered label distribution control mode. FRR
-by default uses independent label distribution control mode for label
-distribution.  This is related to {rfc}`5036`.
+**Enable LDP Ordered Label Distribution Control mode
+([RFC 5036](https://datatracker.ietf.org/doc/html/rfc5036)) for the
+router.**
+
+By default, the router operates in Independent Label Distribution Control
+mode.
+```
+
+Example:
+
+```none
+set protocols mpls ldp parameters ordered-control
 ```
 
 ```{cfgcmd} set protocols mpls ldp parameters transport-prefer-ipv4
 
-Use this command to prefer IPv4 for TCP peer transport connection for LDP
-when both an IPv4 and IPv6 LDP address are configured on the same interface.
+**Configure the router to prefer an IPv4 TCP transport connection for LDP
+peering when LDP is configured for dual-stack operation (both IPv4 and
+IPv6 address families are enabled).**
+```
+
+Example:
+
+```none
+set protocols mpls ldp parameters transport-prefer-ipv4
 ```
 
 ```{cfgcmd} set protocols mpls ldp targeted-neighbor ipv4 enable
+
+**Enable the router to accept targeted IPv4 LDP sessions.**
+
+This allows the router to establish LDP adjacencies with non-directly
+connected peers by responding to inbound targeted (unicast) LDP Hello
+messages.
+```
+
+Example:
+
+```none
+set protocols mpls ldp targeted-neighbor ipv4 enable
 ```
 
 ```{cfgcmd} set protocols mpls ldp targeted-neighbor ipv6 enable
 
-Use this command to enable targeted LDP sessions to the local router. The
-router will then respond to any sessions that are trying to connect to it that
-are not a link local type of TCP connection.
+**Enable the router to accept targeted IPv6 LDP sessions.**
+
+This allows the router to establish LDP adjacencies with non-directly
+connected peers by responding to inbound targeted (unicast) LDP Hello
+messages.
+```
+
+Example:
+
+```none
+set protocols mpls ldp targeted-neighbor ipv6 enable
 ```
 
 ```{cfgcmd} set protocols mpls ldp targeted-neighbor ipv4 address \<address\>
+
+**Configure the router to initiate a targeted IPv4 LDP session with the
+specified remote {abbr}`LSR (Label Switching Router)`.**
+```
+
+Example:
+
+```none
+set protocols mpls ldp targeted-neighbor ipv4 address 192.0.2.5
 ```
 
 ```{cfgcmd} set protocols mpls ldp targeted-neighbor ipv6 address \<address\>
 
-Use this command to enable the local router to try and connect with a targeted
-LDP session to another router.
+**Configure the router to initiate a targeted IPv6 LDP session with the
+specified remote LSR.**
 ```
 
-```{cfgcmd} set protocols mpls ldp targeted-neighbor ipv4 hello-holdtime \<seconds\>
-```
-
-```{cfgcmd} set protocols mpls ldp targeted-neighbor ipv4 hello-interval \<seconds\>
-```
-
-```{cfgcmd} set protocols mpls ldp targeted-neighbor ipv6 hello-holdtime \<seconds\>
-```
-
-```{cfgcmd} set protocols mpls ldp targeted-neighbor ipv6 hello-interval \<seconds\>
-
-Use these commands if you would like to set the discovery hello and hold time
-parameters for the targeted LDP neighbors.
-```
-
-### Sample configuration to setup LDP on VyOS
+Example:
 
 ```none
-set protocols ospf area 0 network '192.168.255.252/32'                      <--- Routing for loopback
-set protocols ospf area 0 network '192.168.0.5/32'                          <--- Routing for an interface connecting to the network
-set protocols ospf parameters router-id '192.168.255.252'                   <--- Router ID setting for OSPF
-set protocols mpls interface 'eth1'                                         <--- Enable MPLS for an interface connecting to network
-set protocols mpls ldp discovery transport-ipv4-address '192.168.255.252'   <--- Transport address for LDP for TCP sessions to connect to
-set protocols mpls ldp interface 'eth1'                                     <--- Enable LDP for an interface connecting to network
-set protocols mpls ldp interface 'lo'                                       <--- Enable LDP on loopback for future services connectivity
-set protocols mpls ldp router-id '192.168.255.252'                          <--- Router ID setting for LDP
-set interfaces ethernet eth1 address '192.168.0.5/31'                       <--- Interface IP for connecting to network
-set interfaces loopback lo address '192.168.255.252/32'                     <--- Interface loopback IP for router ID and other uses
+set protocols mpls ldp targeted-neighbor ipv6 address 2001:db8::5
 ```
 
-## Operational Mode Commands
+```{cfgcmd} set protocols mpls ldp targeted-neighbor ipv4 hello-holdtime \<1-65535\>
 
-When LDP is working, you will be able to see label information in the outcome
-of `show ip route`. Besides that information, there are also specific *show*
-commands for LDP:
+**Configure the hold time, in seconds, advertised in targeted IPv4 LDP
+Hello messages.**
+```
+
+Example:
+
+```none
+set protocols mpls ldp targeted-neighbor ipv4 hello-holdtime 45
+```
+
+```{cfgcmd} set protocols mpls ldp targeted-neighbor ipv4 hello-interval \<1-65535\>
+
+**Configure the interval, in seconds, between targeted IPv4 LDP Hello
+messages sent to remote LSRs.**
+```
+
+Example:
+
+```none
+set protocols mpls ldp targeted-neighbor ipv4 hello-interval 15
+```
+
+```{cfgcmd} set protocols mpls ldp targeted-neighbor ipv6 hello-holdtime \<1-65535\>
+
+**Configure the hold time, in seconds, advertised in targeted IPv6 LDP
+Hello messages.**
+```
+
+Example:
+
+```none
+set protocols mpls ldp targeted-neighbor ipv6 hello-holdtime 45
+```
+
+```{cfgcmd} set protocols mpls ldp targeted-neighbor ipv6 hello-interval \<1-65535\>
+
+**Configure the interval, in seconds, between targeted IPv6 LDP Hello
+messages sent to remote LSRs.**
+```
+
+Example:
+
+```none
+set protocols mpls ldp targeted-neighbor ipv6 hello-interval 15
+```
+
+## Operation
+
+When LDP is established, you can view label assignments directly within the
+`show ip route` or `show ipv6 route` outputs. To inspect LDP operational
+states, use the following commands.
 
 ### Show
 
 ```{opcmd} show mpls ldp binding
 
-Use this command to see the Label Information Base.
+Show the {abbr}`LIB (Label Information Base)`.
+```
 
+```{opcmd} show mpls ldp binding \<prefix\>
+
+Show LDP label bindings for the specified prefix.
+
+The `<prefix>` parameter accepts an IPv4 prefix (`x.x.x.x/x`) or IPv6
+prefix (`h:h:h:h:h:h:h:h/h`).
+```
+
+```{opcmd} show mpls ldp binding detail
+
+Show detailed LDP Label Information Base (LIB) entries.
+```
+
+```{opcmd} show mpls ldp binding neighbor \<address\>
+
+Show LDP label bindings learned from the specified peer.
+
+The `<address>` parameter accepts an IPv4 or IPv6 address.
+```
+
+```{opcmd} show mpls ldp binding local-label \<label\>
+
+Show LDP label bindings associated with the specified locally
+assigned label value.
+```
+
+```{opcmd} show mpls ldp binding remote-label \<label\>
+
+Show LDP label bindings associated with the specified remotely
+assigned label value.
 ```
 
 ```{opcmd} show mpls ldp discovery
 
-Use this command to see discovery hello information
+Show LDP discovery Hello information.
+```
+
+```{opcmd} show mpls ldp discovery detail
+
+Show detailed LDP discovery Hello information.
 ```
 
 ```{opcmd} show mpls ldp interface
 
-Use this command to see LDP interface information
+Show LDP interface information.
 ```
 
 ```{opcmd} show mpls ldp neighbor
 
-Use this command to see LDP neighbor information
+Show basic LDP neighbor information.
 ```
 
 ```{opcmd} show mpls ldp neighbor detail
 
-Use this command to see detailed LDP neighbor information
+Show detailed LDP neighbor information.
+```
+
+```{opcmd} show mpls ldp neighbor capabilities
+
+Show the LDP capabilities negotiated with each peer during session
+initialization.
+```
+
+```{opcmd} show mpls ldp neighbor \<address\>
+
+Show LDP neighbor information for the specified peer.
+
+The `<address>` parameter accepts an IPv4 or IPv6 address.
+```
+
+```{opcmd} show mpls ldp neighbor \<address\> detail
+
+Show detailed LDP session information for the specified peer.
+```
+
+```{opcmd} show mpls ldp neighbor \<address\> capabilities
+
+Show the LDP capabilities negotiated with the specified peer.
+```
+
+```{opcmd} show mpls table
+
+Show the MPLS table.
+```
+
+```{opcmd} show mpls pseudowire
+
+Show MPLS pseudowire interfaces.
 ```
 
 ### Reset
 
-```{opcmd} reset mpls ldp neighbor \<IPv4 or IPv6 address\>
+```{opcmd} reset mpls ldp neighbor \<address\>
 
-Use this command to reset an LDP neighbor/TCP session that is established
+Reset the established LDP session with the specified neighbor.
+
+The `<address>` parameter accepts an IPv4 or IPv6 address.
 ```
 
-[wikipedia (mpls)]: <https://en.wikipedia.org/wiki/Multiprotocol_Label_Switching>
+## Example
+
+The following configuration sets up a basic MPLS LDP-enabled router.
+OSPF is used as the underlying IGP to provide reachability between LDP
+peers' loopback addresses, which are then used as the LDP transport
+addresses and router IDs. MPLS forwarding and LDP are enabled on the
+interface connecting to the network.
+
+```none
+set protocols ospf area 0 network '192.0.2.1/32'                            <--- Routing for the loopback
+set protocols ospf area 0 network '192.0.2.4/31'                            <--- Routing for an interface connecting to the network
+set protocols ospf parameters router-id '192.0.2.1'                         <--- Router ID setting for OSPF
+set protocols mpls interface 'eth1'                                         <--- Enable MPLS for an interface connecting to the network
+set protocols mpls ldp discovery transport-ipv4-address '192.0.2.1'         <--- Transport address for LDP for TCP sessions to connect to
+set protocols mpls ldp interface 'eth1'                                     <--- Enable LDP for an interface connecting to the network
+set protocols mpls ldp interface 'lo'                                       <--- Enable LDP on loopback for future services connectivity
+set protocols mpls ldp router-id '192.0.2.1'                                <--- Router ID setting for LDP
+set interfaces ethernet eth1 address '192.0.2.5/31'                         <--- Interface IP for connecting to the network
+set interfaces loopback lo address '192.0.2.1/32'
+```
+
+```{note}
+This example assumes a transit (P-router) role: MPLS forwarding is
+enabled on the transit interface only, not on the loopback. If the
+router needs to terminate MPLS-encapsulated traffic on its loopback
+(PE-router role), also configure `set protocols mpls interface 'lo'`.
+```
+
+Apply the same configuration on the LDP peer (using its own loopback and
+transit interface addresses) to establish a basic LDP session.

--- a/docs/configuration/protocols/mpls.md
+++ b/docs/configuration/protocols/mpls.md
@@ -213,7 +213,7 @@ Example:
 set protocols mpls ldp neighbor 192.0.2.2 session-holdtime 180
 ```
 
-```{cfgcmd} set protocols mpls ldp neighbor \<ipv4-address\> ttl-security \<disable | hop-count\>
+```{cfgcmd} set protocols mpls ldp neighbor \<ipv4-address\> ttl-security \<disable | 1-254\>
 
 **Configure TTL security ({abbr}`GTSM (Generalized TTL Security Mechanism)`)
 for the LDP session with the specified neighbor.**
@@ -750,15 +750,15 @@ addresses and router IDs. MPLS forwarding and LDP are enabled on the
 interface connecting to the network.
 
 ```none
-set protocols ospf area 0 network '192.0.2.1/32'                            <--- Routing for the loopback
-set protocols ospf area 0 network '192.0.2.4/31'                            <--- Routing for an interface connecting to the network
-set protocols ospf parameters router-id '192.0.2.1'                         <--- Router ID setting for OSPF
-set protocols mpls interface 'eth1'                                         <--- Enable MPLS for an interface connecting to the network
-set protocols mpls ldp discovery transport-ipv4-address '192.0.2.1'         <--- Transport address for LDP for TCP sessions to connect to
-set protocols mpls ldp interface 'eth1'                                     <--- Enable LDP for an interface connecting to the network
-set protocols mpls ldp interface 'lo'                                       <--- Enable LDP on loopback for future services connectivity
-set protocols mpls ldp router-id '192.0.2.1'                                <--- Router ID setting for LDP
-set interfaces ethernet eth1 address '192.0.2.5/31'                         <--- Interface IP for connecting to the network
+set protocols ospf area 0 network '192.0.2.1/32'
+set protocols ospf area 0 network '192.0.2.4/31'
+set protocols ospf parameters router-id '192.0.2.1'
+set protocols mpls interface 'eth1'
+set protocols mpls ldp discovery transport-ipv4-address '192.0.2.1'
+set protocols mpls ldp interface 'eth1'
+set protocols mpls ldp interface 'lo'
+set protocols mpls ldp router-id '192.0.2.1'
+set interfaces ethernet eth1 address '192.0.2.5/31'
 set interfaces loopback lo address '192.0.2.1/32'
 ```
 


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
This PR refactors the MPLS page to comply with the current VyOS documentation style guide.

Changes:

* AI & SEO Context: Added :description: and :keywords: metadata tags.
* Content: Proofread and improved.
* Technical accuracy: Verified commands against VyOS 1.5.
* Added examples for all commands.

Added new conf-mode commands:

* set protocols mpls parameters no-propagate-ttl
* set protocols mpls parameters maximum-ttl <1-255>
* set protocols mpls ldp interface <interface> disable-establish-hello
* set protocols mpls ldp import ipv4 import-filter neighbor-access-list <1-2699>
* set protocols mpls ldp import ipv6 import-filter neighbor-access-list6 <1-2699>
* set protocols mpls ldp export ipv4 export-filter neighbor-access-list <1-2699>
* set protocols mpls ldp export ipv6 export-filter neighbor-access-list6 <1-2699>

Added new op-mode commands:

* show mpls ldp binding <prefix>
* show mpls ldp binding detail
* show mpls ldp binding neighbor <address>
* show mpls ldp binding local-label <label>
* show mpls ldp binding remote-label <label>
* show mpls ldp discovery detail
* show mpls ldp neighbor capabilities
* show mpls ldp neighbor <address>
* show mpls ldp neighbor <address> detail
* show mpls ldp neighbor <address> capabilities
* show mpls table
* show mpls pseudowire

Added value range for:

* set protocols mpls ldp neighbor <ipv4-address> session-holdtime <15-65535>
* set protocols mpls ldp discovery hello-ipv4-interval <1-65535>
* set protocols mpls ldp discovery hello-ipv4-holdtime <1-65535>
* set protocols mpls ldp discovery hello-ipv6-interval <1-65535>
* set protocols mpls ldp discovery hello-ipv6-holdtime <1-65535>
* set protocols mpls ldp discovery session-ipv4-holdtime <15-65535>
* set protocols mpls ldp discovery session-ipv6-holdtime <15-65535>
* set protocols mpls ldp import ipv4 import-filter filter-access-list <1-2699>
* set protocols mpls ldp import ipv6 import-filter filter-access-list6 <1-2699>
* set protocols mpls ldp export ipv4 export-filter filter-access-list <1-2699>
* set protocols mpls ldp export ipv6 export-filter filter-access-list6 <1-2699>
* set protocols mpls ldp allocation ipv4 access-list <1-2699>
* set protocols mpls ldp allocation ipv6 access-list6 <1-2699>
* set protocols mpls ldp targeted-neighbor ipv4 hello-holdtime <1-65535>
* set protocols mpls ldp targeted-neighbor ipv4 hello-interval <1-65535>
* set protocols mpls ldp targeted-neighbor ipv6 hello-holdtime <1-65535>
* set protocols mpls ldp targeted-neighbor ipv6 hello-interval <1-65535>

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
VD-3737

## Related PR(s)


## Backport
<!-- optional: the PR should backport to this documentation branch -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document
- [x] The style guide checklist was applied.