### PR TITLE
docs: Update the minisign verification with the correct public key

### DIFF
--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -128,7 +128,9 @@ and Minisign.
 
 #### Minisign verification
 
+% stop_vyoslinter
 VyOS signs its release images with [minisign](https://github.com/jedisct1/minisign),
+% start_vyoslinter
 a portable Ed25519-based signing tool available for Linux, macOS, and
 Windows. Minisign uses the same signature format as OpenBSD's signify,
 introduced in 2014.
@@ -143,7 +145,7 @@ signature file in the same directory, then run:
 ```none
 $ minisign -V -P RWTR1ty93Oyontk6caB9WqmiQC4fgeyd/ejgRxCRGd2MQej7nqebHneP -m vyos-1.x.x-amd64.iso vyos-1.x.x-amd64.iso.minisig
 Signature and comment signature verified
-Trusted comment: timestamp:<unix_ts>   file:vyos-1.x.x-amd64.iso
+Trusted comment: timestamp:<unix_ts>    file:vyos-1.x.x-amd64.iso    hashed
 ```
 
 During an image upgrade, VyOS runs the equivalent check using the

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -141,18 +141,18 @@ To verify a downloaded LTS image, place the image and its `.minisig`
 signature file in the same directory, then run:
 
 ```none
-$ minisign -V -P RWTR1ty93Oyontk6caB9WqmiQC4fgeyd/ejgRxCRGd2MQej7nqebHneP -m vyos-1.4.x-amd64.iso vyos-1.4.x-amd64.iso.minisig
+$ minisign -V -P RWTR1ty93Oyontk6caB9WqmiQC4fgeyd/ejgRxCRGd2MQej7nqebHneP -m vyos-1.x.x-amd64.iso vyos-1.x.x-amd64.iso.minisig
 Signature and comment signature verified
-Trusted comment: timestamp:<unix_ts>   file:vyos-1.4.x-amd64.iso
+Trusted comment: timestamp:<unix_ts>   file:vyos-1.x.x-amd64.iso
 ```
 
 During an image upgrade, VyOS runs the equivalent check using the
 public key included with the system:
 
 ```none
-$ minisign -V -p /usr/share/vyos/keys/vyos-release.minisign.pub -m vyos-1.4.x-amd64.iso vyos-1.4.x-amd64.iso.minisig
+$ minisign -V -p /usr/share/vyos/keys/vyos-release.minisign.pub -m vyos-1.x.x-amd64.iso vyos-1.x.x-amd64.iso.minisig
 Signature and comment signature verified
-Trusted comment: timestamp:<unix_ts>   file:vyos-1.4.x-amd64.iso
+Trusted comment: timestamp:<unix_ts>   file:vyos-1.x.x-amd64.iso
 ```
 
 :::{warning}
@@ -165,8 +165,8 @@ repository.
 :::
 
 :::{note}
-Releases up to VyOS 1.4.2 were signed with both minisign (preferred)
-and GPG. Beginning with 1.4.3, only minisign signatures are used. This
+Releases up to VyOS 1.4.2 were signed with both Minisign (preferred)
+and GPG. Beginning with 1.4.3, only Minisign signatures are used. This
 change should not affect most upgrades. If you encounter a verification
 error when upgrading directly to 1.4.3 or later, upgrade to 1.4.2 first.
 :::

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -162,7 +162,9 @@ VyOS rolling (nightly) images are signed with a **different key**:
 `RWSIhkR/dkM2DSaBRniv/bbbAf8hmDqdbOEmgXkf1RxRoxzodgKcDyGq`.
 Verification fails if you use the LTS key against a rolling image or
 the rolling key against an LTS image. The **rolling key** is published in
+% stop_vyoslinter
 the [vyos-nightly-build](https://github.com/vyos/vyos-nightly-build/blob/rolling/minisign.pub)
+% start_vyoslinter
 repository.
 :::
 

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -154,7 +154,7 @@ public key included with the system:
 ```none
 $ minisign -V -p /usr/share/vyos/keys/vyos-release.minisign.pub -m vyos-1.x.x-amd64.iso vyos-1.x.x-amd64.iso.minisig
 Signature and comment signature verified
-Trusted comment: timestamp:<unix_ts>   file:vyos-1.x.x-amd64.iso
+Trusted comment: timestamp:<unix_ts>   file:vyos-1.x.x-amd64.iso    hashed
 ```
 
 :::{warning}

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -165,8 +165,8 @@ repository.
 :::
 
 :::{note}
-Releases up to VyOS 1.4.2 were signed with both Minisign (preferred)
-and GPG. Beginning with 1.4.3, only Minisign signatures are used. This
+Releases up to VyOS 1.4.2 were signed with both minisign (preferred)
+and GPG. Beginning with 1.4.3, only minisign signatures are used. This
 change should not affect most upgrades. If you encounter a verification
 error when upgrading directly to 1.4.3 or later, upgrade to 1.4.2 first.
 :::

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -128,38 +128,47 @@ and Minisign.
 
 #### Minisign verification
 
-VyOS uses [Minisign](https://github.com/jedisct1/minisign) for release
-signing. Minisign is a tool for signing files and verifying signatures.
+VyOS signs its release images with [minisign](https://github.com/jedisct1/minisign),
+a portable Ed25519-based signing tool available for Linux, macOS, and
+Windows. Minisign uses the same signature format as OpenBSD's signify,
+introduced in 2014.
 
-OpenBSD introduced signify in 2015. Minisign is an alternative
-implementation of the same protocol, available for Windows, macOS, and
-most GNU/Linux distributions. Minisign is portable, lightweight, and
-uses the Ed25519 public-key signature system.
+All **VyOS LTS images** are signed with the following key:
 
-{vytask}`T2108` switched the validation system to prefer Minisign over GPG keys.
+`RWTR1ty93Oyontk6caB9WqmiQC4fgeyd/ejgRxCRGd2MQej7nqebHneP`
 
-To verify a VyOS image starting with VyOS `1.3.0-rc6`, run:
-
-```none
-$ minisign -V -P RWSIhkR/dkM2DSaBRniv/bbbAf8hmDqdbOEmgXkf1RxRoxzodgKcDyGq -m vyos-1.5-rolling-202409250007-generic-amd64.iso vyos-1.5-rolling-202409250007-generic-amd64.iso.minisig
-
-Signature and comment signature verified
-Trusted comment: timestamp:1727223408 file:vyos-1.5-rolling-202409250007-generic-amd64.iso    hashed
-```
-
-During an image upgrade, VyOS runs the following command:
+To verify a downloaded LTS image, place the image and its `.minisig`
+signature file in the same directory, then run:
 
 ```none
-$ minisign -V -p /usr/share/vyos/keys/vyos-release.minisign.pub -m vyos-1.3.0-rc6-amd64.iso vyos-1.3.0-rc6-amd64.iso.minisig
+$ minisign -V -P RWTR1ty93Oyontk6caB9WqmiQC4fgeyd/ejgRxCRGd2MQej7nqebHneP -m vyos-1.4.x-amd64.iso vyos-1.4.x-amd64.iso.minisig
 Signature and comment signature verified
-Trusted comment: timestamp:1629997936   file:vyos-1.3.0-rc6-amd64.iso
+Trusted comment: timestamp:<unix_ts>   file:vyos-1.4.x-amd64.iso
 ```
+
+During an image upgrade, VyOS runs the equivalent check using the
+public key included with the system:
+
+```none
+$ minisign -V -p /usr/share/vyos/keys/vyos-release.minisign.pub -m vyos-1.4.x-amd64.iso vyos-1.4.x-amd64.iso.minisig
+Signature and comment signature verified
+Trusted comment: timestamp:<unix_ts>   file:vyos-1.4.x-amd64.iso
+```
+
+:::{warning}
+VyOS rolling (nightly) images are signed with a **different key**:
+`RWSIhkR/dkM2DSaBRniv/bbbAf8hmDqdbOEmgXkf1RxRoxzodgKcDyGq`.
+Verification fails if you use the LTS key against a rolling image or
+the rolling key against an LTS image. The **rolling key** is published in
+the [vyos-nightly-build](https://github.com/vyos/vyos-nightly-build/blob/rolling/minisign.pub)
+repository.
+:::
 
 :::{note}
-Starting with version `1.4.3`, VyOS uses Minisign exclusively.
-If you see an unexpected verification error, update your system to version
-`1.4.2` first. Support for GnuPG signatures has been
-removed ({vytask}`T7301`).
+Releases up to VyOS 1.4.2 were signed with both minisign (preferred)
+and GPG. Beginning with 1.4.3, only minisign signatures are used. This
+change should not affect most upgrades. If you encounter a verification
+error when upgrading directly to 1.4.3 or later, upgrade to 1.4.2 first.
 :::
 
 (live_installation)=


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR updates the minisign verification with the correct public key, as the existing example is kind of creating confusion for customers.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
VD-4472

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document