### PR TITLE
Informational Notes on ICMP probes for Prometheus Monitoring with Blackbox Exporter

### DIFF
--- a/docs/configuration/service/monitoring.md
+++ b/docs/configuration/service/monitoring.md
@@ -324,6 +324,26 @@ set service monitoring prometheus blackbox-exporter modules icmp name ping6 ip-p
 set service monitoring prometheus blackbox-exporter modules icmp name ping6 timeout 3
 ```
 
+:::{note}
+ICMP probes require kernel-level permission to send ICMP packets.
+
+The blackbox exporter runs under the `node_exporter` system user,
+which does not have [sufficient privileges] and hence cannot
+send ICMP packets by default.
+:::
+
+To grant the necessary permission, configure the
+`net.ipv4.ping_group_range` sysctl parameter to include
+the `node_exporter` group.
+
+The following command permits any user the ability to ping:
+
+```{cfgcmd} set system sysctl parameter net.ipv4.ping_group_range value '0 2147483647'
+
+This command covers both IPv4 and IPv6 ICMP probes.
+
+```
+
 [azure-data-explorer]: <https://github.com/influxdata/telegraf/tree/master/plugins/outputs/azure_data_explorer>
 [blackbox_exporter]: <https://github.com/prometheus/blackbox_exporter>
 [frr_exporter]: <https://github.com/tynany/frr_exporter>
@@ -332,3 +352,6 @@ set service monitoring prometheus blackbox-exporter modules icmp name ping6 time
 [node_exporter]: <https://github.com/prometheus/node_exporter>
 [prometheus-client]: <https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client>
 [splunk]: <https://www.splunk.com/en_us/blog/it/splunk-metrics-via-telegraf.html>
+% stop_vyoslinter
+[sufficient privileges]: <https://github.com/prometheus/blackbox_exporter#permissions>
+% start_vyoslinter


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
With Prometheus on VyOS, ICMP probes do not work by default. This occurs due to insufficient privileges for the user "node_exporter". Added a note to the documentation, so the user can add the following sysctl command to make it work.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/Txxxx
N/A

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
N/A

## Backport
<!-- optional: the PR should backport to this documentation branch -->
circinus


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document