### PR TITLE
docs: fix local syslog command syntax for 1.5 (T8983)

### DIFF
--- a/docs/configuration/system/syslog.md
+++ b/docs/configuration/system/syslog.md
@@ -55,7 +55,7 @@ Name)` in log messages, even if the syslog server is in the same domain.
 
 Configure which log messages to save to a local log file.
 
-```{cfgcmd} set system syslog local \<filename\> facility \<keyword\> level \<keyword\>
+```{cfgcmd} set system syslog local facility \<keyword\> level \<keyword\>
 
 **Configure syslog to save log messages for a specific facility and
 severity level to \`\`/var/log/messages\`\`.**


### PR DESCRIPTION
## Change Summary
Remove erroneous `<filename>` parameter from `set system syslog local` command.

In VyOS 1.5 the correct syntax is:

  set system syslog local facility <keyword> level <keyword>

The `<filename>` placeholder belonged to the 1.4 syntax
(`set system syslog file <filename> ...`) and caused confusion with the
Ansible `vyos.vyos.vyos_logging_global` module, which generated:

  set system syslog file /var/log/messages facility all level info

resulting in:
  Configuration path: system syslog [file] is not valid

## Related Task(s)
* https://vyos.dev/T8983

## Related PR(s)

## Backport
circinus

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document