### PR TITLE
docs: Remove stale CLI output examples from build-vyos.md

### DIFF
--- a/docs/contributing/build-vyos.md
+++ b/docs/contributing/build-vyos.md
@@ -255,18 +255,8 @@ more or less similar looking error message:
 The following packages have unmet dependencies:
  vyos-1x : Depends: accel-ppp but it is not installable
 E: Unable to correct problems, you have held broken packages.
-P: Begin unmounting filesystems...
-P: Saving caches...
-Reading package lists...
-Building dependency tree...
-Reading state information...
-Del frr-pythontools 7.5-20210215-00-g8a5d3b7cd-0 [38.9 kB]
-Del accel-ppp 1.12.0-95-g59f8e1b [475 kB]
-Del frr 7.5-20210215-00-g8a5d3b7cd-0 [2671 kB]
-Del frr-snmp 7.5-20210215-00-g8a5d3b7cd-0 [55.1 kB]
-Del frr-rpki-rtrlib 7.5-20210215-00-g8a5d3b7cd-0 [37.3 kB]
+...
 make: *** [Makefile:30: iso] Error 1
-(10:13) vyos_bld ece068908a5b:/vyos [rolling] #
 ```
 
 To debug the build process and gain additional information of what could be the
@@ -290,31 +280,7 @@ re-installing the failed package after updating the repository.
 
 ```none
 (live)root@ece068908a5b:/# apt-get update; apt-get install vyos-1x
-Get:1 file:/root/packages ./ InRelease
-Ign:1 file:/root/packages ./ InRelease
-Get:2 file:/root/packages ./ Release [1235 B]
-Get:2 file:/root/packages ./ Release [1235 B]
-Get:3 file:/root/packages ./ Release.gpg
-Ign:3 file:/root/packages ./ Release.gpg
-Hit:4 http://repo.powerdns.com/debian buster-rec-43 InRelease
-Hit:5 http://repo.saltstack.com/py3/debian/10/amd64/archive/3002.2 buster InRelease
-Hit:6 http://deb.debian.org/debian bullseye InRelease
-Hit:7 http://deb.debian.org/debian buster InRelease
-Hit:8 http://deb.debian.org/debian-security buster/updates InRelease
-Hit:9 http://deb.debian.org/debian buster-updates InRelease
-Hit:10 http://deb.debian.org/debian buster-backports InRelease
-Hit:11 http://dev.packages.vyos.net/repositories/current current InRelease
-Reading package lists... Done
-N: Download is performed unsandboxed as root as file '/root/packages/./InRelease' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
-Reading package lists... Done
-Building dependency tree
-Reading state information... Done
-Some packages could not be installed. This may mean that you have
-requested an impossible situation or if you are using the unstable
-distribution that some required packages have not yet been created
-or been moved out of Incoming.
-The following information may help to resolve the situation:
-
+...
 The following packages have unmet dependencies:
  vyos-1x : Depends: accel-ppp but it is not installable
 E: Unable to correct problems, you have held broken packages.
@@ -348,15 +314,7 @@ lucky enough to receive an ISO build error which sounds like:
 ```none
 I: Create initramfs if it does not exist.
 Extra argument '6.1.52-amd64-vyos'
-Usage: update-initramfs {-c|-d|-u} [-k version] [-v] [-b directory]
-Options:
- -k version     Specify kernel version or 'all'
- -c             Create a new initramfs
- -u             Update an existing initramfs
- -d             Remove an existing initramfs
- -b directory   Set alternate boot directory
- -v             Be verbose
-See update-initramfs(8) for further details.
+...
 E: config/hooks/live/17-gen_initramfs.chroot failed (exit non-zero). You should check for errors.
 ```
 
@@ -387,17 +345,6 @@ file (example uses kernel 4.19.146):
 ```none
 $ cd vyos-build/packages/linux-kernel/linux
 $ git checkout v4.19.146
-Checking out files: 100% (61536/61536), done.
-Note: checking out 'v4.19.146'.
-
-You are in 'detached HEAD' state. You can look around, make experimental
-changes and commit them, and you can discard any commits you make in this
-state without impacting any branches by performing another checkout.
-
-If you want to create a new branch to retain commits you create, you may
-do so (now or later) by using -b with the checkout command again. Example:
-  git checkout -b <new-branch-name>
-HEAD is now at 015e94d0e37b Linux 4.19.146
 ```
 
 Now you can use the helper script `build-kernel.sh`, which completes all
@@ -414,75 +361,6 @@ quantity of your CPU/cores and disk speed. Expect 20 minutes
 
 ```none
 (18:59) vyos_bld 412374ca36b8:/vyos/vyos-build/packages/linux-kernel [rolling] # ./build-kernel.sh
-I: Copy Kernel config (x86_64_vyos_defconfig) to Kernel Source
-I: Apply Kernel patch: /vyos/vyos-build/packages/linux-kernel/patches/kernel/0001-VyOS-Add-linkstate-IP-device-attribute.patch
-patching file Documentation/networking/ip-sysctl.txt
-patching file include/linux/inetdevice.h
-patching file include/linux/ipv6.h
-patching file include/uapi/linux/ip.h
-patching file include/uapi/linux/ipv6.h
-patching file net/ipv4/devinet.c
-Hunk #1 succeeded at 2319 (offset 1 line).
-patching file net/ipv6/addrconf.c
-patching file net/ipv6/route.c
-I: Apply Kernel patch: /vyos/vyos-build/packages/linux-kernel/patches/kernel/0002-VyOS-add-inotify-support-for-stackable-filesystems-o.patch
-patching file fs/notify/inotify/Kconfig
-patching file fs/notify/inotify/inotify_user.c
-patching file fs/overlayfs/super.c
-Hunk #2 succeeded at 1713 (offset 9 lines).
-Hunk #3 succeeded at 1739 (offset 9 lines).
-Hunk #4 succeeded at 1762 (offset 9 lines).
-patching file include/linux/inotify.h
-I: Apply Kernel patch: /vyos/vyos-build/packages/linux-kernel/patches/kernel/0003-RFC-builddeb-add-linux-tools-package-with-perf.patch
-patching file scripts/package/builddeb
-I: make x86_64_vyos_defconfig
-  HOSTCC  scripts/basic/fixdep
-  HOSTCC  scripts/kconfig/conf.o
-  YACC    scripts/kconfig/zconf.tab.c
-  LEX     scripts/kconfig/zconf.lex.c
-  HOSTCC  scripts/kconfig/zconf.tab.o
-  HOSTLD  scripts/kconfig/conf
-#
-
-# configuration written to .config
-#
-I: Generate environment file containing Kernel variable
-I: Build Debian Kernel package
-  UPD     include/config/kernel.release
-/bin/sh ./scripts/package/mkdebian
-dpkg-buildpackage -r"fakeroot -u" -a$(cat debian/arch) -b -nc -uc
-dpkg-buildpackage: info: source package linux-4.19.146-amd64-vyos
-dpkg-buildpackage: info: source version 4.19.146-1
-dpkg-buildpackage: info: source distribution buster
-dpkg-buildpackage: info: source changed by vyos_bld <christian@poessinger.com>
-dpkg-buildpackage: info: host architecture amd64
-dpkg-buildpackage: warning: debian/rules is not executable; fixing that
- dpkg-source --before-build .
- debian/rules build
-make KERNELRELEASE=4.19.146-amd64-vyos ARCH=x86         KBUILD_BUILD_VERSION=1 KBUILD_SRC=
-  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
-...
-dpkg-shlibdeps: warning: binaries to analyze should already be installed in their package's directory
-dpkg-shlibdeps: warning: binaries to analyze should already be installed in their package's directory
-dpkg-shlibdeps: warning: binaries to analyze should already be installed in their package's directory
-dpkg-shlibdeps: warning: binaries to analyze should already be installed in their package's directory
-dpkg-shlibdeps: warning: binaries to analyze should already be installed in their package's directory
-dpkg-shlibdeps: warning: binaries to analyze should already be installed in their package's directory
-dpkg-shlibdeps: warning: binaries to analyze should already be installed in their package's directory
-dpkg-shlibdeps: warning: binaries to analyze should already be installed in their package's directory
-dpkg-shlibdeps: warning: binaries to analyze should already be installed in their package's directory
-dpkg-shlibdeps: warning: binaries to analyze should already be installed in their package's directory
-dpkg-shlibdeps: warning: binaries to analyze should already be installed in their package's directory
-dpkg-shlibdeps: warning: binaries to analyze should already be installed in their package's directory
-dpkg-shlibdeps: warning: package could avoid a useless dependency if /vyos/vyos-build/packages/linux-kernel/linux/debian/toolstmp/usr/bin/trace /vyos/vyos-build/packages/linux-kernel/linux/debian/toolstmp/usr/bin/perf were not linked against libcrypto.so.1.1 (they use none of the library's symbols)
-dpkg-shlibdeps: warning: package could avoid a useless dependency if /vyos/vyos-build/packages/linux-kernel/linux/debian/toolstmp/usr/bin/trace /vyos/vyos-build/packages/linux-kernel/linux/debian/toolstmp/usr/bin/perf were not linked against libcrypt.so.1 (they use none of the library's symbols)
-dpkg-deb: building package 'linux-tools-4.19.146-amd64-vyos' in '../linux-tools-4.19.146-amd64-vyos_4.19.146-1_amd64.deb'.
- dpkg-genbuildinfo --build=binary
- dpkg-genchanges --build=binary >../linux-4.19.146-amd64-vyos_4.19.146-1_amd64.changes
-dpkg-genchanges: warning: package linux-image-4.19.146-amd64-vyos-dbg in control file but not in files list
-dpkg-genchanges: info: binary-only upload (no source code included)
- dpkg-source --after-build .
-dpkg-buildpackage: info: binary-only upload (no source included)
 ```
 
 When complete, you will have kernel binary packages to use in your custom ISO
@@ -533,23 +411,6 @@ command:
 
 ```none
 $ ./build-accel-ppp.sh
-I: Build Accel-PPP Debian package
-CMake Deprecation Warning at CMakeLists.txt:3 (cmake_policy):
-  The OLD behavior for policy CMP0003 will be removed from a future version
-  of CMake.
-  The cmake-policies(7) manual explains that the OLD behaviors of all
-  policies are deprecated and that a policy should be set to OLD only under
-  specific short-term circumstances.  Projects should be ported to the NEW
-  behavior and not rely on setting a policy to OLD.
--- The C compiler identification is GNU 8.3.0
-...
-
-CPack: Create package using DEB
-CPack: Install projects
-CPack: - Run preinstall target for: accel-ppp
-CPack: - Install project: accel-ppp
-CPack: Create package
-CPack: - package: /vyos/vyos-build/packages/linux-kernel/accel-ppp/build/accel-ppp.deb generated.
 ```
 
 After compiling the packages you will find yourself the newly generated `*.deb`
@@ -564,18 +425,6 @@ to build all driver modules:
 
 ```none
 ./build-intel-drivers.sh
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100  490k  100  490k    0     0   648k      0 --:--:-- --:--:-- --:--:--  648k
-I: Compile Kernel module for Intel ixgbe driver
-...
-
-I: Building Debian package vyos-intel-iavf
-Doing `require 'backports'` is deprecated and will not load any backport in the next major release.
-Require just the needed backports instead, or 'backports/latest'.
-Debian packaging tools generally labels all files in /etc as config files, as mandated by policy, so fpm defaults to this behavior for deb packages. You can disable this default behavior with --deb-no-default-config-files flag {:level=>:warn}
-Created package {:path=>"vyos-intel-iavf_4.0.1-0_amd64.deb"}
-I: Cleanup iavf source
 ```
 
 After compilation, find the generated `*.deb` binaries in
@@ -591,23 +440,6 @@ Use the following wrapper script to build all driver modules:
 
 ```none
 $ ./build-intel-qat.sh
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100 5065k  100 5065k    0     0  1157k      0  0:00:04  0:00:04 --:--:-- 1157k
-I: Compile Kernel module for Intel qat driver
-checking for a BSD-compatible install... /usr/bin/install -c
-checking whether build environment is sane... yes
-checking for a thread-safe mkdir -p... /bin/mkdir -p
-checking for gawk... gawk
-checking whether make sets $(MAKE)... yes
-...
-
-I: Building Debian package vyos-intel-qat
-Doing `require 'backports'` is deprecated and will not load any backport in the next major release.
-Require just the needed backports instead, or 'backports/latest'.
-Debian packaging tools generally labels all files in /etc as config files, as mandated by policy, so fpm defaults to this behavior for deb packages. You can disable this default behavior with --deb-no-default-config-files flag {:level=>:warn}
-Created package {:path=>"vyos-intel-qat_1.7.l.4.9.0-00008-0_amd64.deb"}
-I: Cleanup qat source
 ```
 
 After compiling the packages you will find yourself the newly generated `*.deb`
@@ -704,12 +536,7 @@ and install the new `*.deb` package to replace the current one.
 Install the package using the following commands:
 
 ```none
-vyos@vyos:~$ dpkg --install /tmp/vyos-1x_1.3dev0-1847-gb6dcb0a8_all.deb
-(Reading database ... 58209 files and directories currently installed.)
-Preparing to unpack .../vyos-1x_1.3dev0-1847-gb6dcb0a8_all.deb ...
-Unpacking vyos-1x (1.3dev0-1847-gb6dcb0a8) over (1.3dev0-1847-gb6dcb0a8) ...
-Setting up vyos-1x (1.3dev0-1847-gb6dcb0a8) ...
-Processing triggers for rsyslog (8.1901.0-1) ...
+vyos@vyos:~$ dpkg --install /tmp/vyos-1x_<version>_all.deb
 ```
 
 You can also place the generated `*.deb` in your ISO build environment to


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR removes stale CLI output examples from `docs/contributing/build-vyos.md`.
Affected blocks (9 total):
- ISO Build Issues error signature 
- chroot apt-get debugging example
- initramfs hook failure signature
- git checkout v4.19.146 output
- ./build-kernel.sh 
- ./build-accel-ppp.sh build log
- ./build-intel-drivers.sh build log
- ./build-intel-qat.sh build log
- dpkg --install example 

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
VD-4412

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
#2088

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document