### PR TITLE
T8967: Fix update-check URL for rolling

### DIFF
--- a/docs/_locale/de/installation.pot
+++ b/docs/_locale/de/installation.pot
@@ -2205,8 +2205,8 @@ msgid "https://pgp.mit.edu/pks/lookup?op=get&search=0xFD220285A0FE6D7E"
 msgstr "https://pgp.mit.edu/pks/lookup?op=get&search=0xFD220285A0FE6D7E"
 
 #: ../../installation/update.rst:86
-msgid "https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/current/version.json"
-msgstr "https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/current/version.json"
+msgid "https://raw.githubusercontent.com/vyos/vyos-nightly-build/rolling/version.json"
+msgstr "https://raw.githubusercontent.com/vyos/vyos-nightly-build/rolling/version.json"
 
 #: ../../installation/update.rst:91
 msgid "https://vyos.net/get/nightly-builds/"

--- a/docs/_locale/es/installation.pot
+++ b/docs/_locale/es/installation.pot
@@ -2205,8 +2205,8 @@ msgid "https://pgp.mit.edu/pks/lookup?op=get&search=0xFD220285A0FE6D7E"
 msgstr "https://pgp.mit.edu/pks/lookup?op=get&amp;search=0xFD220285A0FE6D7E"
 
 #: ../../installation/update.rst:86
-msgid "https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/current/version.json"
-msgstr "https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/current/version.json"
+msgid "https://raw.githubusercontent.com/vyos/vyos-nightly-build/rolling/version.json"
+msgstr "https://raw.githubusercontent.com/vyos/vyos-nightly-build/rolling/version.json"
 
 #: ../../installation/update.rst:91
 msgid "https://vyos.net/get/nightly-builds/"

--- a/docs/_locale/ja/installation.pot
+++ b/docs/_locale/ja/installation.pot
@@ -2205,8 +2205,8 @@ msgid "https://pgp.mit.edu/pks/lookup?op=get&search=0xFD220285A0FE6D7E"
 msgstr "https://pgp.mit.edu/pks/lookup?op=get&search=0xFD220285A0FE6D7E"
 
 #: ../../installation/update.rst:86
-msgid "https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/current/version.json"
-msgstr "https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/current/version.json"
+msgid "https://raw.githubusercontent.com/vyos/vyos-nightly-build/rolling/version.json"
+msgstr "https://raw.githubusercontent.com/vyos/vyos-nightly-build/rolling/version.json"
 
 #: ../../installation/update.rst:91
 msgid "https://vyos.net/get/nightly-builds/"

--- a/docs/_locale/pt/installation.pot
+++ b/docs/_locale/pt/installation.pot
@@ -2205,8 +2205,8 @@ msgid "https://pgp.mit.edu/pks/lookup?op=get&search=0xFD220285A0FE6D7E"
 msgstr "https://pgp.mit.edu/pks/lookup?op=get&search=0xFD220285A0FE6D7E"
 
 #: ../../installation/update.rst:86
-msgid "https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/current/version.json"
-msgstr "https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/current/version.json"
+msgid "https://raw.githubusercontent.com/vyos/vyos-nightly-build/rolling/version.json"
+msgstr "https://raw.githubusercontent.com/vyos/vyos-nightly-build/rolling/version.json"
 
 #: ../../installation/update.rst:91
 msgid "https://vyos.net/get/nightly-builds/"

--- a/docs/_locale/uk/installation.pot
+++ b/docs/_locale/uk/installation.pot
@@ -2205,8 +2205,8 @@ msgid "https://pgp.mit.edu/pks/lookup?op=get&search=0xFD220285A0FE6D7E"
 msgstr "https://pgp.mit.edu/pks/lookup?op=get&amp;search=0xFD220285A0FE6D7E"
 
 #: ../../installation/update.rst:86
-msgid "https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/current/version.json"
-msgstr "https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/current/version.json"
+msgid "https://raw.githubusercontent.com/vyos/vyos-nightly-build/rolling/version.json"
+msgstr "https://raw.githubusercontent.com/vyos/vyos-nightly-build/rolling/version.json"
 
 #: ../../installation/update.rst:91
 msgid "https://vyos.net/get/nightly-builds/"

--- a/docs/configuration/system/updates.md
+++ b/docs/configuration/system/updates.md
@@ -19,7 +19,7 @@ Configure a URL that contains information about images.
 
 ```none
 set system update-check auto-check
-set system update-check url 'https://raw.githubusercontent.com/vyos/vyos-rolling-nightly-builds/main/version.json'
+set system update-check url 'https://raw.githubusercontent.com/vyos/vyos-nightly-build/rolling/version.json'
 ```
 
 Check:
@@ -29,7 +29,7 @@ vyos@r4:~$ show system updates
 Current version: 1.5-rolling-202312220023
 
 Update available: 1.5-rolling-202312250024
-Update URL: https://github.com/vyos/vyos-rolling-nightly-builds/releases/download/1.5-rolling-202312250024/1.5-rolling-202312250024-amd64.iso
+Update URL: https://github.com/vyos/vyos-nightly-build/releases/download/1.5-rolling-202312250024/1.5-rolling-202312250024-amd64.iso
 vyos@r4:~$
 
 vyos@r4:~$ add system image latest

--- a/docs/installation/update.md
+++ b/docs/installation/update.md
@@ -91,7 +91,7 @@ configured appropriately for your installed release.
 For updates to the Rolling Release for AMD64, the following URL may be
 used:
 
-<https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/current/version.json>
+<https://raw.githubusercontent.com/vyos/vyos-nightly-build/rolling/version.json>
 :::
 
 :::{hint}


### PR DESCRIPTION
## Change Summary
Fix the URL in various docs locations for checking for updates to the vyos images on the rolling release so that they work.

## Related Task(s)
* https://vyos.dev/T8967

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document