### PR TITLE
docs: Update IS-IS page to VyOS 1.5 standards

### DIFF
--- a/docs/configuration/protocols/isis.md
+++ b/docs/configuration/protocols/isis.md
@@ -903,7 +903,6 @@ Example:
 set protocols isis interface eth1 ldp-sync disable
 ```
 
-```{cfgcmd} set protocols isis interface \<interface\> ldp-sync holddown \<seconds\>
 
 **Configure the time, in seconds, that IS-IS keeps the specified interface
 at max-metric while waiting for LDP-IGP synchronization to complete.**
@@ -1410,7 +1409,6 @@ Example:
 set protocols isis lsp-gen-interval 5
 ```
 
-```{cfgcmd} set protocols isis lsp-refresh-interval \<seconds\>
 
 **Configure the maximum interval, in seconds, between consecutive
 regenerations of this router's own LSP.**
@@ -1502,7 +1500,6 @@ Example:
 set protocols isis spf-delay-ietf init-delay 500
 ```
 
-```{cfgcmd} set protocols isis spf-delay-ietf time-to-learn \<milliseconds\>
 
 **Configure the learning interval, in milliseconds, that begins when the
 first topology change is received.**
@@ -1521,7 +1518,6 @@ Example:
 set protocols isis spf-delay-ietf time-to-learn 5000
 ```
 
-```{cfgcmd} set protocols isis spf-delay-ietf long-delay \<milliseconds\>
 
 **Configure the interval, in milliseconds, the router applies before
 running an SPF calculation when topology changes arrive after the
@@ -1534,7 +1530,6 @@ Example:
 set protocols isis spf-delay-ietf long-delay 10000
 ```
 
-```{cfgcmd} set protocols isis spf-delay-ietf short-delay \<milliseconds\>
 
 **Configure the interval, in milliseconds, the router applies before
 running subsequent SPF calculations triggered by additional topology

--- a/docs/configuration/protocols/isis.md
+++ b/docs/configuration/protocols/isis.md
@@ -1978,7 +1978,7 @@ set policy route-map EXPORT-ISIS rule 10 action 'permit'
 set policy route-map EXPORT-ISIS rule 10 match ip address prefix-list 'EXPORT-ISIS'
 
 set protocols isis interface eth1
-set protocols isis net '49.0001.2030.1130.0001.00'
+set protocols isis net '49.0001.2030.0011.3001.00'
 set protocols isis redistribute ipv4 connected level-2 route-map 'EXPORT-ISIS'
 ```
 
@@ -1988,7 +1988,7 @@ set protocols isis redistribute ipv4 connected level-2 route-map 'EXPORT-ISIS'
 set interfaces ethernet eth1 address '192.0.2.2/24'
 
 set protocols isis interface eth1
-set protocols isis net '49.0001.1920.0020.0002.00'
+set protocols isis net '49.0001.1920.0000.2002.00'
 ```
 
 Routes on Node 2:

--- a/docs/configuration/protocols/isis.md
+++ b/docs/configuration/protocols/isis.md
@@ -1,452 +1,1839 @@
-```{include} /_include/need_improvement.txt
-```
+---
+myst:
+  html_meta:
+    description: |
+      IS-IS is a link-state interior gateway protocol that uses Dijkstra's
+      Shortest Path First algorithm to build a network topology database
+      and compute the shortest path to each destination.
+    keywords: isis, link-state, igp, dijkstra, spf, lfa, ti-lfa, srv6
+---
 
-(routing-isis)=
+(isis)=
 
 # IS-IS
 
-{abbr}`IS-IS (Intermediate System to Intermediate System)` is a link-state
-interior gateway protocol (IGP) which is described in ISO10589,
-{rfc}`1195`, {rfc}`5308`. IS-IS runs the Dijkstra shortest-path first (SPF)
-algorithm to create a database of the network’s topology, and
-from that database to determine the best (that is, lowest cost) path to a
-destination. The intermediate systems (the name for routers) exchange topology
-information with their directly connected neighbors. IS-IS runs directly on
-the data link layer (Layer 2). IS-IS addresses are called
-{abbr}`NETs (Network Entity Titles)` and can be 8 to 20 bytes long, but are
-generally 10 bytes long. The tree database that is created with IS-IS is
-similar to the one that is created with OSPF in that the paths chosen should
-be similar. Comparisons to OSPF are inevitable and often are reasonable ones
-to make in regards to the way a network will respond with either IGP.
+Intermediate System-to-Intermediate System (IS-IS) is a link-state
+{abbr}`IGP (Interior Gateway Protocol)` described in ISO/IEC 10589,
+[RFC 1195](https://datatracker.ietf.org/doc/html/rfc1195), and
+[RFC 5308](https://datatracker.ietf.org/doc/html/rfc5308). It uses
+Dijkstra's {abbr}`SPF (Shortest Path First)` algorithm to build a network
+topology database ({abbr}`LSDB (Link State Database)`) and compute the
+shortest path to each destination.
 
-## General
+In an IS-IS network, routers are called Intermediate Systems (ISs). They
+exchange topology information with directly connected neighbors via the
+IS-IS protocol, whose PDUs are carried directly in Layer 2 frames rather
+than over IP. IS-IS routers are identified by a
+{abbr}`NET (Network Entity Title)`, which ranges from 8 to 20 bytes
+(typically 10 bytes).
 
-### Configuration
+## IS-IS vs OSPF
 
-#### Mandatory Settings
+IS-IS builds an LSDB from link-state information flooded by other routers
+and computes routing paths using Dijkstra's algorithm, just like OSPF.
+Because both protocols share the same link-state architecture, they make
+nearly identical path-selection decisions. Given the similarities between
+IS-IS and OSPF, comparing their routing behaviors is an effective way to
+understand how a network will respond with either IGP.
 
-For IS-IS top operate correctly, one must do the equivalent of a Router ID in
-CLNS. This Router ID is called the {abbr}`NET (Network Entity Title)`. This
-must be unique for each and every router that is operating in IS-IS. It also
-must not be duplicated otherwise the same issues that occur within OSPF will
-occur within IS-IS when it comes to said duplication.
+## Configuration
+
+### Mandatory settings
+
+Each IS-IS router must be configured with a unique NET, the
+{abbr}`CLNS (Connectionless Network Service)` equivalent of a Router ID.
+The 6-byte system identifier portion of the NET must be unique across the
+IS-IS routing domain.
 
 ```{cfgcmd} set protocols isis net \<network-entity-title\>
 
-This command sets network entity title (NET) provided in ISO format.
+**Configure the Network Entity Title (NET) for the router.**
 
-Here is an example {abbr}`NET (Network Entity Title)` value:
+A typical NET looks like `49.0001.1921.6800.1002.00`.
 
-:::{code-block} none
-49.0001.1921.6800.1002.00
-:::
-The CLNS address consists of the following parts:
+The NET consists of the following parts:
 
-* {abbr}`AFI (Address family authority identifier)` - ``49`` The AFI value
-  49 is what IS-IS uses for private addressing.
+- {abbr}`AFI (Authority and Format Identifier)` (`49`): IS-IS
+  conventionally uses AFI value 49 for private addressing.
+- Area identifier (`0001`): The area number within the IS-IS routing
+  domain (in this example, Area 1).
+- System identifier (`1921.6800.1002`): Uniquely identifies the router
+  within the IS-IS routing domain. We recommend deriving this value from
+  the router IP address or MAC address. To construct the system identifier
+  from an IPv4 address (for example, `192.168.1.2`):
 
-* Area identifier: ``0001`` IS-IS area number (numerical area ``1``)
+  - Pad each octet with leading zeros: `192.168.1.2` → `192.168.001.002`.
+  - Regroup the digits into three 4-digit blocks: `192.168.001.002` →
+    `1921.6800.1002`.
 
-* System identifier: ``1921.6800.1002`` - for system identifiers we recommend
-  to use IP address or MAC address of the router itself. The way to construct
-  this is to keep all of the zeroes of the router IP address, and then change
-  the periods from being every three numbers to every four numbers. The
-  address that is listed here is ``192.168.1.2``, which if expanded will turn
-  into ``192.168.001.002``. Then all one has to do is move the dots to have
-  four numbers instead of three. This gives us ``1921.6800.1002``.
+- NET selector (`00`): Must always be `00` to indicate the local system.
+```
 
-* {abbr}`NET (Network Entity Title)` selector: ``00`` Must always be 00. This
-  setting indicates "this system" or "local system."
+Example:
 
+```none
+set protocols isis net 49.0001.1921.6800.1002.00
 ```
 
 ```{cfgcmd} set protocols isis interface \<interface\>
 
-This command enables IS-IS on this interface, and allows for
-adjacency to occur. Note that the name of IS-IS instance must be
-the same as the one used to configure the IS-IS process.
+**Enable IS-IS on the specified interface.**
+
+This enables the router to form adjacencies with directly connected peers.
 ```
 
-#### IS-IS Global Configuration
+Example:
+
+```none
+set protocols isis interface eth0
+```
+
+### IS-IS global configuration
 
 ```{cfgcmd} set protocols isis dynamic-hostname
 
-This command enables support for dynamic hostname TLV. Dynamic hostname
-mapping determined as described in {rfc}`2763`, Dynamic Hostname
-Exchange Mechanism for IS-IS.
+**Enable Dynamic Hostname {abbr}`TLV (Type-Length-Value)` support on the
+router ([RFC 5301](https://datatracker.ietf.org/doc/html/rfc5301)).**
+
+This enables the router to include its human-readable system name
+alongside its System ID in IS-IS advertisements for easier peer
+identification.
 ```
 
-```{cfgcmd} set protocols isis level \<level-1|level-1-2|level-2\>
+Example:
 
-This command defines the IS-IS router behavior:
-
-* **level-1** - Act as a station (Level 1) router only.
-* **level-1-2** - Act as a station (Level 1) router and area (Level 2) router.
-* **level-2-only** - Act as an area (Level 2) router only.
+```none
+set protocols isis dynamic-hostname
 ```
 
-```{cfgcmd} set protocols isis lsp-mtu \<size\>
+```{cfgcmd} set protocols isis level \<level-1 | level-1-2 | level-2\>
 
-This command configures the maximum size of generated
-{abbr}`LSPs (Link State PDUs)`, in bytes. The size range is 128 to 4352.
+**Configure the IS-IS level at which the router operates:**
+
+- `level-1`: Participates exclusively in Level-1 (intra-area) routing.
+- `level-1-2`: Participates in both Level-1 (intra-area) and Level-2
+  (inter-area) routing.
+- `level-2`: Participates exclusively in Level-2 (inter-area) routing.
 ```
 
-```{cfgcmd} set protocols isis metric-style \<narrow|transition|wide\>
+Example:
 
-This command sets old-style (ISO 10589) or new style packet formats:
+```none
+set protocols isis level level-1
+```
 
-* **narrow** - Use old style of TLVs with narrow metric.
-* **transition** - Send and accept both styles of TLVs during transition.
-* **wide** - Use new style of TLVs to carry wider metric.
+```{cfgcmd} set protocols isis lsp-mtu \<128-4352\>
+
+**Configure the {abbr}`MTU (Maximum Transmission Unit)` size, in bytes,
+for originating or receiving IS-IS {abbr}`LSPs (Link State PDUs)`.**
+```
+
+Example:
+
+```none
+set protocols isis lsp-mtu 1400
+```
+
+```{cfgcmd} set protocols isis metric-style \<narrow | transition | wide\>
+
+**Configure the TLV format (metric style) the router uses when originating
+or processing IS-IS LSPs:**
+
+- `narrow`: Originates and processes only the original ISO/IEC 10589 TLVs.
+- `transition`: Originates and processes both narrow and wide TLV formats.
+- `wide`: Originates and processes only extended TLVs.
+```
+
+Example:
+
+```none
+set protocols isis metric-style wide
 ```
 
 ```{cfgcmd} set protocols isis purge-originator
 
-This command enables {rfc}`6232` purge originator identification. Enable
-purge originator identification (POI) by adding the type, length and value
-(TLV) with the Intermediate System (IS) identification to the LSPs that do
-not contain POI information. If an IS generates a purge, VyOS adds this TLV
-with the system ID of the IS to the purge.
+**Enable {abbr}`POI (Purge Originator Identification)`
+([RFC 6232](https://datatracker.ietf.org/doc/html/rfc6232)) for IS-IS
+purges triggered by the router.**
+
+When enabled, the router includes the POI TLV with its System ID in each
+purge it triggers. This identifies which
+{abbr}`IS (Intermediate System)` triggered the purge.
+```
+
+Example:
+
+```none
+set protocols isis purge-originator
 ```
 
 ```{cfgcmd} set protocols isis set-attached-bit
 
-This command sets ATT bit to 1 in Level1 LSPs. It is described in {rfc}`3787`.
+**Configure the L1/L2 IS-IS router to set the ATT (Attached) bit in the
+Level-1 LSPs it originates
+([RFC 3787](https://datatracker.ietf.org/doc/html/rfc3787)).**
+
+This signals to pure Level-1 routers that this L1/L2 router has Level-2
+reachability.
+```
+
+Example:
+
+```none
+set protocols isis set-attached-bit
 ```
 
 ```{cfgcmd} set protocols isis set-overload-bit
 
-This command sets overload bit to avoid any transit traffic through this
-router. It is described in {rfc}`3787`.
+**Configure the router to set the OL (LSP Database Overload) bit in LSPs
+it originates ([RFC 3787](https://datatracker.ietf.org/doc/html/rfc3787)).**
+
+When configured, other IS-IS routers stop sending transit traffic through
+this router but can still reach its directly connected networks.
 ```
 
-```{cfgcmd} set protocols isis default-information originate \<ipv4|ipv6\> level-1
+Example:
 
-This command will generate a default-route in L1 database.
+```none
+set protocols isis set-overload-bit
 ```
 
-```{cfgcmd} set protocols isis default-information originate \<ipv4|ipv6\> level-2
+```{cfgcmd} set protocols isis advertise-high-metrics
 
-This command will generate a default-route in L2 database.
+**Configure the router to advertise the maximum non-infinite metric value
+on all of its IS-IS interfaces, regardless of the metric configured on
+each interface.**
 ```
+
+Example:
+
+```none
+set protocols isis advertise-high-metrics
+```
+
+```{cfgcmd} set protocols isis advertise-passive-only
+
+**Configure the router to advertise in its LSPs only the IP prefixes of
+passive interfaces.**
+```
+
+Example:
+
+```none
+set protocols isis advertise-passive-only
+```
+
+```{cfgcmd} set protocols isis log-adjacency-changes
+
+**Configure the router to log IS-IS adjacency state changes to syslog.**
+```
+
+Example:
+
+```none
+set protocols isis log-adjacency-changes
+```
+
+```{cfgcmd} set protocols isis topology \<ipv4-multicast | ipv4-mgmt | ipv6-unicast | ipv6-multicast | ipv6-mgmt | ipv6-dstsrc\>
+
+**Enable an additional IS-IS Multi-Topology for the router:**
+
+- `ipv4-multicast`: IPv4 multicast topology (MT 3).
+- `ipv4-mgmt`: IPv4 management topology (MT 1).
+- `ipv6-unicast`: IPv6 unicast topology (MT 2).
+- `ipv6-multicast`: IPv6 multicast topology (MT 4).
+- `ipv6-mgmt`: IPv6 management topology (MT 5).
+- `ipv6-dstsrc`: IPv6 destination/source routing topology.
+
+The default IPv4-unicast topology (MT 0) is always present and does not
+need to be explicitly configured.
+```
+
+Example:
+
+```none
+set protocols isis topology ipv6-unicast
+```
+
+#### Authentication
+
+IS-IS supports two protocol-wide passwords: 
+
+- **area-password**: applied to Level-1 LSPs/SNPs (within the area).
+- **domain-password**: applied to Level-2 LSPs/SNPs (across the Level-2
+  backbone).
+
+These are distinct from the per-interface `password` command
+(see [Interface configuration](#interface-configuration)), which
+authenticates Hello (IIH) PDUs on a single link only.
+
+```{cfgcmd} set protocols isis area-password plaintext-password \<text\>
+
+**Configure a plaintext password used to authenticate Level-1 LSPs and
+SNPs originated and received by this router.**
+
+All Level-1 routers in the area must be configured with the same
+password.
+```
+
+Example:
+
+```none
+set protocols isis area-password plaintext-password mysharedsecret
+```
+
+```{cfgcmd} set protocols isis area-password md5 \<text\>
+
+**Configure an HMAC-MD5 key used to authenticate Level-1 LSPs and SNPs
+originated and received by this router.**
+
+All Level-1 routers in the area must be configured with the same key.
+```
+
+```{note}
+For each of `area-password` and `domain-password`, configure either
+`plaintext-password` or `md5`, but not both.
+```
+
+Example:
+
+```none
+set protocols isis area-password md5 mysharedsecret
+```
+
+```{cfgcmd} set protocols isis domain-password plaintext-password \<text\>
+
+**Configure a plaintext password used to authenticate Level-2 LSPs and
+SNPs originated and received by this router.**
+
+All Level-2 routers in the routing domain must be configured with the
+same password.
+```
+
+Example:
+
+```none
+set protocols isis domain-password plaintext-password mysharedsecret
+```
+
+```{cfgcmd} set protocols isis domain-password md5 \<text\>
+
+**Configure an HMAC-MD5 key used to authenticate Level-2 LSPs and SNPs
+originated and received by this router.**
+
+All Level-2 routers in the routing domain must be configured with the
+same key.
+```
+
+Example:
+
+```none
+set protocols isis domain-password md5 mysharedsecret
+```
+
+#### Default route advertisement
+
+##### Level-1 IPv4
+
+```{cfgcmd} set protocols isis default-information originate ipv4 level-1
+
+**Configure the router to originate the IPv4 default route (`0.0.0.0/0`)
+and advertise it in locally generated LSPs throughout the Level-1 area.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-1` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv4 level-1
+```
+
+```{cfgcmd} set protocols isis default-information originate ipv4 level-1 always
+
+**Configure the router to unconditionally originate the IPv4 default route
+and advertise it throughout the Level-1 area, even if the router lacks a
+default route in its {abbr}`RIB (Routing Information Base)`.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-1` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv4 level-1 always
+```
+
+```{cfgcmd} set protocols isis default-information originate ipv4 level-1 metric \<0-16777215\>
+
+**Configure the IS-IS metric for the IPv4 default route advertised at
+Level 1.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-1` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv4 level-1 metric 100
+```
+
+```{cfgcmd} set protocols isis default-information originate ipv4 level-1 route-map \<name\>
+
+**Apply a route-map to the IPv4 default route advertised at Level 1.**
+
+The route-map can permit or deny the advertisement and, if permitted,
+modify the route's metric.
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-1` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv4 level-1 route-map ISIS-DEFAULT
+```
+
+##### Level-1 IPv6
+
+```{cfgcmd} set protocols isis default-information originate ipv6 level-1
+
+**Configure the router to originate the IPv6 default route (`::/0`) and
+advertise it in locally generated LSPs throughout the Level-1 area.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-1` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv6 level-1
+```
+
+```{cfgcmd} set protocols isis default-information originate ipv6 level-1 always
+
+**Configure the router to unconditionally originate the IPv6 default route
+and advertise it throughout the Level-1 area, even if the router lacks a
+default route in its RIB.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-1` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv6 level-1 always
+```
+
+```{cfgcmd} set protocols isis default-information originate ipv6 level-1 metric \<0-16777215\>
+
+**Configure the IS-IS metric for the IPv6 default route advertised at
+Level 1.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-1` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv6 level-1 metric 100
+```
+
+```{cfgcmd} set protocols isis default-information originate ipv6 level-1 route-map \<name\>
+
+**Apply a route-map to the IPv6 default route advertised at Level 1.**
+
+The route-map can permit or deny the advertisement and, if permitted,
+modify the route's metric.
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-1` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv6 level-1 route-map ISIS-DEFAULT
+```
+
+##### Level-2 IPv4
+
+```{cfgcmd} set protocols isis default-information originate ipv4 level-2
+
+**Configure the router to originate the IPv4 default route (`0.0.0.0/0`)
+and advertise it in locally generated LSPs throughout the Level-2
+backbone.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-2` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv4 level-2
+```
+
+```{cfgcmd} set protocols isis default-information originate ipv4 level-2 always
+
+**Configure the router to unconditionally originate the IPv4 default route
+and advertise it throughout the Level-2 backbone, even if the router lacks
+a default route in its RIB.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-2` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv4 level-2 always
+```
+
+```{cfgcmd} set protocols isis default-information originate ipv4 level-2 metric \<0-16777215\>
+
+**Configure the IS-IS metric for the IPv4 default route advertised into
+the Level-2 backbone.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-2` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv4 level-2 metric 100
+```
+
+```{cfgcmd} set protocols isis default-information originate ipv4 level-2 route-map \<name\>
+
+**Apply a route-map to the IPv4 default route advertised into the Level-2
+backbone.**
+
+The route-map can permit or deny the advertisement and, if permitted,
+modify the route's metric.
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-2` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv4 level-2 route-map ISIS-DEFAULT
+```
+
+##### Level-2 IPv6
+
+```{cfgcmd} set protocols isis default-information originate ipv6 level-2
+
+**Configure the router to originate the IPv6 default route (`::/0`) and
+advertise it in locally generated LSPs throughout the Level-2 backbone.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-2` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv6 level-2
+```
+
+```{cfgcmd} set protocols isis default-information originate ipv6 level-2 always
+
+**Configure the router to unconditionally originate the IPv6 default route
+and advertise it throughout the Level-2 backbone, even if the router lacks
+a default route in its RIB.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-2` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv6 level-2 always
+```
+
+```{cfgcmd} set protocols isis default-information originate ipv6 level-2 metric \<0-16777215\>
+
+**Configure the IS-IS metric for the IPv6 default route advertised into
+the Level-2 backbone.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-2` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv6 level-2 metric 100
+```
+
+```{cfgcmd} set protocols isis default-information originate ipv6 level-2 route-map \<name\>
+
+**Apply a route-map to the IPv6 default route advertised into the Level-2
+backbone.**
+
+The route-map can permit or deny the advertisement and, if permitted,
+modify the route's metric.
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-2` or
+`level-1-2`.
+```
+
+Example:
+
+```none
+set protocols isis default-information originate ipv6 level-2 route-map ISIS-DEFAULT
+```
+
+#### LDP synchronization
 
 ```{cfgcmd} set protocols isis ldp-sync
 
-This command will enable IGP-LDP synchronization globally for ISIS. This
-requires for LDP to be functional. This is described in {rfc}`5443`. By
-default all interfaces operational in IS-IS are enabled for synchronization.
-Loopbacks are exempt.
+**Enable LDP IGP synchronization
+([RFC 5443](https://datatracker.ietf.org/doc/html/rfc5443)) for the IS-IS
+routing process.**
 
+When enabled, all operational IS-IS interfaces automatically participate
+in synchronization, except for loopback interfaces.
 ```
 
-```{cfgcmd} set protocols isis ldp-sync holddown \<seconds\>
-
-This command will change the hold down value globally for IGP-LDP
-synchronization during convergence/interface flap events.
+```{note}
+LDP must be configured and functional on the router for synchronization
+to operate.
 ```
 
-#### Interface Configuration
+Example:
 
-```{cfgcmd} set protocols isis interface \<interface\> circuit-type \<level-1|level-1-2|level-2-only\>
-
-This command specifies circuit type for interface:
-
-* **level-1** - Level-1 only adjacencies are formed.
-* **level-1-2** - Level-1-2 adjacencies are formed
-* **level-2-only** - Level-2 only adjacencies are formed
-
+```none
+set protocols isis ldp-sync
 ```
 
-```{cfgcmd} set protocols isis interface \<interface\> hello-interval \<seconds\>
+```{cfgcmd} set protocols isis ldp-sync holddown \<0-10000\>
 
-This command sets hello interval in seconds on a given interface.
-The range is 1 to 600.
+**Configure the time, in seconds, that IS-IS keeps any of its interfaces
+at max-metric while waiting for LDP-IGP synchronization to complete.**
+
+When this time expires on an interface, IS-IS restores the configured
+interface metric even if LDP-IGP synchronization has not completed.
+
+The default value is 0, which causes IS-IS to wait indefinitely.
 ```
 
-```{cfgcmd} set protocols isis interface \<interface\> hello-multiplier \<seconds\>
+Example:
 
-This command sets multiplier for hello holding time on a given
-interface. The range is 2 to 100.
+```none
+set protocols isis ldp-sync holddown 60
+```
+
+### Interface configuration
+
+```{cfgcmd} set protocols isis interface \<interface\> circuit-type \<level-1 | level-1-2 | level-2-only\>
+
+**Configure the IS-IS level at which the router can form adjacencies on
+the specified interface:**
+
+- `level-1`: Permits only Level-1 (intra-area) adjacencies.
+- `level-2-only`: Permits only Level-2 (inter-area) adjacencies.
+- `level-1-2`: Permits both Level-1 (intra-area) and Level-2 (inter-area)
+  adjacencies.
+```
+
+```{note}
+The selected level must be supported by the router's IS-IS process.
+```
+
+Example:
+
+```none
+set protocols isis interface eth0 circuit-type level-1
+```
+
+```{cfgcmd} set protocols isis interface \<interface\> hello-interval \<1-600\>
+
+**Configure the interval, in seconds, between successive IS-IS Hello PDUs
+(IIH) sent on the specified interface.**
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 hello-interval 5
+```
+
+```{cfgcmd} set protocols isis interface \<interface\> hello-multiplier \<2-100\>
+
+**Configure the multiplier applied to the Hello interval to derive the
+Holding Time advertised in IS-IS Hello PDUs (IIH) sent on the specified
+interface.**
+
+The receiving neighbor uses the advertised Holding Time as its adjacency
+timeout. If no IIH arrives within that period, the adjacency is declared
+down.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 hello-multiplier 5
 ```
 
 ```{cfgcmd} set protocols isis interface \<interface\> hello-padding
 
-This command configures padding on hello packets to accommodate asymmetrical
-maximum transfer units (MTUs) from different hosts as described in
-{rfc}`3719`. This helps to prevent a premature adjacency Up state when one
-routing devices MTU does not meet the requirements to establish the adjacency.
+**Enable padding of IS-IS Hello PDUs (IIH) sent on the specified interface
+to that interface's full MTU
+([RFC 3719](https://datatracker.ietf.org/doc/html/rfc3719)).**
+
+This ensures that neighbors with asymmetric MTUs cannot establish an
+adjacency. Without padding, asymmetric MTUs bypass detection during
+adjacency setup.
 ```
 
-```{cfgcmd} set protocols isis interface \<interface\> metric \<metric\>
+Example:
 
-This command set default metric for circuit.
+```none
+set protocols isis interface eth0 hello-padding
+```
 
-The metric range is 1 to 16777215 (Max value depend if metric support narrow
-or wide value).
+```{cfgcmd} set protocols isis interface \<interface\> metric \<0-16777215\>
+
+**Configure the IS-IS metric (cost) advertised for the specified
+interface.**
+
+The SPF algorithm uses this value to calculate the optimal routing path
+to destinations.
+
+The valid range depends on the configured metric style: `narrow` limits
+the metric to 0-63, while `wide` extends it to 0-16777215.
+
+The default value is 10.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 metric 100
 ```
 
 ```{cfgcmd} set protocols isis interface \<interface\> network point-to-point
 
-This command specifies network type to Point-to-Point. The default
-network type is broadcast.
+**Configure the IS-IS network type for the specified interface as
+point-to-point.**
+
+The default network type is broadcast.
+```
+
+```{note}
+The neighboring interface must be configured with the same network type;
+otherwise, the adjacency does not form.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 network point-to-point
 ```
 
 ```{cfgcmd} set protocols isis interface \<interface\> passive
 
-This command configures the passive mode for this interface.
+**Enable passive mode for the specified interface.**
+
+On a passive interface, the router neither sends nor processes IS-IS Hello
+PDUs (IIH), so no adjacency forms. The interface's IP prefix is still
+advertised in this router's LSP.
+```
+
+Example:
+
+```none
+set protocols isis interface lo passive
 ```
 
 ```{cfgcmd} set protocols isis interface \<interface\> password plaintext-password \<text\>
 
-This command configures the authentication password for the interface.
+**Configure the plaintext authentication password for the specified
+interface.**
+
+This password is included in IS-IS Hello (IIH) PDUs sent on the interface
+and validated on IIH PDUs received from neighbors.
+
+A mismatch prevents adjacency formation and tears down an established
+adjacency.
 ```
 
-```{cfgcmd} set protocols isis interface \<interface\> priority \<number\>
+Example:
 
-This command sets priority for the interface for
-{abbr}`DIS (Designated Intermediate System)` election. The priority
-range is 0 to 127.
+```none
+set protocols isis interface eth1 password plaintext-password mysharedsecret
 ```
 
-```{cfgcmd} set protocols isis interface \<interface\> psnp-interval \<number\>
+```{cfgcmd} set protocols isis interface \<interface\> password md5 \<text\>
 
-This command sets PSNP interval in seconds. The interval range is 0
-to 127.
+**Configure the MD5 authentication key for the specified interface.**
+
+This key is used to generate a cryptographic hash that is included in
+IS-IS Hello (IIH) PDUs sent on the interface and validated in IIH PDUs
+received from neighbors.
+
+A mismatch prevents adjacency formation and tears down an established
+adjacency.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 password md5 mysharedsecret
+```
+
+```{cfgcmd} set protocols isis interface \<interface\> priority \<0-127\>
+
+**Configure the IS-IS {abbr}`DIS (Designated Intermediate System)`
+election priority for the specified interface.**
+
+The priority is used in DIS election on the broadcast (LAN) segment. The
+router whose interface advertises the highest priority wins.
+
+The default priority is 64.
+```
+
+```{note}
+The configured value applies only to broadcast interfaces and has no
+effect on point-to-point interfaces.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 priority 100
+```
+
+```{cfgcmd} set protocols isis interface \<interface\> psnp-interval \<0-127\>
+
+**Configure the interval, in seconds, between successive IS-IS
+{abbr}`PSNP (Partial Sequence Number PDU)` transmissions on the
+specified interface.**
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 psnp-interval 2
 ```
 
 ```{cfgcmd} set protocols isis interface \<interface\> no-three-way-handshake
 
-This command disables Three-Way Handshake for P2P adjacencies which
-described in {rfc}`5303`. Three-Way Handshake is enabled by default.
+**Disable the Three-Way Handshake for Point-to-Point (P2P) adjacencies
+([RFC 5303](https://datatracker.ietf.org/doc/html/rfc5303)).**
+
+The three-way handshake is enabled by default.
+```
+
+```{note}
+This command applies only to point-to-point interfaces and has no effect
+on broadcast interfaces.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 no-three-way-handshake
 ```
 
 ```{cfgcmd} set protocols isis interface \<interface\> ldp-sync disable
 
-This command disables IGP-LDP sync for this specific interface.
+**Disable LDP-IGP synchronization on the specified IS-IS interface.**
+
+With LDP-IGP synchronization enabled, IS-IS advertises a maximum metric
+on the interface while LDP is not yet synchronized on it.
+
+Disabling it on this interface causes IS-IS to advertise the configured
+metric regardless of LDP synchronization state.
+```
+
+```{note}
+This command applies only if LDP-IGP synchronization is enabled for the
+IS-IS routing process.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 ldp-sync disable
 ```
 
 ```{cfgcmd} set protocols isis interface \<interface\> ldp-sync holddown \<seconds\>
 
-This command will change the hold down value for IGP-LDP synchronization
-during convergence/interface flap events, but for this interface only.
+**Configure the time, in seconds, that IS-IS keeps the specified interface
+at max-metric while waiting for LDP-IGP synchronization to complete.**
+
+When this time expires, IS-IS restores the configured interface metric
+even if LDP-IGP synchronization has not completed.
+
+The default value is 0, which causes IS-IS to wait indefinitely.
 ```
 
-```{cfgcmd} set protocols isis interface \<interface\> fast-reroute lfa [level-1 | level-2] enable
-
-This command enables per-prefix local LFA fast reroute link protection.
+```{note}
+This setting overrides the LDP-IGP synchronization hold-down time
+configured for the IS-IS routing process.
 ```
 
-```{cfgcmd} set protocols isis interface \<interface\> fast-reroute lfa [level-1 | level-2] exclude
+Example:
 
-This command excludes an interface from the local LFA backup nexthop computation.
+```none
+set protocols isis interface eth1 ldp-sync holddown 60
 ```
 
-```{cfgcmd} set protocols isis interface \<interface\> fast-reroute remote-lfa [level-1 | level-2] tunnel mpls-ldp
+```{cfgcmd} set protocols isis interface \<interface\> bfd profile \<profile-name\>
 
-This command enables per-prefix Remote LFA fast reroute link protection.
-Note that other routers in the network need to be configured to accept LDP
-targeted hello messages in order for RLFA to work.
+**Attach a BFD profile to the IS-IS adjacency on the specified
+interface.**
+
+When configured, IS-IS uses the BFD session described by the named
+profile to detect adjacency failure. If BFD reports the session down,
+the IS-IS adjacency is torn down immediately rather than waiting for
+the Hello holding time to expire.
+
+The profile itself is configured under
+`set protocols bfd profile <profile-name>`.
 ```
 
-```{cfgcmd} set protocols isis interface \<interface\> fast-reroute remote-lfa [level-1 | level-2] maximum-metric \<metric\>
+Example:
 
-This command limits Remote LFA PQ node selection within the specified metric. Metric value range (1-16777215).
+```none
+set protocols isis interface eth1 bfd profile ISIS-FAST
 ```
 
-```{cfgcmd} set protocols isis interface \<interface\> fast-reroute ti-lfa [level-1|level-2] [node-protection [link-fallback]]
+#### Level-1 fast-reroute
 
-This command enables per-prefix TI-LFA fast reroute link or node protection.
-When node protection is used, option link-fallback enables the computation
-and use of link-protecting LFAs for destinations unprotected by node
-protection.
+```{cfgcmd} set protocols isis interface \<interface\> fast-reroute lfa level-1 enable
+
+**Enable Level-1 {abbr}`LFA (Loop-Free Alternate)` computation on the
+specified interface.**
+
+When enabled, IS-IS precomputes a backup next-hop for each Level-1
+destination reached through this interface. If the primary next-hop
+fails, the router uses the precomputed backup instead.
 ```
 
-#### Route Redistribution
+Example:
 
-```{cfgcmd} set protocols isis redistribute ipv4 \<route source\> level-1
-
-This command redistributes routing information from the given route source
-into the ISIS database as Level-1. There are six modes available for route
-source: bgp, connected, kernel, ospf, rip, static.
+```none
+set protocols isis interface eth1 fast-reroute lfa level-1 enable
 ```
 
-```{cfgcmd} set protocols isis redistribute ipv4 \<route source\> level-2
+```{cfgcmd} set protocols isis interface \<interface-1\> fast-reroute lfa level-1 exclude interface \<interface-2\>
 
-This command redistributes routing information from the given route source
-into the ISIS database as Level-2. There are six modes available for route
-source: bgp, connected, kernel, ospf, rip, static.
+**Exclude an interface from being selected as a Level-1 LFA backup
+next-hop on the specified interface.**
+
+In the command syntax, `<interface-1>` identifies the protected interface,
+and `<interface-2>` identifies the interface that must not be used as an
+LFA backup next-hop.
 ```
 
-```{cfgcmd} set protocols isis redistribute ipv4 \<route source\> \<level-1|level-2\> metric \<number\>
+Example:
 
-This command specifies metric for redistributed routes from the given route
-source. There are six modes available for route source: bgp, connected,
-kernel, ospf, rip, static. The metric range is 1 to 16777215.
+```none
+set protocols isis interface eth1 fast-reroute lfa level-1 exclude interface eth2
 ```
 
-```{cfgcmd} set protocols isis redistribute ipv4 \<route source\> \<level-1|level-2\> route-map \<name\>
+```{cfgcmd} set protocols isis interface \<interface\> fast-reroute remote-lfa level-1 tunnel mpls-ldp
 
-This command allows to use route map to filter redistributed routes from
-the given route source. There are six modes available for route source:
-bgp, connected, kernel, ospf, rip, static.
+**Enable Level-1 remote LFA computation using MPLS-LDP tunnels on the
+specified interface.**
+
+Remote LFA provides backup paths when local LFA cannot find a loop-free
+alternate neighbor.
+
+If the primary next-hop fails, the router sends traffic into an MPLS-LDP
+tunnel to a precomputed remote LFA node. From there, normal IS-IS
+forwarding delivers it to the destination.
 ```
 
-#### Timers
+```{note}
+Remote LFA requires the corresponding local LFA to be configured on this
+interface.
+```
 
-```{cfgcmd} set protocols isis lsp-gen-interval \<seconds\>
+```{note}
+Remote LFA requires all potential remote LFA endpoints in the IS-IS
+routing instance to accept targeted LDP Hello messages.
+```
 
-This command sets minimum interval in seconds between regenerating same
-LSP. The interval range is 1 to 120.
+Example:
+
+```none
+set protocols isis interface eth1 fast-reroute remote-lfa level-1 tunnel mpls-ldp
+```
+
+```{cfgcmd} set protocols isis interface \<interface\> fast-reroute remote-lfa level-1 maximum-metric \<1-16777215\>
+
+**Configure the maximum metric for Level-1 remote LFA node selection on
+the specified interface.**
+
+Remote LFA nodes with a metric exceeding this value are excluded from
+selection.
+```
+
+```{note}
+The maximum metric applies only when the corresponding remote LFA is
+enabled on this interface.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 fast-reroute remote-lfa level-1 maximum-metric 100
+```
+
+```{cfgcmd} set protocols isis interface \<interface\> fast-reroute ti-lfa level-1
+
+**Enable Level-1 {abbr}`TI-LFA (Topology Independent Loop-Free Alternate)`
+computation on the specified interface.**
+
+By default, TI-LFA operates in link protection mode, computing backup
+paths that protect against the failure of this interface's link.
+```
+
+```{note}
+LFA and TI-LFA cannot be configured at the same level on the same
+interface.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 fast-reroute ti-lfa level-1
+```
+
+```{cfgcmd} set protocols isis interface \<interface\> fast-reroute ti-lfa level-1 node-protection
+
+**Enable node protection mode for Level-1 TI-LFA on the specified
+interface.**
+
+In node protection mode, TI-LFA computes backup paths that protect
+against the failure of the next-hop node.
+```
+
+```{note}
+LFA and TI-LFA cannot be configured at the same level on the same
+interface.
+```
+
+Example:
+
+```none
+set protocols isis interface eth0 fast-reroute ti-lfa level-1 node-protection
+```
+
+```{cfgcmd} set protocols isis interface \<interface\> fast-reroute ti-lfa level-1 node-protection link-fallback
+
+**Enable link-protection fallback for Level-1 TI-LFA on the specified
+interface.**
+
+When node protection cannot compute a backup path, the computation falls
+back to link protection.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 fast-reroute ti-lfa level-1 node-protection link-fallback
+```
+
+#### Level-2 fast-reroute
+
+```{cfgcmd} set protocols isis interface \<interface\> fast-reroute lfa level-2 enable
+
+**Enable Level-2 LFA computation on the specified interface.**
+
+When enabled, IS-IS precomputes a backup next-hop for each Level-2
+destination reached through this interface. If the primary next-hop
+fails, the router uses the precomputed backup instead.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 fast-reroute lfa level-2 enable
+```
+
+```{cfgcmd} set protocols isis interface \<interface-1\> fast-reroute lfa level-2 exclude interface \<interface-2\>
+
+**Exclude an interface from being selected as a Level-2 LFA backup
+next-hop on the specified interface.**
+
+In the command syntax, `<interface-1>` identifies the protected interface,
+and `<interface-2>` identifies the interface that must not be used as an
+LFA backup next-hop.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 fast-reroute lfa level-2 exclude interface eth2
+```
+
+```{cfgcmd} set protocols isis interface \<interface\> fast-reroute remote-lfa level-2 tunnel mpls-ldp
+
+**Enable Level-2 remote LFA computation using MPLS-LDP tunnels on the
+specified interface.**
+
+Remote LFA provides backup paths when local LFA cannot find a loop-free
+alternate neighbor.
+
+If the primary next-hop fails, the router sends traffic into an MPLS-LDP
+tunnel to a precomputed remote LFA node. From there, normal IS-IS
+forwarding delivers it to the destination.
+```
+
+```{note}
+Remote LFA requires the corresponding local LFA to be configured on this
+interface.
+```
+
+```{note}
+Remote LFA requires all potential remote LFA endpoints in the IS-IS
+routing instance to accept targeted LDP Hello messages.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 fast-reroute remote-lfa level-2 tunnel mpls-ldp
+```
+
+```{cfgcmd} set protocols isis interface \<interface\> fast-reroute remote-lfa level-2 maximum-metric \<1-16777215\>
+
+**Configure the maximum metric for Level-2 remote LFA node selection on
+the specified interface.**
+
+Remote LFA nodes with a metric exceeding this value are excluded from
+selection.
+```
+
+```{note}
+The maximum metric applies only when the corresponding remote LFA is
+enabled on this interface.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 fast-reroute remote-lfa level-2 maximum-metric 100
+```
+
+```{cfgcmd} set protocols isis interface \<interface\> fast-reroute ti-lfa level-2
+
+**Enable Level-2 TI-LFA computation on the specified interface.**
+
+By default, TI-LFA operates in link protection mode, computing backup
+paths that protect against the failure of this interface's link.
+```
+
+```{note}
+LFA and TI-LFA cannot be configured at the same level on the same
+interface.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 fast-reroute ti-lfa level-2
+```
+
+```{cfgcmd} set protocols isis interface \<interface\> fast-reroute ti-lfa level-2 node-protection
+
+**Enable node protection mode for Level-2 TI-LFA on the specified
+interface.**
+
+In node protection mode, TI-LFA computes backup paths that protect
+against the failure of the next-hop node.
+```
+
+```{note}
+LFA and TI-LFA cannot be configured at the same level on the same
+interface.
+```
+
+Example:
+
+```none
+set protocols isis interface eth0 fast-reroute ti-lfa level-2 node-protection
+```
+
+```{cfgcmd} set protocols isis interface \<interface\> fast-reroute ti-lfa level-2 node-protection link-fallback
+
+**Enable link-protection fallback for Level-2 TI-LFA on the specified
+interface.**
+
+When node protection cannot compute a backup path, the computation falls
+back to link protection.
+```
+
+```{note}
+LFA and TI-LFA cannot be configured at the same level on the same
+interface.
+```
+
+Example:
+
+```none
+set protocols isis interface eth1 fast-reroute ti-lfa level-2 node-protection link-fallback
+```
+
+### Route redistribution
+
+#### Level-1 IPv4
+
+```{cfgcmd} set protocols isis redistribute ipv4 \<bgp | connected | kernel | nhrp | ospf | rip | babel | static\> level-1
+
+**Configure the redistribution of IPv4 routing information from the
+specified route source into IS-IS Level-1.**
+```
+
+Example:
+
+```none
+set protocols isis redistribute ipv4 bgp level-1
+```
+
+```{cfgcmd} set protocols isis redistribute ipv4 \<bgp | connected | kernel | nhrp | ospf | rip | babel | static\> level-1 metric \<0-16777215\>
+
+**Configure the IS-IS metric for IPv4 routes redistributed from the
+specified route source into IS-IS Level-1.**
+```
+
+Example:
+
+```none
+set protocols isis redistribute ipv4 bgp level-1 metric 50
+```
+
+```{cfgcmd} set protocols isis redistribute ipv4 \<bgp | connected | kernel | nhrp | ospf | rip | babel | static\> level-1 route-map \<name\>
+
+**Apply a route-map to IPv4 routes redistributed from the specified route
+source into IS-IS Level-1.**
+
+Only routes permitted by the route-map are redistributed. The route-map
+can modify the metric and tag of permitted routes.
+```
+
+Example:
+
+```none
+set protocols isis redistribute ipv4 bgp level-1 route-map BGP-TO-ISIS
+```
+
+#### Level-1 IPv6
+
+```{cfgcmd} set protocols isis redistribute ipv6 \<bgp | connected | kernel | ospf6 | ripng | babel | static\> level-1
+
+**Configure the redistribution of IPv6 routing information from the
+specified route source into IS-IS Level-1.**
+```
+
+Example:
+
+```none
+set protocols isis redistribute ipv6 bgp level-1
+```
+
+```{cfgcmd} set protocols isis redistribute ipv6 \<bgp | connected | kernel | ospf6 | ripng | babel | static\> level-1 metric \<0-16777215\>
+
+**Configure the IS-IS metric for IPv6 routes redistributed from the
+specified route source into IS-IS Level-1.**
+```
+
+Example:
+
+```none
+set protocols isis redistribute ipv6 bgp level-1 metric 50
+```
+
+```{cfgcmd} set protocols isis redistribute ipv6 \<bgp | connected | kernel | ospf6 | ripng | babel | static\> level-1 route-map \<name\>
+
+**Apply a route-map to IPv6 routes redistributed from the specified route
+source into IS-IS Level-1.**
+
+Only routes permitted by the route-map are redistributed. The route-map
+can modify the metric and tag of permitted routes.
+```
+
+Example:
+
+```none
+set protocols isis redistribute ipv6 bgp level-1 route-map BGP-TO-ISIS
+```
+
+#### Level-2 IPv4
+
+```{cfgcmd} set protocols isis redistribute ipv4 \<bgp | connected | kernel | nhrp | ospf | rip | babel | static\> level-2
+
+**Configure the redistribution of IPv4 routing information from the
+specified route source into IS-IS Level-2.**
+```
+
+Example:
+
+```none
+set protocols isis redistribute ipv4 bgp level-2
+```
+
+```{cfgcmd} set protocols isis redistribute ipv4 \<bgp | connected | kernel | nhrp | ospf | rip | babel | static\> level-2 metric \<0-16777215\>
+
+**Configure the IS-IS metric for IPv4 routes redistributed from the
+specified route source into IS-IS Level-2.**
+```
+
+Example:
+
+```none
+set protocols isis redistribute ipv4 bgp level-2 metric 50
+```
+
+```{cfgcmd} set protocols isis redistribute ipv4 \<bgp | connected | kernel | nhrp | ospf | rip | babel | static\> level-2 route-map \<name\>
+
+**Apply a route-map to IPv4 routes redistributed from the specified route
+source into IS-IS Level-2.**
+
+Only routes permitted by the route-map are redistributed. The route-map
+can modify the metric and tag of permitted routes.
+```
+
+Example:
+
+```none
+set protocols isis redistribute ipv4 bgp level-2 route-map BGP-TO-ISIS
+```
+
+#### Level-2 IPv6
+
+```{cfgcmd} set protocols isis redistribute ipv6 \<bgp | connected | kernel | ospf6 | ripng | babel | static\> level-2
+
+**Configure the redistribution of IPv6 routing information from the
+specified route source into IS-IS Level-2.**
+```
+
+Example:
+
+```none
+set protocols isis redistribute ipv6 bgp level-2
+```
+
+```{cfgcmd} set protocols isis redistribute ipv6 \<bgp | connected | kernel | ospf6 | ripng | babel | static\> level-2 metric \<0-16777215\>
+
+**Configure the IS-IS metric for IPv6 routes redistributed from the
+specified route source into IS-IS Level-2.**
+```
+
+Example:
+
+```none
+set protocols isis redistribute ipv6 bgp level-2 metric 50
+```
+
+```{cfgcmd} set protocols isis redistribute ipv6 \<bgp | connected | kernel | ospf6 | ripng | babel | static\> level-2 route-map \<name\>
+
+**Apply a route-map to IPv6 routes redistributed from the specified route
+source into IS-IS Level-2.**
+
+Only routes permitted by the route-map are redistributed. The route-map
+can modify the metric and tag of permitted routes.
+```
+
+Example:
+
+```none
+set protocols isis redistribute ipv6 bgp level-2 route-map BGP-TO-ISIS
+```
+
+### Timers
+
+```{cfgcmd} set protocols isis lsp-gen-interval \<1-120\>
+
+**Configure the minimum interval, in seconds, between consecutive
+regenerations of this router's own LSP.**
+
+Regenerations triggered by events, such as network topology changes, are
+postponed until the specified interval has elapsed since the previous
+regeneration.
+
+The default interval is 30 seconds.
+```
+
+Example:
+
+```none
+set protocols isis lsp-gen-interval 5
 ```
 
 ```{cfgcmd} set protocols isis lsp-refresh-interval \<seconds\>
 
-This command sets LSP refresh interval in seconds. IS-IS generates LSPs
-when the state of a link changes. However, to ensure that routing
-databases on all routers remain converged, LSPs in stable networks are
-generated on a regular basis even though there has been no change to
-the state of the links. The interval range is 1 to 65235. The default
-value is 900 seconds.
+**Configure the maximum interval, in seconds, between consecutive
+regenerations of this router's own LSP.**
+
+When this interval elapses, the router regenerates its LSP even if no
+event has triggered a regeneration.
 ```
 
-```{cfgcmd} set protocols isis max-lsp-lifetime \<seconds\>
-
-This command sets LSP maximum LSP lifetime in seconds. The interval range
-is 350 to 65535. LSPs remain in a database for 1200 seconds by default.
-If they are not refreshed by that time, they are deleted. You can change
-the LSP refresh interval or the LSP lifetime. The LSP refresh interval
-should be less than the LSP lifetime or else LSPs will time out before
-they are refreshed.
+```{note}
+The value must be less than the configured `max-lsp-lifetime` so that the
+LSP is refreshed before its remaining lifetime expires.
 ```
 
-```{cfgcmd} set protocols isis spf-interval \<seconds\>
+Example:
 
-This command sets minimum interval between consecutive SPF calculations in
-seconds.The interval range is 1 to 120.
+```none
+set protocols isis lsp-refresh-interval 600
 ```
 
-```{cfgcmd} set protocols isis spf-delay-ietf holddown \<milliseconds\>
+```{cfgcmd} set protocols isis max-lsp-lifetime \<350-65535\>
+
+**Configure the lifetime, in seconds, of LSPs originated by this router.**
+
+The default is 1200 seconds.
 ```
 
-```{cfgcmd} set protocols isis spf-delay-ietf init-delay \<milliseconds\>
+```{note}
+This value must be greater than `lsp-refresh-interval` so that LSPs are
+refreshed before their lifetime expires.
 ```
 
-```{cfgcmd} set protocols isis spf-delay-ietf long-delay \<milliseconds\>
+Example:
+
+```none
+set protocols isis max-lsp-lifetime 1500
 ```
 
-```{cfgcmd} set protocols isis spf-delay-ietf short-delay \<milliseconds\>
+```{cfgcmd} set protocols isis spf-interval \<1-120\>
+
+**Configure the interval, in seconds, between consecutive SPF calculations
+on this router.**
+
+SPF calculations triggered by events, such as network topology changes,
+are postponed until the specified interval has elapsed since the previous
+calculation.
+```
+
+Example:
+
+```none
+set protocols isis spf-interval 5
+```
+
+The following commands implement the IETF SPF delay algorithm for IS-IS
+described in [RFC 8405](https://datatracker.ietf.org/doc/html/rfc8405).
+They control how quickly the router runs the SPF calculation after topology
+changes are detected.
+
+```{note}
+All five `spf-delay-ietf` parameters must be configured; setting only some
+of them causes a commit failure.
+```
+
+```{cfgcmd} set protocols isis spf-delay-ietf holddown \<0-60000\>
+
+**Configure the interval, in milliseconds, that must elapse without
+topology changes before the router considers the network stable.**
+
+Once this time passes, the router returns to its initial response state
+and applies `init-delay` to the next SPF calculation.
+```
+
+Example:
+
+```none
+set protocols isis spf-delay-ietf holddown 10000
+```
+
+```{cfgcmd} set protocols isis spf-delay-ietf init-delay \<0-60000\>
+
+**Configure the interval, in milliseconds, that the router waits before
+running the first SPF calculation when a new topology change arrives
+after the network is considered stable.**
+```
+
+Example:
+
+```none
+set protocols isis spf-delay-ietf init-delay 500
 ```
 
 ```{cfgcmd} set protocols isis spf-delay-ietf time-to-learn \<milliseconds\>
 
-This commands specifies the Finite State Machine (FSM) intended to
-control the timing of the execution of SPF calculations in response
-to IGP events. The process described in {rfc}`8405`.
+**Configure the learning interval, in milliseconds, that begins when the
+first topology change is received.**
+
+Within this window, the router applies the `short-delay` before performing
+SPF recalculations triggered by additional topology changes.
+
+If topology changes continue to arrive after this window expires, the
+router considers the network unstable and delays subsequent SPF
+recalculations by the configured `long-delay`.
 ```
 
-#### Loop Free Alternate (LFA)
+Example:
 
-```{cfgcmd} set protocols isis fast-reroute lfa remote prefix-list \<name\> \<level-1|level-2\>
-
-This command enables IP fast re-routing that is part of {rfc}`5286`.
-Specifically this is a prefix list which references a prefix in which
-will select eligible PQ nodes for remote LFA backups.
+```none
+set protocols isis spf-delay-ietf time-to-learn 5000
 ```
 
-```{cfgcmd} set protocols isis fast-reroute lfa local load-sharing disable \<level-1|level-2\>
+```{cfgcmd} set protocols isis spf-delay-ietf long-delay \<milliseconds\>
 
-This command disables the load sharing across multiple LFA backups.
+**Configure the interval, in milliseconds, the router applies before
+running an SPF calculation when topology changes arrive after the
+`time-to-learn` window expires.**
 ```
 
-```{cfgcmd} set protocols isis fast-reroute lfa local tiebreaker \<downstream|lowest-backup-metric|node-protecting\> index \<number\> \<level-1|level-2\>
+Example:
 
-This command will configure a tie-breaker for multiple local LFA backups.
-The lower index numbers will be processed first.
+```none
+set protocols isis spf-delay-ietf long-delay 10000
 ```
 
-```{cfgcmd} set protocols isis fast-reroute lfa local priority-limit \<medium|high|critical\> \<level-1|level-2\>
+```{cfgcmd} set protocols isis spf-delay-ietf short-delay \<milliseconds\>
 
-This command will limit LFA backup computation up to the specified
-prefix priority.
+**Configure the interval, in milliseconds, the router applies before
+running subsequent SPF calculations triggered by additional topology
+changes within the `time-to-learn` window.**
+
+The first SPF in the window is delayed by `init-delay`.
 ```
 
-#### Segment Routing over IPv6 (SRv6)
+Example:
+
+```none
+set protocols isis spf-delay-ietf short-delay 1000
+```
+
+### Loop-Free Alternate (LFA)
+
+#### Level-1
+
+```{cfgcmd} set protocols isis fast-reroute lfa remote prefix-list \<name\> level-1
+
+**Filter which PQ nodes the router evaluates as Remote LFA tunnel
+endpoints for IS-IS Level-1 using the specified prefix-list.**
+
+Only PQ nodes permitted by the prefix-list are evaluated as potential
+backup routers.
+```
+
+Example:
+
+```none
+set protocols isis fast-reroute lfa remote prefix-list CRITICAL-ROUTES level-1
+```
+
+```{cfgcmd} set protocols isis fast-reroute lfa local load-sharing disable level-1
+
+**Disable load sharing across multiple local LFAs for IS-IS Level-1.**
+
+When multiple LFAs are available to back up a given destination, the
+router uses only one LFA instead of distributing rerouted traffic across
+all of them.
+```
+
+Example:
+
+```none
+set protocols isis fast-reroute lfa local load-sharing disable level-1
+```
+
+```{cfgcmd} set protocols isis fast-reroute lfa local tiebreaker \<downstream | lowest-backup-metric | node-protecting\> index \<1-255\> level-1
+
+**Configure a tiebreaker rule for selecting a single LFA when multiple
+local LFAs exist for an IS-IS Level-1 prefix.**
+
+Tiebreaker rules with lower index numbers are evaluated first. You can
+choose one of the following tiebreaker behaviors:
+
+- `downstream`: Prefers an alternate that is closer to the destination
+  than this router.
+- `lowest-backup-metric`: Prefers the alternate with the shortest path to
+  the destination.
+- `node-protecting`: Prefers an alternate that bypasses the primary
+  next-hop router, protecting against a complete node failure rather than
+  just link failure.
+```
+
+Example:
+
+```none
+set protocols isis fast-reroute lfa local tiebreaker node-protecting index 10 level-1
+```
+
+```{cfgcmd} set protocols isis fast-reroute lfa local priority-limit \<critical | high | medium\> level-1
+
+**Configure the priority limit for calculating local LFAs in IS-IS
+Level-1.**
+
+The router calculates LFAs only for prefixes with a priority greater than
+or equal to the specified limit. For example, setting the limit to `high`
+protects both `high` and `critical` prefixes.
+```
+
+```{note}
+Prefixes carry one of the following priorities: `low`, `medium`, `high`,
+or `critical`. By default, the router assigns `medium` priority to
+loopbacks and `low` priority to all other prefixes. The limit itself
+accepts only `medium`, `high`, or `critical`.
+```
+
+Example:
+
+```none
+set protocols isis fast-reroute lfa local priority-limit critical level-1
+```
+
+#### Level-2
+
+```{cfgcmd} set protocols isis fast-reroute lfa remote prefix-list \<name\> level-2
+
+**Filter which PQ nodes the router evaluates as Remote LFA tunnel
+endpoints for IS-IS Level-2 using the specified prefix-list.**
+
+Only PQ nodes permitted by the prefix-list are evaluated as potential
+backup routers.
+```
+
+Example:
+
+```none
+set protocols isis fast-reroute lfa remote prefix-list CRITICAL-ROUTES level-2
+```
+
+```{cfgcmd} set protocols isis fast-reroute lfa local load-sharing disable level-2
+
+**Disable load sharing across multiple local LFAs for IS-IS Level-2.**
+
+When multiple LFAs are available to back up a given destination, the
+router uses only one LFA instead of distributing rerouted traffic across
+all of them.
+```
+
+Example:
+
+```none
+set protocols isis fast-reroute lfa local load-sharing disable level-2
+```
+
+```{cfgcmd} set protocols isis fast-reroute lfa local tiebreaker \<downstream | lowest-backup-metric | node-protecting\> index \<1-255\> level-2
+
+**Configure a tiebreaker rule for selecting a single LFA when multiple
+local LFAs exist for an IS-IS Level-2 prefix.**
+
+Tiebreaker rules with lower index numbers are evaluated first. You can
+choose one of the following tiebreaker behaviors:
+
+- `downstream`: Prefers an alternate that is closer to the destination
+  than this router.
+- `lowest-backup-metric`: Prefers the alternate with the shortest path to
+  the destination.
+- `node-protecting`: Prefers an alternate that bypasses the primary
+  next-hop router, protecting against a complete node failure rather than
+  just link failure.
+```
+
+Example:
+
+```none
+set protocols isis fast-reroute lfa local tiebreaker node-protecting index 10 level-2
+```
+
+```{cfgcmd} set protocols isis fast-reroute lfa local priority-limit \<critical | high | medium\> level-2
+
+**Configure the priority limit for calculating local LFAs in IS-IS
+Level-2.**
+```
+
+```{note}
+Prefixes carry one of the following priorities: `low`, `medium`, `high`,
+or `critical`. By default, the router assigns `medium` priority to
+loopbacks and `low` priority to all other prefixes. The limit itself
+accepts only `medium`, `high`, or `critical`.
+```
+
+Example:
+
+```none
+set protocols isis fast-reroute lfa local priority-limit critical level-2
+```
+
+### Segment Routing over IPv6 (SRv6)
 
 ```{cfgcmd} set protocols isis segment-routing srv6 interface \<interface\>
 
-The dummy interface used
-to install SRv6 SIDs into the Linux data plane. The interface must exist and
-must be present when configuring IS-IS with
-SRv6.
+**Enable IS-IS Segment Routing over IPv6 (SRv6) on the specified
+interface.**
+
+Once enabled, IS-IS allocates and advertises an adjacency SID for each
+IS-IS neighbor reached through this interface, so other routers can steer
+SRv6 traffic over it.
+```
+
+Example:
+
+```none
+set protocols isis segment-routing srv6 interface eth1
 ```
 
 ```{cfgcmd} set protocols isis segment-routing srv6 locator \<locator\>
 
-Specifies the SRv6 locator to use for IS-IS. IS-IS automatically allocates
-prefix and adjacency SIDs, creates local SID entries and advertises them
-into the IGP domain.
+**Configure IS-IS to use a globally defined SRv6 locator.**
+
+The locator itself must be configured separately using
+`set protocols segment-routing srv6 locator <name> prefix <ipv6-prefix>`.
+
+Once you attach the locator to IS-IS, the routing process automatically:
+
+- Allocates a node SID for the router and an adjacency SID for each of
+  its IS-IS neighbors.
+- Advertises the locator and these SIDs to the network so other routers
+  can route SRv6 traffic through this node.
+```
+
+Example:
+
+```none
+set protocols isis segment-routing srv6 locator MAIN-LOCATOR
 ```
 
 ```{cfgcmd} set protocols isis segment-routing srv6 node-msd max-end-d \<0-255\>
 
-The Maximum End D MSD Type specifies the maximum number of SIDs present in an
-SRH when performing decapsulation. As specified in {rfc}`8986`, the permitted
-SID types include, but are not limited to, End.DX6, End.DT4, End.DT46, End
-with USD, and End.X with USD.
+**Configure the Maximum End D MSD value advertised by the router
+([RFC 9352](https://datatracker.ietf.org/doc/html/rfc9352)).**
 
-If the advertised value is zero or no value is advertised, then the router
-cannot apply any behavior that results in decapsulation and forwarding of the
-inner packet if the outer IPv6 header contains an SRH.
+This value indicates the maximum number of SIDs in the SRH that this
+router can handle when performing a decapsulation behavior (e.g.,
+`End.DX6`, `End.DT4`, `End.DT46`, `End with USD`, `End.X with USD`)
+defined in [RFC 8986](https://datatracker.ietf.org/doc/html/rfc8986).
 
-Reference: {rfc}`9352`
+If this value is set to 0 or left unconfigured, the router advertises
+that it cannot decapsulate and forward packets when an SRH is present.
+```
+
+Example:
+
+```none
+set protocols isis segment-routing srv6 node-msd max-end-d 8
 ```
 
 ```{cfgcmd} set protocols isis segment-routing srv6 node-msd max-end-pop \<0-255\>
 
-The Maximum End Pop MSD Type signals the maximum number of SIDs in the SRH to
-which the router can apply "Penultimate Segment Pop (PSP) of the SRH" or
-"Ultimate Segment Pop (USP) of the SRH" behavior, as defined in "Flavors"
-(Section 4.16 of {rfc}`8986`).
+**Configure the Maximum End Pop MSD value advertised by the router
+([RFC 9352](https://datatracker.ietf.org/doc/html/rfc9352)).**
 
-If the advertised value is zero or no value is advertised, then the router
-cannot apply PSP or USP flavors.
+This value indicates the maximum number of SIDs in the received SRH to
+which this router can apply the PSP (Penultimate Segment Pop) or USP
+(Ultimate Segment Pop) flavors defined in
+[RFC 8986, §4.16](https://datatracker.ietf.org/doc/html/rfc8986#section-4.16).
 
-Reference: {rfc}`9352`
+If this value is set to 0 or left unconfigured, the router advertises
+that it cannot apply the PSP or USP flavors.
+```
+
+Example:
+
+```none
+set protocols isis segment-routing srv6 node-msd max-end-pop 16
 ```
 
 ```{cfgcmd} set protocols isis segment-routing srv6 node-msd max-h-encaps \<0-255\>
 
-The Maximum H.Encaps MSD Type signals the maximum number of SIDs that can be
-added to the segment list of an SRH as part of the "H.Encaps" behavior, as
-defined in {rfc}`8986`.
+**Configure the Maximum H.Encaps MSD value advertised by the router
+([RFC 9352](https://datatracker.ietf.org/doc/html/rfc9352)).**
 
-If the advertised value is zero or no value is advertised, then the headend
-can apply an SR Policy that only contains one segment without inserting any
-SRH header. A non-zero SRH Max H.encaps MSD indicates that the headend can
-insert an SRH up to the advertised number of SIDs.
+This value indicates the maximum number of SIDs that this router can
+insert into a new {abbr}`SRH (Segment Routing Header)` when encapsulating
+traffic (the H.Encaps behavior), as defined in
+[RFC 8986](https://datatracker.ietf.org/doc/html/rfc8986).
 
-Reference: {rfc}`9352`
+If set to 0 or left unconfigured, the router advertises that it can only
+apply an SR Policy containing a single segment, without inserting an SRH.
+```
+
+Example:
+
+```none
+set protocols isis segment-routing srv6 node-msd max-h-encaps 8
 ```
 
 ```{cfgcmd} set protocols isis segment-routing srv6 node-msd max-segs-left \<0-255\>
 
-The Maximum Segments Left MSD Type signals the maximum value of the
-"Segments Left" field ({rfc}`8754`) in the SRH of a received packet before
-applying the Endpoint behavior associated with a SID.
+**Configure the Maximum Segments Left MSD value advertised by the router
+([RFC 9352](https://datatracker.ietf.org/doc/html/rfc9352)).**
 
-If no value is advertised, the supported value is 0.
+This value indicates the maximum Segments Left value
+([RFC 8754](https://datatracker.ietf.org/doc/html/rfc8754)) in the SRH of
+a received packet that this router can process before applying the
+Endpoint behavior associated with a SID.
 
-Reference: {rfc}`9352`
+If set to 0 or left unconfigured, the router advertises that it can only
+be the last segment of an SRv6 path. Set a value greater than 0 to also
+allow the router to be used as a segment in the middle of a path.
+```
+
+Example:
+
+```none
+set protocols isis segment-routing srv6 node-msd max-segs-left 8
 ```
 
 ## Examples
 
 ### Enable IS-IS
 
+The following example demonstrates a basic IS-IS routing protocol setup between
+two VyOS routers.
+
 **Node 1:**
 
 ```none
-set interfaces loopback lo address '192.168.255.255/32'
+set interfaces loopback lo address '198.51.100.1/32'
 set interfaces ethernet eth1 address '192.0.2.1/24'
 
 set protocols isis interface eth1
@@ -457,9 +1844,7 @@ set protocols isis net '49.0001.1921.6825.5255.00'
 **Node 2:**
 
 ```none
-set interfaces ethernet eth1 address '192.0.2.2/24'
-
-set interfaces loopback lo address '192.168.255.254/32'
+set interfaces loopback lo address '198.51.100.2/32'
 set interfaces ethernet eth1 address '192.0.2.2/24'
 
 set protocols isis interface eth1
@@ -472,13 +1857,13 @@ This gives us the following neighborships, Level 1 and Level 2:
 ```none
 Node-1@vyos:~$ show isis neighbor
 Area VyOS:
-  System Id           Interface   L  State        Holdtime SNPA
+ System Id           Interface   L  State        Holdtime SNPA
  vyos                eth1        1  Up            28       0c87.6c09.0001
  vyos                eth1        2  Up            28       0c87.6c09.0001
 
 Node-2@vyos:~$ show isis neighbor
 Area VyOS:
-  System Id           Interface   L  State        Holdtime SNPA
+ System Id           Interface   L  State        Holdtime SNPA
  vyos                eth1        1  Up            29       0c33.0280.0001
  vyos                eth1        2  Up            28       0c33.0280.0001
 ```
@@ -495,7 +1880,7 @@ Codes: K - kernel route, C - connected, S - static, R - RIP,
        t - trapped, o - offload failure
 
 I   192.0.2.0/24 [115/20] via 192.0.2.2, eth1 inactive, weight 1, 00:02:22
-I>* 192.168.255.254/32 [115/20] via 192.0.2.2, eth1, weight 1, 00:02:22
+I>* 198.51.100.2/32 [115/20] via 192.0.2.2, eth1, weight 1, 00:02:22
 
 Node-2@vyos:~$ show ip route isis
 Codes: K - kernel route, C - connected, S - static, R - RIP,
@@ -506,10 +1891,14 @@ Codes: K - kernel route, C - connected, S - static, R - RIP,
        t - trapped, o - offload failure
 
 I   192.0.2.0/24 [115/20] via 192.0.2.1, eth1 inactive, weight 1, 00:02:21
-I>* 192.168.255.255/32 [115/20] via 192.0.2.1, eth1, weight 1, 00:02:21
+I>* 198.51.100.1/32 [115/20] via 192.0.2.1, eth1, weight 1, 00:02:21
 ```
 
 ### Enable IS-IS and redistribute routes not natively in IS-IS
+
+The following example demonstrates a basic IS-IS setup between two VyOS
+routers, with Node 1 also redistributing a connected network that isn't running
+IS-IS.
 
 **Node 1:**
 
@@ -523,7 +1912,7 @@ set policy route-map EXPORT-ISIS rule 10 action 'permit'
 set policy route-map EXPORT-ISIS rule 10 match ip address prefix-list 'EXPORT-ISIS'
 
 set protocols isis interface eth1
-set protocols isis net '49.0001.1921.6800.1002.00'
+set protocols isis net '49.0001.2030.1130.0001.00'
 set protocols isis redistribute ipv4 connected level-2 route-map 'EXPORT-ISIS'
 ```
 
@@ -533,7 +1922,7 @@ set protocols isis redistribute ipv4 connected level-2 route-map 'EXPORT-ISIS'
 set interfaces ethernet eth1 address '192.0.2.2/24'
 
 set protocols isis interface eth1
-set protocols isis net '49.0001.1921.6800.2002.00'
+set protocols isis net '49.0001.1920.0020.0002.00'
 ```
 
 Routes on Node 2:
@@ -551,23 +1940,26 @@ I   203.0.113.0/24 [115/10] via 192.0.2.1, eth1, 00:03:42
 
 ### Enable IS-IS and IGP-LDP synchronization
 
+The following example demonstrates an IS-IS setup with IGP-LDP synchronization
+enabled on Node 1.
+
 **Node 1:**
 
 ```none
-set interfaces loopback lo address 192.168.255.255/32
+set interfaces loopback lo address 198.51.100.1/32
 set interfaces ethernet eth0 address 192.0.2.1/24
 
 set protocols isis interface eth0
 set protocols isis interface lo passive
 set protocols isis ldp-sync
-set protocols isis net 49.0001.1921.6825.5255.00
+set protocols isis net 49.0001.1985.1100.0001.00
 
 set protocols mpls interface eth0
-set protocols mpls ldp discovery transport-ipv4-address 192.168.255.255
+set protocols mpls ldp discovery transport-ipv4-address 198.51.100.1
 set protocols mpls ldp interface lo
 set protocols mpls ldp interface eth0
 set protocols mpls ldp parameters transport-prefer-ipv4
-set protocols mpls ldp router-id 192.168.255.255
+set protocols mpls ldp router-id 198.51.100.1
 ```
 
 This gives us IGP-LDP synchronization for all non-loopback interfaces with
@@ -581,37 +1973,40 @@ eth0
   State: Sync achieved
 ```
 
-### Enable IS-IS with Segment Routing (Experimental)
+### Enable IS-IS with Segment Routing (experimental)
+
+The following example demonstrates IS-IS with segment routing between two VyOS
+routers.
 
 **Node 1:**
 
 ```none
-set interfaces loopback lo address '192.168.255.255/32'
+set interfaces loopback lo address '198.51.100.1/32'
 set interfaces ethernet eth1 address '192.0.2.1/24'
 
 set protocols isis interface eth1
 set protocols isis interface lo
-set protocols isis net '49.0001.1921.6825.5255.00'
+set protocols isis net '49.0001.1980.5110.0001.00'
 set protocols isis segment-routing global-block high-label-value '599'
 set protocols isis segment-routing global-block low-label-value '550'
-set protocols isis segment-routing prefix 192.168.255.255/32 index value '1'
-set protocols isis segment-routing prefix 192.168.255.255/32 index explicit-null
+set protocols isis segment-routing prefix 198.51.100.1/32 index value '1'
+set protocols isis segment-routing prefix 198.51.100.1/32 index explicit-null
 set protocols mpls interface 'eth1'
 ```
 
 **Node 2:**
 
 ```none
-set interfaces loopback lo address '192.168.255.254/32'
+set interfaces loopback lo address '198.51.100.2/32'
 set interfaces ethernet eth1 address '192.0.2.2/24'
 
 set protocols isis interface eth1
 set protocols isis interface lo
-set protocols isis net '49.0001.1921.6825.5254.00'
+set protocols isis net '49.0001.1980.5110.0002.00'
 set protocols isis segment-routing global-block high-label-value '599'
 set protocols isis segment-routing global-block low-label-value '550'
-set protocols isis segment-routing prefix 192.168.255.254/32 index value '2'
-set protocols isis segment-routing prefix 192.168.255.254/32 index explicit-null
+set protocols isis segment-routing prefix 198.51.100.2/32 index value '2'
+set protocols isis segment-routing prefix 198.51.100.2/32 index explicit-null
 set protocols mpls interface 'eth1'
 ```
 
@@ -649,7 +2044,7 @@ Codes: K - kernel route, C - connected, S - static, R - RIP,
        t - trapped, o - offload failure
 
 I   192.0.2.0/24 [115/20] via 192.0.2.2, eth1 inactive, weight 1, 00:07:48
-I>* 192.168.255.254/32 [115/20] via 192.0.2.2, eth1, label IPv4 Explicit Null, weight 1, 00:03:39
+I>* 198.51.100.2/32 [115/20] via 192.0.2.2, eth1, label IPv4 Explicit Null, weight 1, 00:03:39
 
 Node-2@vyos:~$ show ip route isis
 Codes: K - kernel route, C - connected, S - static, R - RIP,
@@ -660,24 +2055,27 @@ Codes: K - kernel route, C - connected, S - static, R - RIP,
        t - trapped, o - offload failure
 
 I   192.0.2.0/24 [115/20] via 192.0.2.1, eth1 inactive, weight 1, 00:07:46
-I>* 192.168.255.255/32 [115/20] via 192.0.2.1, eth1, label IPv4 Explicit Null, weight 1, 00:03:43
+I>* 198.51.100.1/32 [115/20] via 192.0.2.1, eth1, label IPv4 Explicit Null, weight 1, 00:03:43
 ```
 
-### Enable IS-IS with Segment Routing over IPv6 (Experimental)
+### Enable IS-IS with Segment Routing over IPv6 (experimental)
+
+The following example demonstrates IS-IS with Segment Routing over IPv6
+between two VyOS routers.
 
 **Node 1:**
 
 ```none
 set interfaces dummy dum6 description "SRv6 IS-IS"
 set interfaces ethernet eth1 address '192.0.2.1/24'
-set interfaces loopback lo address '192.168.255.255/32'
+set interfaces loopback lo address '198.51.100.1/32'
 
 set protocols segment-routing srv6 locator MAIN prefix 2001:db8:1::/64
 set protocols segment-routing interface eth1
 
 set protocols isis interface eth1
 set protocols isis interface lo
-set protocols isis net '49.0001.1921.6825.5255.00'
+set protocols isis net '49.0001.1980.5110.0001.00'
 set protocols isis segment-routing srv6 locator MAIN
 set protocols isis segment-routing srv6 interface dum6
 ```
@@ -687,26 +2085,29 @@ set protocols isis segment-routing srv6 interface dum6
 ```none
 set interfaces dummy dum6 description "SRv6 IS-IS"
 set interfaces ethernet eth1 address '192.0.2.2/24'
-set interfaces loopback lo address '192.168.255.254/32'
+set interfaces loopback lo address '198.51.100.2/32'
 
 set protocols segment-routing srv6 locator MAIN prefix 2001:db8:2::/64
 set protocols segment-routing interface eth1
 
 set protocols isis interface eth1
 set protocols isis interface lo
-set protocols isis net '49.0001.1921.6825.5254.00'
+set protocols isis net '49.0001.1980.5110.0002.00'
 set protocols isis segment-routing srv6 locator MAIN
 set protocols isis segment-routing srv6 interface dum6
 ```
 
-### Enable IS-IS with Segment Routing over IPv6 (uSID) (Experimental)
+### Enable IS-IS with Segment Routing over IPv6 (uSID) (experimental)
+
+The following example demonstrates IS-IS with SRv6 uSID (micro-SID) between two
+VyOS routers.
 
 **Node 1:**
 
 ```none
 set interfaces dummy dum6 description "SRv6 IS-IS"
 set interfaces ethernet eth1 address '192.0.2.1/24'
-set interfaces loopback lo address '192.168.255.255/32'
+set interfaces loopback lo address '198.51.100.1/32'
 
 set protocols segment-routing interface eth1
 set protocols segment-routing srv6 locator MAIN prefix 2001:db8:1::/48
@@ -718,7 +2119,7 @@ set protocols segment-routing srv6 locator MAIN node-len 16
 
 set protocols isis interface eth1
 set protocols isis interface lo
-set protocols isis net '49.0001.1921.6825.5255.00'
+set protocols isis net '49.0001.1980.5110.0001.00'
 set protocols isis segment-routing srv6 interface dum6
 set protocols isis segment-routing srv6 locator MAIN
 ```
@@ -728,7 +2129,7 @@ set protocols isis segment-routing srv6 locator MAIN
 ```none
 set interfaces dummy dum6 description "SRv6 IS-IS"
 set interfaces ethernet eth1 address '192.0.2.2/24'
-set interfaces loopback lo address '192.168.255.254/32'
+set interfaces loopback lo address '198.51.100.2/32'
 
 set protocols segment-routing interface eth1
 set protocols segment-routing srv6 locator MAIN prefix 2001:db8:2::/48
@@ -740,7 +2141,7 @@ set protocols segment-routing srv6 locator MAIN node-len 16
 
 set protocols isis interface eth1
 set protocols isis interface lo
-set protocols isis net '49.0001.1921.6825.5254.00'
+set protocols isis net '49.0001.1980.5110.0002.00'
 set protocols isis segment-routing srv6 interface dum6
 set protocols isis segment-routing srv6 locator MAIN
 ```

--- a/docs/configuration/protocols/isis.md
+++ b/docs/configuration/protocols/isis.md
@@ -200,9 +200,11 @@ set protocols isis set-overload-bit
 
 ```{cfgcmd} set protocols isis advertise-high-metrics
 
-**Configure the router to advertise the maximum non-infinite metric value
-on all of its IS-IS interfaces, regardless of the metric configured on
-each interface.**
+**Configure the router to advertise a high metric value on all of its IS-IS
+interfaces, regardless of the metric configured on each interface.**
+
+The advertised value depends on the metric style: 63 for `narrow`, 16777215
+for `wide`, and 62 for `transition`.
 ```
 
 Example:
@@ -215,6 +217,9 @@ set protocols isis advertise-high-metrics
 
 **Configure the router to advertise in its LSPs only the IP prefixes of
 passive interfaces.**
+
+Prefixes of non-passive interfaces are not advertised, but those interfaces
+are still used to form adjacencies and participate in SPF.
 ```
 
 Example:
@@ -263,9 +268,10 @@ IS-IS supports two protocol-wide passwords:
 - **domain-password**: applied to Level-2 LSPs/SNPs (across the Level-2
   backbone).
 
-These are distinct from the per-interface `password` command
-(see [Interface configuration](#interface-configuration)), which
-authenticates Hello (IIH) PDUs on a single link only.
+These are distinct from the per-interface `password` command (see
+[Interface configuration](#interface-configuration)). That command
+authenticates only the Hello (IIH) PDUs exchanged with the neighbor on the
+interface where it is configured.
 
 ```{cfgcmd} set protocols isis area-password plaintext-password \<text\>
 
@@ -903,6 +909,7 @@ Example:
 set protocols isis interface eth1 ldp-sync disable
 ```
 
+```{cfgcmd} set protocols isis interface \<interface\> ldp-sync holddown \<0-10000\>
 
 **Configure the time, in seconds, that IS-IS keeps the specified interface
 at max-metric while waiting for LDP-IGP synchronization to complete.**
@@ -1233,6 +1240,11 @@ set protocols isis interface eth1 fast-reroute ti-lfa level-2 node-protection li
 specified route source into IS-IS Level-1.**
 ```
 
+```{note}
+This command requires the router's IS-IS level to be set to `level-1` or
+`level-1-2`.
+```
+
 Example:
 
 ```none
@@ -1243,6 +1255,11 @@ set protocols isis redistribute ipv4 bgp level-1
 
 **Configure the IS-IS metric for IPv4 routes redistributed from the
 specified route source into IS-IS Level-1.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-1` or
+`level-1-2`.
 ```
 
 Example:
@@ -1260,6 +1277,11 @@ Only routes permitted by the route-map are redistributed. The route-map
 can modify the metric and tag of permitted routes.
 ```
 
+```{note}
+This command requires the router's IS-IS level to be set to `level-1` or
+`level-1-2`.
+```
+
 Example:
 
 ```none
@@ -1274,6 +1296,11 @@ set protocols isis redistribute ipv4 bgp level-1 route-map BGP-TO-ISIS
 specified route source into IS-IS Level-1.**
 ```
 
+```{note}
+This command requires the router's IS-IS level to be set to `level-1` or
+`level-1-2`.
+```
+
 Example:
 
 ```none
@@ -1284,6 +1311,11 @@ set protocols isis redistribute ipv6 bgp level-1
 
 **Configure the IS-IS metric for IPv6 routes redistributed from the
 specified route source into IS-IS Level-1.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-1` or
+`level-1-2`.
 ```
 
 Example:
@@ -1301,6 +1333,11 @@ Only routes permitted by the route-map are redistributed. The route-map
 can modify the metric and tag of permitted routes.
 ```
 
+```{note}
+This command requires the router's IS-IS level to be set to `level-1` or
+`level-1-2`.
+```
+
 Example:
 
 ```none
@@ -1315,6 +1352,11 @@ set protocols isis redistribute ipv6 bgp level-1 route-map BGP-TO-ISIS
 specified route source into IS-IS Level-2.**
 ```
 
+```{note}
+This command requires the router's IS-IS level to be set to `level-2` or
+`level-1-2`.
+```
+
 Example:
 
 ```none
@@ -1325,6 +1367,11 @@ set protocols isis redistribute ipv4 bgp level-2
 
 **Configure the IS-IS metric for IPv4 routes redistributed from the
 specified route source into IS-IS Level-2.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-2` or
+`level-1-2`.
 ```
 
 Example:
@@ -1342,6 +1389,11 @@ Only routes permitted by the route-map are redistributed. The route-map
 can modify the metric and tag of permitted routes.
 ```
 
+```{note}
+This command requires the router's IS-IS level to be set to `level-2` or
+`level-1-2`.
+```
+
 Example:
 
 ```none
@@ -1356,6 +1408,11 @@ set protocols isis redistribute ipv4 bgp level-2 route-map BGP-TO-ISIS
 specified route source into IS-IS Level-2.**
 ```
 
+```{note}
+This command requires the router's IS-IS level to be set to `level-2` or
+`level-1-2`.
+```
+
 Example:
 
 ```none
@@ -1366,6 +1423,11 @@ set protocols isis redistribute ipv6 bgp level-2
 
 **Configure the IS-IS metric for IPv6 routes redistributed from the
 specified route source into IS-IS Level-2.**
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-2` or
+`level-1-2`.
 ```
 
 Example:
@@ -1381,6 +1443,11 @@ source into IS-IS Level-2.**
 
 Only routes permitted by the route-map are redistributed. The route-map
 can modify the metric and tag of permitted routes.
+```
+
+```{note}
+This command requires the router's IS-IS level to be set to `level-2` or
+`level-1-2`.
 ```
 
 Example:
@@ -1409,6 +1476,7 @@ Example:
 set protocols isis lsp-gen-interval 5
 ```
 
+```{cfgcmd} set protocols isis lsp-refresh-interval \<2-65235\>
 
 **Configure the maximum interval, in seconds, between consecutive
 regenerations of this router's own LSP.**
@@ -1500,6 +1568,7 @@ Example:
 set protocols isis spf-delay-ietf init-delay 500
 ```
 
+```{cfgcmd} set protocols isis spf-delay-ietf time-to-learn \<0-60000\>
 
 **Configure the learning interval, in milliseconds, that begins when the
 first topology change is received.**
@@ -1518,6 +1587,7 @@ Example:
 set protocols isis spf-delay-ietf time-to-learn 5000
 ```
 
+```{cfgcmd} set protocols isis spf-delay-ietf long-delay \<0-60000\>
 
 **Configure the interval, in milliseconds, the router applies before
 running an SPF calculation when topology changes arrive after the
@@ -1530,6 +1600,7 @@ Example:
 set protocols isis spf-delay-ietf long-delay 10000
 ```
 
+```{cfgcmd} set protocols isis spf-delay-ietf short-delay \<0-60000\>
 
 **Configure the interval, in milliseconds, the router applies before
 running subsequent SPF calculations triggered by additional topology
@@ -1833,7 +1904,7 @@ set interfaces ethernet eth1 address '192.0.2.1/24'
 
 set protocols isis interface eth1
 set protocols isis interface lo
-set protocols isis net '49.0001.1921.6825.5255.00'
+set protocols isis net '49.0001.1980.5110.0001.00'
 ```
 
 **Node 2:**
@@ -1844,7 +1915,7 @@ set interfaces ethernet eth1 address '192.0.2.2/24'
 
 set protocols isis interface eth1
 set protocols isis interface lo
-set protocols isis net '49.0001.1921.6825.5254.00'
+set protocols isis net '49.0001.1980.5110.0002.00'
 ```
 
 This gives us the following neighborships, Level 1 and Level 2:
@@ -1947,7 +2018,7 @@ set interfaces ethernet eth0 address 192.0.2.1/24
 set protocols isis interface eth0
 set protocols isis interface lo passive
 set protocols isis ldp-sync
-set protocols isis net 49.0001.1985.1100.0001.00
+set protocols isis net 49.0001.1980.5110.0001.00
 
 set protocols mpls interface eth0
 set protocols mpls ldp discovery transport-ipv4-address 198.51.100.1


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR refactors the IS-IS page to comply with the current VyOS documentation style guide.

Changes:

* AI & SEO Context: Added :description: and :keywords: metadata tags.
* Content: Proofread and improved.
* Technical accuracy: Verified commands against VyOS 1.5.
* Added examples for all commands.

Added new conf-mode commands:

set protocols isis advertise-high-metrics
set protocols isis advertise-passive-only
set protocols isis log-adjacency-changes
set protocols isis topology <ipv4-multicast | ipv4-mgmt | ipv6-unicast | ipv6-multicast | ipv6-mgmt | ipv6-dstsrc>
set protocols isis area-password plaintext-password 
set protocols isis area-password md5 
set protocols isis domain-password plaintext-password 
set protocols isis domain-password md5 
set protocols isis default-information originate ipv4 level-1 always
set protocols isis default-information originate ipv4 level-1 metric <0-16777215>
set protocols isis default-information originate ipv4 level-1 route-map 
set protocols isis default-information originate ipv6 level-1 always
set protocols isis default-information originate ipv6 level-1 metric <0-16777215>
set protocols isis default-information originate ipv6 level-1 route-map 
set protocols isis default-information originate ipv4 level-2 always
set protocols isis default-information originate ipv4 level-2 metric <0-16777215>
set protocols isis default-information originate ipv4 level-2 route-map 
set protocols isis default-information originate ipv6 level-2 always
set protocols isis default-information originate ipv6 level-2 metric <0-16777215>
set protocols isis default-information originate ipv6 level-2 route-map 
set protocols isis interface  password md5 
set protocols isis interface  bfd profile 
set protocols isis redistribute ipv4 <babel | nhrp> level-1
set protocols isis redistribute ipv4 <babel | nhrp> level-1 metric <0-16777215>
set protocols isis redistribute ipv4 <babel | nhrp> level-1 route-map 
set protocols isis redistribute ipv4 <babel | nhrp> level-2
set protocols isis redistribute ipv4 <babel | nhrp> level-2 metric <0-16777215>
set protocols isis redistribute ipv4 <babel | nhrp> level-2 route-map 
set protocols isis redistribute ipv6 <bgp | connected | kernel | ospf6 | ripng | babel | static> level-1
set protocols isis redistribute ipv6 <bgp | connected | kernel | ospf6 | ripng | babel | static> level-1 metric <0-16777215>
set protocols isis redistribute ipv6 <bgp | connected | kernel | ospf6 | ripng | babel | static> level-1 route-map 
set protocols isis redistribute ipv6 <bgp | connected | kernel | ospf6 | ripng | babel | static> level-2
set protocols isis redistribute ipv6 <bgp | connected | kernel | ospf6 | ripng | babel | static> level-2 metric <0-16777215>
set protocols isis redistribute ipv6 <bgp | connected | kernel | ospf6 | ripng | babel | static> level-2 route-map 

Added value range for:

set protocols isis lsp-mtu <128-4352>
set protocols isis lsp-gen-interval <1-120>
set protocols isis spf-interval <1-120>
set protocols isis max-lsp-lifetime <350-65535>
set protocols isis spf-delay-ietf holddown <0-60000>
set protocols isis spf-delay-ietf init-delay <0-60000>
set protocols isis interface  hello-interval <1-600>
set protocols isis interface  hello-multiplier <2-100>
set protocols isis interface  metric <0-16777215>
set protocols isis interface  priority <0-127>
set protocols isis interface  psnp-interval <0-127>
set protocols isis interface  fast-reroute remote-lfa level-1 maximum-metric <1-16777215>
set protocols isis interface  fast-reroute remote-lfa level-2 maximum-metric <1-16777215>
set protocols isis fast-reroute lfa local tiebreaker <downstream | lowest-backup-metric | node-protecting> index <1-255> level-1
set protocols isis fast-reroute lfa local tiebreaker <downstream | lowest-backup-metric | node-protecting> index <1-255> level-2

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
VD-3731

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document
- [x] The style guide checklist was applied.