### PR TITLE
T8997: Fix Cookiebot consent dialog rendering unstyled on first load

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -533,3 +533,27 @@ html {
 		bottom: 85px;
 	}
 }
+
+/* Cookiebot consent dialog — safety net (defense-in-depth).
+   Cookiebot delivers its dialog styling as a constructed stylesheet on
+   document.adoptedStyleSheets. The adoptedStyleSheets shim in layout.html keeps that
+   sheet from being dropped by another library (e.g. ReadTheDocs' readthedocs-addons.js,
+   which reassigns the whole list with a destructive replace). As a backstop, these
+   rules live in a regular stylesheet — which cascades *before* adopted stylesheets, so
+   Cookiebot's own CSS overrides every one of them whenever its sheet is present, and
+   they have no effect on the normal styled banner. They only take effect if that sheet
+   is ever absent, keeping the dialog a contained, scrollable, centered panel instead of
+   falling back to position:static and expanding to full page height. Only properties
+   Cookiebot itself sets are used here, so there is verifiably no leak into the good state. */
+#CybotCookiebotDialog {
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	max-width: 920px;
+	max-height: 90vh;
+	overflow: auto;
+	background: #fff;
+	box-shadow: 0 0 24px rgba(0, 0, 0, 0.25);
+	z-index: 2147483631;
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -2,6 +2,46 @@
 {%- set current_version = "1.5.x circinus" %}
 {% block extrahead %}
     {% if gtm_id and cookiebot_id %}
+    {# Keep Cookiebot's consent dialog from rendering unstyled and breaking the page.
+       Cookiebot delivers its dialog CSS as a constructed stylesheet via
+       document.adoptedStyleSheets. That property holds the *whole* sheet list, and
+       ReadTheDocs' readthedocs-addons.js reassigns it with a destructive replace; when
+       that lands after Cookiebot's (network-gated) adoption it drops Cookiebot's sheet,
+       leaving #CybotCookiebotDialog at position:static, expanded to full page height.
+       This shim makes assignment preserve Cookiebot's sheet specifically. It must run
+       before the first adoptedStyleSheets write, so it is the first thing in <head>. #}
+    <script>
+    (function () {
+      try {
+        var desc = Object.getOwnPropertyDescriptor(Document.prototype, "adoptedStyleSheets");
+        if (!desc || !desc.get || !desc.set) return;
+        var guarded = null;
+        var isCookiebot = function (sheet) {
+          try {
+            var rules = sheet.cssRules;
+            for (var i = 0; i < rules.length; i++) {
+              if (rules[i].selectorText && rules[i].selectorText.indexOf("CybotCookiebotDialog") !== -1) return true;
+            }
+          } catch (e) {}
+          return false;
+        };
+        Object.defineProperty(document, "adoptedStyleSheets", {
+          configurable: true,
+          get: function () { return desc.get.call(document); },
+          set: function (sheets) {
+            for (var i = 0; i < sheets.length; i++) {
+              if (isCookiebot(sheets[i])) { guarded = sheets[i]; break; }
+            }
+            if (guarded && Array.prototype.indexOf.call(sheets, guarded) === -1) {
+              sheets = Array.prototype.slice.call(sheets).concat(guarded);
+            }
+            desc.set.call(document, sheets);
+          }
+        });
+      } catch (e) {}
+    })();
+    </script>
+
     {# Cookiebot CMP — must load first so its auto-blocker can scan/block other tags #}
     <script id="Cookiebot"
             src="https://consent.cookiebot.com/uc.js"


### PR DESCRIPTION
## Summary

On a fresh (no-consent) load of docs.vyos.io — e.g. incognito — the Cookiebot consent banner could render completely unstyled and expand to full page height (a giant "Cookiebot by Usercentrics" logo across the page), breaking the layout. Dismissing it sets the consent cookie, so it never re-renders and the page looks fine afterwards. It is a race, so it is intermittent.

## Root cause

Cookiebot delivers its consent-dialog CSS as a **constructed stylesheet** via `document.adoptedStyleSheets` (the `<style>` element path is an old-browser fallback only — so the CSS is invisible to `document.styleSheets` / `<style>` / `<link>`). That property holds the whole sheet list, and ReadTheDocs' `readthedocs-addons.js` reassigns it with a **destructive replace**. `cc.js` is network-gated (~500 ms); when RTD's replace lands after Cookiebot's adoption it drops Cookiebot's sheet, leaving `#CybotCookiebotDialog` at `position:static`, expanded to ~6700 px.

Verified in-browser (Chrome DevTools): in the broken state the only surviving adopted sheet is RTD's `@layer defaults{ … --readthedocs-search-… }`; manually replacing `document.adoptedStyleSheets` in a good state reproduces the exact broken render.

## Changes

- **`docs/_templates/layout.html`** — a small `adoptedStyleSheets` shim, installed before any page script, that remembers Cookiebot's sheet and re-appends it if a later whole-array reassignment drops it. Order-independent once installed before the first write.
- **`docs/_static/css/custom.css`** — a leak-safe safety net (defense-in-depth) that keeps the dialog contained even if its adopted sheet is ever absent. It uses only properties Cookiebot itself sets, so its rules are fully overridden when the sheet is present — verifiably no effect on the normal styled banner.

## Verification

- Guard (exact shipped code): 3/3 cold loads render styled (`fixed`, 218 px) across rolling / 1.5 / a deep page.
- Deterministic: a destructive `adoptedStyleSheets` replace after the shim installs → Cookiebot's sheet is preserved.
- CSS net: good-state computed styles byte-identical with/without it (zero leak); broken-state dialog is contained (centered, ≤ 920×90vh, scrollable).

## Notes

- Affects all branches sharing the theme — should be backported to **circinus** and **sagitta** after merge.
- Underlying cause is an upstream antipattern (`readthedocs-addons.js` destructively replacing `document.adoptedStyleSheets` clobbers any other library's constructed sheets) — worth reporting to ReadTheDocs separately.

Phorge task: https://vyos.dev/T8997

🤖 Generated by [robots](https://vyos.io)
