### PR TITLE
DOCS: traffic-engineering: backport from rolling

### DIFF
--- a/docs/configuration/protocols/traffic-engineering.md
+++ b/docs/configuration/protocols/traffic-engineering.md
@@ -1,54 +1,136 @@
+---
+myst:
+  html_meta:
+    description: |
+      Traffic Engineering (TE) is a set of techniques for steering traffic
+      along paths different from the shortest path computed by the IGP.
+    keywords: traffic engineering, te, isis, mpls, srv6, admin-group,
+      bandwidth, ted
+---
+
 (traffic-engineering)=
 
 # Traffic Engineering
 
-Traffic Engineering (TE) is possibility to send traffic from node to node using
-alternative path.
+{abbr}`TE (Traffic Engineering)` is a set of techniques for steering traffic
+along paths different from the shortest path computed by the
+{abbr}`IGP (Interior Gateway Protocol)`.
+
+To enforce these paths, TE typically uses a form of source routing, such as
+{abbr}`MPLS (Multiprotocol Label Switching)` labels or
+{abbr}`SRv6 (Segment Routing over IPv6)` extension headers, combined with
+path constraints, such as administrative groups or bandwidth requirements,
+and a method to map traffic to TE paths.
+
+Use the commands below to configure link-level TE attributes (administrative
+groups and bandwidth) and enable TE in the IGP (specifically, IS-IS) so this
+information is distributed across the network.
 
 ## Common link parameters
 
-Traffic Engineering parameters are used for both IS-IS and OSPF (not supported yet).
+The following commands define link-level TE attributes that can be advertised
+by both IS-IS and OSPF (not supported yet).
 
-```{cfgcmd} set protocols traffic-engineering admin-group \<admin-group-name\> bit-position \<bit-position-value\>
+```{cfgcmd} set protocols traffic-engineering admin-group \<admin-group-name\> bit-position \<0-31\>
 
-Create Administrative group and assosiate bit position with it. These groups can be
-used in the following commands.
+**Configure an administrative group and associate it with a bit position.**
 
-\<bit-position-value\> can have value 0-31. There cannot be two groups with same bit position.
+These groups can then be referenced by the per-interface commands below.
 ```
 
+```{note}
+Two administrative groups cannot share the same `bit-position` value.
+```
+
+Example:
+
+```none
+set protocols traffic-engineering admin-group primary bit-position 0
+set protocols traffic-engineering admin-group backup bit-position 1
+```
 
 ```{cfgcmd} set protocols traffic-engineering interface \<ifname\> admin-group \<admin-group-name\>
 
-Set administrative group for interface \<ifname\>. Multiple values can be provided.
+**Configure an administrative group on the specified interface.**
+
+You can configure multiple administrative groups on the same interface.
 ```
 
+Example:
 
-```{cfgcmd} set protocols traffic-engineering interface \<ifname\> max-bandwidth \<max-bandwidth-value-mbps\>
-
-Set maximum bandwidth for interface \<ifname\>. Value given in Mbits per second.
+```none
+set protocols traffic-engineering interface eth0 admin-group primary
 ```
 
+```{cfgcmd} set protocols traffic-engineering interface \<ifname\> metric \<1-4294967295\>
 
-```{cfgcmd} set protocols traffic-engineering interface \<ifname\> max-reservable-bandwidth \<max-reservable-bandwidth-value-mbps\>
-
-Set maximum reservable bandwidth for interface \<ifname\>. Value given in Mbits per second.
+**Configure the TE metric for the specified interface (distinct from the
+OSPF/ISIS metric).**
 ```
 
-## IS-IS TE Configuration
+Example:
 
-Traffic Engineering (TE) can be enabled and exported for IS-IS
-using the following commands:
+```none
+set protocols traffic-engineering interface eth0 metric 100
+```
+
+```{cfgcmd} set protocols traffic-engineering interface \<ifname\> max-bandwidth \<1-4294967295\>
+
+**Configure the maximum bandwidth, in Mbps, for the specified interface.**
+```
+
+Example:
+
+```none
+set protocols traffic-engineering interface eth0 max-bandwidth 1000
+```
+
+```{cfgcmd} set protocols traffic-engineering interface \<ifname\> max-reservable-bandwidth \<1-4294967295\>
+
+**Configure the maximum reservable bandwidth, in Mbps, for the specified
+interface.**
+```
+
+Example:
+
+```none
+set protocols traffic-engineering interface eth0 max-reservable-bandwidth 800
+```
+
+## IS-IS TE configuration
+
+The following commands enable TE for IS-IS.
 
 ```{cfgcmd} set protocols isis traffic-engineering enable
 
-Enable Traffic Engineering for IS-IS.
+**Enable Traffic Engineering for IS-IS.**
 ```
+
+Example:
+
+```none
+set protocols isis traffic-engineering enable
+```
+
 ```{cfgcmd} set protocols isis traffic-engineering export
 
-Export Traffic Engineering data to neighbors.
+**Export the local {abbr}`TED (Traffic Engineering Database)` to other FRR
+daemons.**
 ```
+
+Example:
+
+```none
+set protocols isis traffic-engineering export
+```
+
 ```{cfgcmd} set protocols isis traffic-engineering address \<ipv4-address\>
 
-Configure IPv4 address for MPLS-TE.
+**Configure the IPv4 address used as the TE Router ID for MPLS-TE.**
+```
+
+Example:
+
+```none
+set protocols isis traffic-engineering address 198.51.100.1
 ```


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR backports the Traffic Engineering page from `rolling` to `circinus` (1.5).

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->


## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document