### PR TITLE
docs: update flowtable and ethernet/bonding documentation

### DIFF
--- a/docs/configuration/firewall/flowtables.md
+++ b/docs/configuration/firewall/flowtables.md
@@ -279,7 +279,7 @@ Run the following command to verify that the connections are offloaded to
 the flowtable fast path:
 
 ```none
-vyos@firewall:~$ sudo conntrack -L | grep OFFLOAD
+vyos@FlowTables:~$ sudo conntrack -L | grep OFFLOAD
 tcp      6 src=192.168.10.2 dst=192.168.20.2 sport=55604 dport=5201 src=192.168.20.2 dst=192.168.10.2 sport=5201 dport=55604 [OFFLOAD] mark=0 use=5
 tcp      6 src=192.168.10.2 dst=192.168.20.2 sport=55602 dport=5201 src=192.168.20.2 dst=192.168.10.2 sport=5201 dport=55602 [OFFLOAD] mark=0 use=2
 conntrack v1.4.6 (conntrack-tools): 2 flow entries have been shown.
@@ -288,4 +288,4 @@ conntrack v1.4.6 (conntrack-tools): 2 flow entries have been shown.
 The `[OFFLOAD]` flag confirms that post-handshake packets for these flows
 are forwarded via the flowtable fast path, bypassing the firewall entirely.
 This applies to sub-interface traffic (`bond1.10` → `bond2.20`) in the
-same way as physical interface traffic..
+same way as physical interface traffic.

--- a/docs/configuration/firewall/flowtables.md
+++ b/docs/configuration/firewall/flowtables.md
@@ -166,8 +166,10 @@ Here's what happens for a desired connection:
 
 ## Flowtable Configuration on Logical and Sub-Interfaces
 
-Configure the flowtable with the interface name you used in VyOS configuration. 
-When VLANs, bonds, or bridges are involved, that is the logical interface (bond0, br0, eth0.10) — not the underlying physical port.
+Configure the flowtable with the interface name you used in VyOS
+configuration. When VLANs, bonds, or bridges are involved, that is the
+logical interface (`bond0`, `br0`, `eth0.10`) — not the underlying physical
+port.
 
 For example:
 - If `bond0` is configured, VyOS sees `bond0` — not `eth0` or `eth1`

--- a/docs/configuration/firewall/flowtables.md
+++ b/docs/configuration/firewall/flowtables.md
@@ -99,9 +99,9 @@ to use. Only applicable if the action is ``offload``.
 
 ### Interface Selection
 :::{important}
-Always configure the flowtable with the interface that Netfilter observes
+Always configure the flowtable with the interface that VyOS observes
 at the forward hook — which is not necessarily the physical interface.
-When traffic is received or transmitted via a logical interface, Netfilter
+When traffic is received or transmitted via a logical interface, VyOS
 tracks that logical interface, not the underlying physical device. Registering
 the wrong interface in the flowtable causes every flow lookup to miss,
 falling back to the classic forwarding path and defeating the purpose of
@@ -167,15 +167,15 @@ Here's what happens for a desired connection:
 ### Flowtable Configuration on Logical and Sub-Interfaces
 
 When configuring flowtables it is essential to identify which interface
-Netfilter observes at the forward hook for ingress and egress traffic.
-The Netfilter framework identifies interfaces by their **iifname** and
+VyOS observes at the forward hook for ingress and egress traffic.
+The VyOS identifies interfaces by their **iifname** and
 **oifname** — always at the highest logical level, not the underlying
 physical members.
 
 For example:
-- If `bond0` is configured, Netfilter sees `bond0` — not `eth0` or `eth1`
-- If `br0` is configured, Netfilter sees `br0` — not its member interfaces
-- The flowtable must reference the same interface name Netfilter observes
+- If `bond0` is configured, VyOS sees `bond0` — not `eth0` or `eth1`
+- If `br0` is configured, VyOS sees `br0` — not its member interfaces
+- The flowtable must reference the same interface name VyOS observes
 
 The behaviour differs for sub-interfaces (VLANs):
 
@@ -227,6 +227,9 @@ The interface directions in this example are from the perspective of
 client-to-server traffic. In practice each interface handles traffic in
 both directions, and the flowtable manages offload symmetrically once the
 flow is established.
+To be sure what are the ingress and egress interface, you can check the firewall
+logs, by enabling the log in any rule of the forward hook. Check firewall section
+for the configuration.
 :::
 
 ### Checks
@@ -253,3 +256,10 @@ conntrack v1.4.6 (conntrack-tools): 5 flow entries have been shown.
 tcp      6 src=198.51.100.100 dst=192.0.2.100 sport=41676 dport=1122 src=192.0.2.100 dst=198.51.100.100 sport=1122 dport=41676 [OFFLOAD] mark=0 use=2
 vyos@FlowTables:~$
 ```
+Check the interfaces where traffic is being forwarded:
+
+```none
+vyos@FlowTables:~$ show log firewall
+Jun 18 22:22:00 kernel: [ipv4-FWD-filter-200-A]IN=bond1.10 OUT=bond2.20 MAC=02:dd:f1:e7:3d:00:5a:a3:d1:fc:5f:cb:08:00 SRC=192.168.10.2 DST=192.168.20.2 LEN=84 TOS=0x00 PREC=0x00 TTL=63 ID=56215 DF PROTO=ICMP TYPE=8 CODE=0 ID=3572 SEQ=1
+```
+Notice the IN and OUT interface are bond1.10 and bond2.20 and not the physical interface. 

--- a/docs/configuration/firewall/flowtables.md
+++ b/docs/configuration/firewall/flowtables.md
@@ -62,10 +62,7 @@ To use flowtables, you need to configure the following:
 Creating a flow table:
 
 ```{cfgcmd} set firewall flowtable \<flow_table_name\> interface \<iface\>
-
 Specify interfaces to use in the flowtable.
-
-```
 
 ```{cfgcmd} set firewall flowtable \<flow_table_name\> description \<text\>
 ```

--- a/docs/configuration/firewall/flowtables.md
+++ b/docs/configuration/firewall/flowtables.md
@@ -252,10 +252,10 @@ Rule     Action    Protocol      Packets    Bytes  Conditions
 110      accept    tcp                 2      120  ip daddr 192.0.2.100 tcp dport 1122 iifname "eth0"  accept
 default  drop      all                 7      420
 
-vyos@FlowTables:~$ sudo conntrack -L | grep tcp
-conntrack v1.4.6 (conntrack-tools): 5 flow entries have been shown.
-tcp      6 src=198.51.100.100 dst=192.0.2.100 sport=41676 dport=1122 src=192.0.2.100 dst=198.51.100.100 sport=1122 dport=41676 [OFFLOAD] mark=0 use=2
-vyos@FlowTables:~$
+vyos@FlowTables:~$ show conntrack table ipv4
+Original src        Original dst    Reply src        Reply dst           Protocol    State    Timeout    Mark    Zone
+------------------  --------------  ---------------  ------------------  ----------  -------  ---------  ------  ------
+198.51.100.100:41676  192.0.2.100:1122  192.0.2.100:1122  198.51.100.100:41676  tcp                  n/a        0
 ```
 
 #### Interface identification
@@ -279,14 +279,20 @@ Run the following command to verify that the connections are offloaded to
 the flowtable fast path:
 
 ```none
-vyos@firewall:~$ show conntrack table ipv4
-Id          Original src        Original dst       Reply src          Reply dst           Protocol    State    Timeout    Mark    Zone
-----------  ------------------  -----------------  -----------------  ------------------  ----------  -------  ---------  ------  ------
-167046433   192.168.10.2:45140  192.168.20.2:5201  192.168.20.2:5201  192.168.10.2:45140  tcp                  n/a        0
-4162237083  192.168.10.2:45124  192.168.20.2:5201  192.168.20.2:5201  192.168.10.2:45124  tcp                  n/a        0
+vyos@FlowTables:~$ show conntrack table ipv4
+Original src        Original dst       Reply src          Reply dst           Protocol    State    Timeout    Mark    Zone
+------------------  -----------------  -----------------  ------------------  ----------  -------  ---------  ------  ------
+192.168.10.2:45140  192.168.20.2:5201  192.168.20.2:5201  192.168.10.2:45140  tcp                  n/a        0
+192.168.10.2:45124  192.168.20.2:5201  192.168.20.2:5201  192.168.10.2:45124  tcp                  n/a        0
+
+
+vyos@FlowTables:~$ show conntrack table ipv4
+Original src        Original dst       Reply src          Reply dst           Protocol    State      Timeout    Mark    Zone
+------------------  -----------------  -----------------  ------------------  ----------  ---------  ---------  ------  ------
+192.168.10.2:45124  192.168.20.2:5201  192.168.20.2:5201  192.168.10.2:45124  tcp         TIME_WAIT  105        0
 ```
 
-The `[OFFLOAD]` flag confirms that post-handshake packets for these flows
-are forwarded via the flowtable fast path, bypassing the firewall entirely.
-This applies to sub-interface traffic (`bond1.10` → `bond2.20`) in the
-same way as physical interface traffic.
+Entries with `Timeout` shown as `n/a` and a blank `State` confirm that
+the flows are offloaded to the flowtable fast path — subsequent packets
+bypass the firewall entirely. Once the TCP session closes, the entry
+transitions to `TIME_WAIT` and the timeout counter resumes.

--- a/docs/configuration/firewall/flowtables.md
+++ b/docs/configuration/firewall/flowtables.md
@@ -64,6 +64,7 @@ Creating a flow table:
 ```{cfgcmd} set firewall flowtable \<flow_table_name\> interface \<iface\>
 
 Specify interfaces to use in the flowtable.
+
 ```
 
 ```{cfgcmd} set firewall flowtable \<flow_table_name\> description \<text\>
@@ -95,6 +96,18 @@ Create a firewall rule in the forward chain with the action set to
 Create a firewall rule in the forward chain and specify which flowtable
 to use. Only applicable if the action is ``offload``.
 ```
+
+### Interface Selection
+:::{important}
+Always configure the flowtable with the interface that Netfilter observes
+at the forward hook — which is not necessarily the physical interface.
+When traffic is received or transmitted via a logical interface, Netfilter
+tracks that logical interface, not the underlying physical device. Registering
+the wrong interface in the flowtable causes every flow lookup to miss,
+falling back to the classic forwarding path and defeating the purpose of
+fast-path offload. 
+:::
+
 
 ## Configuration Example
 
@@ -149,6 +162,72 @@ Here's what happens for a desired connection:
 >    entry in the flowtable FT01 for this connection.
 > 6. Subsequent packets skip the traditional path and use the **Fast Path**
 >    for offloading.
+
+
+### Flowtable Configuration on Logical and Sub-Interfaces
+
+When configuring flowtables it is essential to identify which interface
+Netfilter observes at the forward hook for ingress and egress traffic.
+The Netfilter framework identifies interfaces by their **iifname** and
+**oifname** — always at the highest logical level, not the underlying
+physical members.
+
+For example:
+- If `bond0` is configured, Netfilter sees `bond0` — not `eth0` or `eth1`
+- If `br0` is configured, Netfilter sees `br0` — not its member interfaces
+- The flowtable must reference the same interface name Netfilter observes
+
+The behaviour differs for sub-interfaces (VLANs):
+
+- Configuring `bond1` in the flowtable offloads traffic on the parent
+  interface **and all its sub-interfaces** (`bond1.10`, `bond1.20`, etc.)
+- Configuring `bond1.10` in the flowtable offloads **only VLAN 10** traffic
+
+```none
+# Offload bond1 and all sub-interfaces (bond1.10, bond1.20, ...)
+set firewall flowtable FT01 interface 'bond1'
+
+# Offload VLAN 10 only
+set firewall flowtable FT01 interface 'bond1.10'
+```
+
+#### Example: Mixed parent and sub-interface offload
+
+Consider a setup where:
+- Traffic ingresses on `bond1.10` (VLAN 10)
+- Traffic egresses on `bond2.20` (VLAN 20)
+
+```none
+set firewall flowtable FT01 interface 'bond1'
+set firewall flowtable FT01 interface 'bond2.20'
+set firewall ipv4 forward filter default-action 'drop'
+set firewall ipv4 forward filter rule 10 action 'offload'
+set firewall ipv4 forward filter rule 10 offload-target 'FT01'
+set firewall ipv4 forward filter rule 10 state 'established'
+set firewall ipv4 forward filter rule 10 state 'related'
+set firewall ipv4 forward filter rule 20 action 'accept'
+set firewall ipv4 forward filter rule 20 state 'established'
+set firewall ipv4 forward filter rule 20 state 'related'
+set firewall ipv4 forward filter rule 200 action 'accept'
+set firewall ipv4 forward filter rule 200 inbound-interface name 'bond*'
+```
+
+In this configuration:
+- `bond1` covers ingress from `bond1.10` and any other `bond1` sub-interfaces
+- `bond2.20` covers egress on VLAN 20 only — other `bond2` sub-interfaces
+  are not offloaded
+- Rule 200 uses a wildcard to accept new connections (TCP handshake) arriving
+  on any bond interface or sub-interface before the flow reaches established
+  state and is eligible for offload
+- Once a flow is established, rule 10 adds it to the flowtable and subsequent
+  packets bypass Netfilter entirely via the fast path
+
+:::{note}
+The interface directions in this example are from the perspective of
+client-to-server traffic. In practice each interface handles traffic in
+both directions, and the flowtable manages offload symmetrically once the
+flow is established.
+:::
 
 ### Checks
 

--- a/docs/configuration/firewall/flowtables.md
+++ b/docs/configuration/firewall/flowtables.md
@@ -175,7 +175,7 @@ For example:
 - If `br0` is configured, VyOS sees `br0` — not its member interfaces
 - The flowtable must reference the same interface name VyOS observes
 
-The behavior differs for sub-interfaces (VLANs):
+Two forms are accepted, but registering the parent is recommended::
 
 - Registering `bond1` offloads the parent interface **and all its VLAN
   sub-interfaces** (`bond1.10`, `bond1.20`, etc.) — the kernel
@@ -213,9 +213,10 @@ set firewall ipv4 forward filter rule 200 inbound-interface name 'bond*'
 ```
 
 In this configuration:
-- `bond1` covers ingress from `bond1.10` and any other `bond1` sub-interfaces
-- `bond2.20` covers egress on VLAN 20 only — other `bond2` sub-interfaces
-  are not offloaded
+- `bond1` covers ingress from `bond1.10` and any other `bond1` sub-interfaces.
+- `bond2.20` offloads VLAN 20 only — other `bond2` sub-interfaces remain on
+  the standard forwarding path. This illustrates how to selectively offload
+  a single VLAN while leaving others on the slow path. 
 - Rule 200 uses a wildcard to accept any traffic arriving
   on any bond interface or sub-interface before the flow reaches established
   state and is eligible for offload

--- a/docs/configuration/firewall/flowtables.md
+++ b/docs/configuration/firewall/flowtables.md
@@ -257,6 +257,8 @@ Check the interfaces where traffic is being forwarded:
 
 ```none
 vyos@FlowTables:~$ show log firewall
-Jun 18 22:22:00 kernel: [ipv4-FWD-filter-200-A]IN=bond1.10 OUT=bond2.20 MAC=000:53:00:00:00:01 00:53:00:00:00:02 SRC=192.168.10.2 DST=192.168.20.2 LEN=84 TOS=0x00 PREC=0x00 TTL=63 ID=56215 DF PROTO=ICMP TYPE=8 CODE=0 ID=3572 SEQ=1
+Jun 18 22:22:00 kernel: [ipv4-FWD-filter-200-A] IN=bond1.10 OUT=bond2.20 \
+  MAC=00:53:00:00:00:02:00:53:00:00:00:01:08:00 SRC=192.168.10.2 \
+  DST=192.168.20.2 LEN=84 PROTO=ICMP TYPE=8 CODE=0 ID=3572 SEQ=1
 ```
 Notice the IN and OUT interface are bond1.10 and bond2.20 and not the physical interface. 

--- a/docs/configuration/firewall/flowtables.md
+++ b/docs/configuration/firewall/flowtables.md
@@ -97,6 +97,7 @@ to use. Only applicable if the action is ``offload``.
 ```
 
 ### Interface Selection
+
 :::{important}
 Always configure the flowtable with the interface that VyOS observes
 at the forward hook — which is not necessarily the physical interface.
@@ -104,7 +105,7 @@ When traffic is received or transmitted via a logical interface, VyOS
 tracks that logical interface, not the underlying physical device. Registering
 the wrong interface in the flowtable causes every flow lookup to miss,
 falling back to the classic forwarding path and defeating the purpose of
-fast-path offload. 
+fast-path offload.
 :::
 
 
@@ -176,11 +177,11 @@ For example:
 
 The behavior differs for sub-interfaces (VLANs):
 
-- Registering ``bond1`` offloads the parent interface **and all its VLAN
-  sub-interfaces** (``bond1.10``, ``bond1.20``, etc.) — the kernel
+- Registering `bond1` offloads the parent interface **and all its VLAN
+  sub-interfaces** (`bond1.10`, `bond1.20`, etc.) — the kernel
   automatically discovers them by parsing L2 headers (Linux 5.13+).
-- Registering ``bond1.10`` directly offloads **only VLAN 10** traffic.
-  But the sub-interface **must exist at commit time**; if it is not 
+- Registering `bond1.10` directly offloads **only VLAN 10** traffic.
+  But the sub-interface **must exist at commit time**; if it is not
   yet present when the ruleset is loaded, the configuration might fail.
 
 ```none
@@ -191,7 +192,7 @@ set firewall flowtable FT01 interface 'bond1'
 set firewall flowtable FT01 interface 'bond1.10'
 ```
 
-#### Example: Mixed parent and sub-interface offload
+### Example: Mixed parent and sub-interface offload
 
 Consider a setup where:
 - Traffic ingresses on `bond1.10` (VLAN 10)
@@ -226,9 +227,9 @@ The interface directions in this example are from the perspective of
 client-to-server traffic. In practice each interface handles traffic in
 both directions, and the flowtable manages offload symmetrically once the
 flow is established.
-To be sure what are the ingress and egress interface, you can check the firewall
-logs, by enabling the log in any rule of the forward hook. Check firewall section
-for the configuration.
+To confirm the ingress and egress interfaces, enable `log` on a rule in the
+forward hook and check the firewall logs — see the
+{doc}`Firewall </configuration/firewall/index>` section for configuration.
 :::
 
 ### Checks
@@ -259,8 +260,9 @@ Check the interfaces where traffic is being forwarded:
 
 ```none
 vyos@FlowTables:~$ show log firewall
-Jun 18 22:22:00 kernel: [ipv4-FWD-filter-200-A]IN=bond1.10 OUT=bond2.20 MAC=00:53:00:00:00:01
-00:53:00:00:00:02 SRC=192.168.10.2 DST=192.168.20.2 LEN=84 TOS=0x00 PREC=0x00 TTL=63 ID=56215 DF
-PROTO=ICMP TYPE=8 CODE=0 ID=3572 SEQ=1
+Jun 18 22:22:00 kernel: [ipv4-FWD-filter-200-A] IN=bond1.10 OUT=bond2.20 \
+  MAC=00:53:00:00:00:02:00:53:00:00:00:01:08:00 SRC=192.168.10.2 \
+  DST=192.168.20.2 LEN=84 PROTO=ICMP TYPE=8 CODE=0 ID=3572 SEQ=1
 ```
-Notice the IN and OUT interface are bond1.10 and bond2.20 and not the physical interface. 
+Notice the IN and OUT interface are `bond1.10` and `bond2.20` and not the
+physical interface.

--- a/docs/configuration/firewall/flowtables.md
+++ b/docs/configuration/firewall/flowtables.md
@@ -175,7 +175,7 @@ For example:
 - If `br0` is configured, VyOS sees `br0` — not its member interfaces
 - The flowtable must reference the same interface name VyOS observes
 
-Two forms are accepted, but registering the parent is recommended::
+Two forms are accepted, but registering the parent is recommended:
 
 - Registering `bond1` offloads the parent interface **and all its VLAN
   sub-interfaces** (`bond1.10`, `bond1.20`, etc.) — the kernel
@@ -216,7 +216,7 @@ In this configuration:
 - `bond1` covers ingress from `bond1.10` and any other `bond1` sub-interfaces.
 - `bond2.20` offloads VLAN 20 only — other `bond2` sub-interfaces remain on
   the standard forwarding path. This illustrates how to selectively offload
-  a single VLAN while leaving others on the slow path. 
+  a single VLAN while leaving others on the slow path.
 - Rule 200 uses a wildcard to accept any traffic arriving
   on any bond interface or sub-interface before the flow reaches established
   state and is eligible for offload
@@ -257,7 +257,11 @@ conntrack v1.4.6 (conntrack-tools): 5 flow entries have been shown.
 tcp      6 src=198.51.100.100 dst=192.0.2.100 sport=41676 dport=1122 src=192.0.2.100 dst=198.51.100.100 sport=1122 dport=41676 [OFFLOAD] mark=0 use=2
 vyos@FlowTables:~$
 ```
-Check the interfaces where traffic is being forwarded:
+
+#### Interface identification
+
+To verify that VyOS identifies traffic by its logical sub-interface
+and not the underlying physical device, inspect the firewall log:
 
 ```none
 vyos@FlowTables:~$ show log firewall
@@ -265,5 +269,23 @@ Jun 18 22:22:00 kernel: [ipv4-FWD-filter-200-A] IN=bond1.10 OUT=bond2.20 \
   MAC=00:53:00:00:00:02:00:53:00:00:00:01:08:00 SRC=192.168.10.2 \
   DST=192.168.20.2 LEN=84 PROTO=ICMP TYPE=8 CODE=0 ID=3572 SEQ=1
 ```
-Notice the IN and OUT interface are `bond1.10` and `bond2.20` and not the
-physical interface.
+
+The `IN` and `OUT` fields show `bond1.10` and `bond2.20` — the logical
+sub-interfaces — not the underlying physical or bond device.
+
+#### Flowtable offload
+
+Run the following command to verify that the connections are offloaded to
+the flowtable fast path:
+
+```none
+vyos@firewall:~$ sudo conntrack -L | grep OFFLOAD
+tcp      6 src=192.168.10.2 dst=192.168.20.2 sport=55604 dport=5201 src=192.168.20.2 dst=192.168.10.2 sport=5201 dport=55604 [OFFLOAD] mark=0 use=5
+tcp      6 src=192.168.10.2 dst=192.168.20.2 sport=55602 dport=5201 src=192.168.20.2 dst=192.168.10.2 sport=5201 dport=55602 [OFFLOAD] mark=0 use=2
+conntrack v1.4.6 (conntrack-tools): 2 flow entries have been shown.
+```
+
+The `[OFFLOAD]` flag confirms that post-handshake packets for these flows
+are forwarded via the flowtable fast path, bypassing the firewall entirely.
+This applies to sub-interface traffic (`bond1.10` → `bond2.20`) in the
+same way as physical interface traffic..

--- a/docs/configuration/firewall/flowtables.md
+++ b/docs/configuration/firewall/flowtables.md
@@ -164,20 +164,17 @@ Here's what happens for a desired connection:
 >    for offloading.
 
 
-### Flowtable Configuration on Logical and Sub-Interfaces
+## Flowtable Configuration on Logical and Sub-Interfaces
 
-When configuring flowtables it is essential to identify which interface
-VyOS observes at the forward hook for ingress and egress traffic.
-The VyOS identifies interfaces by their **iifname** and
-**oifname** — always at the highest logical level, not the underlying
-physical members.
+Configure the flowtable with the interface name you used in VyOS configuration. 
+When VLANs, bonds, or bridges are involved, that is the logical interface (bond0, br0, eth0.10) — not the underlying physical port.
 
 For example:
 - If `bond0` is configured, VyOS sees `bond0` — not `eth0` or `eth1`
 - If `br0` is configured, VyOS sees `br0` — not its member interfaces
 - The flowtable must reference the same interface name VyOS observes
 
-The behaviour differs for sub-interfaces (VLANs):
+The behavior differs for sub-interfaces (VLANs):
 
 - Configuring `bond1` in the flowtable offloads traffic on the parent
   interface **and all its sub-interfaces** (`bond1.10`, `bond1.20`, etc.)
@@ -216,11 +213,11 @@ In this configuration:
 - `bond1` covers ingress from `bond1.10` and any other `bond1` sub-interfaces
 - `bond2.20` covers egress on VLAN 20 only — other `bond2` sub-interfaces
   are not offloaded
-- Rule 200 uses a wildcard to accept new connections (TCP handshake) arriving
+- Rule 200 uses a wildcard to accept any traffic arriving
   on any bond interface or sub-interface before the flow reaches established
   state and is eligible for offload
 - Once a flow is established, rule 10 adds it to the flowtable and subsequent
-  packets bypass Netfilter entirely via the fast path
+  packets bypass entirely the forward hook via the fast path
 
 :::{note}
 The interface directions in this example are from the perspective of
@@ -260,6 +257,6 @@ Check the interfaces where traffic is being forwarded:
 
 ```none
 vyos@FlowTables:~$ show log firewall
-Jun 18 22:22:00 kernel: [ipv4-FWD-filter-200-A]IN=bond1.10 OUT=bond2.20 MAC=02:dd:f1:e7:3d:00:5a:a3:d1:fc:5f:cb:08:00 SRC=192.168.10.2 DST=192.168.20.2 LEN=84 TOS=0x00 PREC=0x00 TTL=63 ID=56215 DF PROTO=ICMP TYPE=8 CODE=0 ID=3572 SEQ=1
+Jun 18 22:22:00 kernel: [ipv4-FWD-filter-200-A]IN=bond1.10 OUT=bond2.20 MAC=000:53:00:00:00:01 00:53:00:00:00:02 SRC=192.168.10.2 DST=192.168.20.2 LEN=84 TOS=0x00 PREC=0x00 TTL=63 ID=56215 DF PROTO=ICMP TYPE=8 CODE=0 ID=3572 SEQ=1
 ```
 Notice the IN and OUT interface are bond1.10 and bond2.20 and not the physical interface. 

--- a/docs/configuration/firewall/flowtables.md
+++ b/docs/configuration/firewall/flowtables.md
@@ -216,7 +216,7 @@ In this configuration:
   on any bond interface or sub-interface before the flow reaches established
   state and is eligible for offload
 - Once a flow is established, rule 10 adds it to the flowtable and subsequent
-  packets bypass entirely the forward hook via the fast path
+  packets bypass the forward hook entirely via the fast path
 
 :::{note}
 The interface directions in this example are from the perspective of

--- a/docs/configuration/firewall/flowtables.md
+++ b/docs/configuration/firewall/flowtables.md
@@ -64,23 +64,23 @@ Creating a flow table:
 ```{cfgcmd} set firewall flowtable \<flow_table_name\> interface \<iface\>
 
 Specify interfaces to use in the flowtable.
-
 ```
 
 ```{cfgcmd} set firewall flowtable \<flow_table_name\> description \<text\>
-```
 
 Provide a description for the flow table.
+```
 
 ```{cfgcmd} set firewall flowtable \<flow_table_name\> offload \<hardware | software\>
 
 Specify the offload type the flowtable uses: ``hardware`` or
 ``software``. The default is ``software`` offload.
 ```
+
 :::{note}
 **Hardware offload**: Make sure your network interface controller
 (NIC) supports hardware offloading and that you have the necessary drivers
-> installed before enabling this option.
+installed before enabling this option.
 :::
 
 Creating rules for using flow tables:
@@ -135,7 +135,6 @@ set firewall ipv4 forward filter default-action 'drop'
 set firewall ipv4 forward filter rule 10 action 'offload'
 set firewall ipv4 forward filter rule 10 offload-target 'FT01'
 set firewall ipv4 forward filter rule 10 state 'established'
-set firewall ipv4 forward filter rule 10 state 'related'
 set firewall ipv4 forward filter rule 20 action 'accept'
 set firewall ipv4 forward filter rule 20 state 'established'
 set firewall ipv4 forward filter rule 20 state 'related'
@@ -167,7 +166,8 @@ Here's what happens for a desired connection:
 ## Flowtable Configuration on Logical and Sub-Interfaces
 
 Configure the flowtable with the interface name you used in VyOS configuration. 
-When VLANs, bonds, or bridges are involved, that is the logical interface (bond0, br0, eth0.10) — not the underlying physical port.
+When VLANs, bonds, or bridges are involved, that is the logical interface (bond0, br0, eth0.10),
+not the underlying physical port.
 
 For example:
 - If `bond0` is configured, VyOS sees `bond0` — not `eth0` or `eth1`
@@ -176,15 +176,18 @@ For example:
 
 The behavior differs for sub-interfaces (VLANs):
 
-- Configuring `bond1` in the flowtable offloads traffic on the parent
-  interface **and all its sub-interfaces** (`bond1.10`, `bond1.20`, etc.)
-- Configuring `bond1.10` in the flowtable offloads **only VLAN 10** traffic
+- Registering ``bond1`` offloads the parent interface **and all its VLAN
+  sub-interfaces** (``bond1.10``, ``bond1.20``, etc.) — the kernel
+  automatically discovers them by parsing L2 headers (Linux 5.13+).
+- Registering ``bond1.10`` directly offloads **only VLAN 10** traffic.
+  But the sub-interface **must exist at commit time**; if it is not 
+  yet present when the ruleset is loaded, the configuration might fail.
 
 ```none
 # Offload bond1 and all sub-interfaces (bond1.10, bond1.20, ...)
 set firewall flowtable FT01 interface 'bond1'
 
-# Offload VLAN 10 only
+# Offload VLAN 10 only: register the sub-interface directly
 set firewall flowtable FT01 interface 'bond1.10'
 ```
 
@@ -201,7 +204,6 @@ set firewall ipv4 forward filter default-action 'drop'
 set firewall ipv4 forward filter rule 10 action 'offload'
 set firewall ipv4 forward filter rule 10 offload-target 'FT01'
 set firewall ipv4 forward filter rule 10 state 'established'
-set firewall ipv4 forward filter rule 10 state 'related'
 set firewall ipv4 forward filter rule 20 action 'accept'
 set firewall ipv4 forward filter rule 20 state 'established'
 set firewall ipv4 forward filter rule 20 state 'related'
@@ -257,6 +259,8 @@ Check the interfaces where traffic is being forwarded:
 
 ```none
 vyos@FlowTables:~$ show log firewall
-Jun 18 22:22:00 kernel: [ipv4-FWD-filter-200-A]IN=bond1.10 OUT=bond2.20 MAC=000:53:00:00:00:01 00:53:00:00:00:02 SRC=192.168.10.2 DST=192.168.20.2 LEN=84 TOS=0x00 PREC=0x00 TTL=63 ID=56215 DF PROTO=ICMP TYPE=8 CODE=0 ID=3572 SEQ=1
+Jun 18 22:22:00 kernel: [ipv4-FWD-filter-200-A]IN=bond1.10 OUT=bond2.20 MAC=00:53:00:00:00:01
+00:53:00:00:00:02 SRC=192.168.10.2 DST=192.168.20.2 LEN=84 TOS=0x00 PREC=0x00 TTL=63 ID=56215 DF
+PROTO=ICMP TYPE=8 CODE=0 ID=3572 SEQ=1
 ```
 Notice the IN and OUT interface are bond1.10 and bond2.20 and not the physical interface. 

--- a/docs/configuration/firewall/flowtables.md
+++ b/docs/configuration/firewall/flowtables.md
@@ -279,10 +279,11 @@ Run the following command to verify that the connections are offloaded to
 the flowtable fast path:
 
 ```none
-vyos@FlowTables:~$ sudo conntrack -L | grep OFFLOAD
-tcp      6 src=192.168.10.2 dst=192.168.20.2 sport=55604 dport=5201 src=192.168.20.2 dst=192.168.10.2 sport=5201 dport=55604 [OFFLOAD] mark=0 use=5
-tcp      6 src=192.168.10.2 dst=192.168.20.2 sport=55602 dport=5201 src=192.168.20.2 dst=192.168.10.2 sport=5201 dport=55602 [OFFLOAD] mark=0 use=2
-conntrack v1.4.6 (conntrack-tools): 2 flow entries have been shown.
+vyos@firewall:~$ show conntrack table ipv4
+Id          Original src        Original dst       Reply src          Reply dst           Protocol    State    Timeout    Mark    Zone
+----------  ------------------  -----------------  -----------------  ------------------  ----------  -------  ---------  ------  ------
+167046433   192.168.10.2:45140  192.168.20.2:5201  192.168.20.2:5201  192.168.10.2:45140  tcp                  n/a        0
+4162237083  192.168.10.2:45124  192.168.20.2:5201  192.168.20.2:5201  192.168.10.2:45124  tcp                  n/a        0
 ```
 
 The `[OFFLOAD]` flag confirms that post-handshake packets for these flows

--- a/docs/configuration/interfaces/ethernet.md
+++ b/docs/configuration/interfaces/ethernet.md
@@ -7,10 +7,7 @@ lastproofread: '2026-01-19'
 # Ethernet
 
 Ethernet interfaces (e.g., `eth0`, `eth1`) represent the host's physical
-or virtual network ports.
-
-
-They are the most common interface type, serving as the base layer upon which
+or virtual network ports. They are the most common interface type, serving as the base layer upon which
 IP addresses, VLANs, and tunnels are configured to carry traffic across both
 LANs and WANs.
 

--- a/docs/configuration/interfaces/ethernet.md
+++ b/docs/configuration/interfaces/ethernet.md
@@ -9,6 +9,7 @@ lastproofread: '2026-01-19'
 Ethernet interfaces (e.g., `eth0`, `eth1`) represent the host's physical
 or virtual network ports.
 
+
 They are the most common interface type, serving as the base layer upon which
 IP addresses, VLANs, and tunnels are configured to carry traffic across both
 LANs and WANs.

--- a/docs/configuration/interfaces/ethernet.md
+++ b/docs/configuration/interfaces/ethernet.md
@@ -7,8 +7,8 @@ lastproofread: '2026-01-19'
 # Ethernet
 
 Ethernet interfaces (e.g., `eth0`, `eth1`) represent the host's physical
-or virtual network ports. They are the most common interface type, serving as the base layer upon which
-IP addresses, VLANs, and tunnels are configured to carry traffic across both
+or virtual network ports. They are the most common interface type, serving as the base layer
+upon which IP addresses, VLANs, and tunnels are configured to carry traffic across both
 LANs and WANs.
 
 ## Configuration

--- a/docs/configuration/interfaces/ethernet.md
+++ b/docs/configuration/interfaces/ethernet.md
@@ -7,8 +7,10 @@ lastproofread: '2026-01-19'
 # Ethernet
 
 Ethernet interfaces (e.g., `eth0`, `eth1`) represent the host's physical
-or virtual network ports. They are the most common interface type, serving as the base layer
-upon which IP addresses, VLANs, and tunnels are configured to carry traffic across both
+or virtual network ports.
+
+They are the most common interface type, serving as the base layer upon which
+IP addresses, VLANs, and tunnels are configured to carry traffic across both
 LANs and WANs.
 
 ## Configuration


### PR DESCRIPTION
## Change Summary
I have added how the FlowTable works with bond interfaces and sub-interfaces and example configurations. 

## Related Task(s)
NA

## Related PR(s)
NA

## Backport
NA



## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document
- I have read the CLA Document and I hereby sign the CLA