### PR TITLE
configexamples/inter-vrf-routing-vrf-lite: fix formatting

### DIFF
--- a/docs/configexamples/inter-vrf-routing-vrf-lite.md
+++ b/docs/configexamples/inter-vrf-routing-vrf-lite.md
@@ -58,12 +58,12 @@ limitation:
 –called VPNs- inside the BGP Process. The RD is appended to each IPv4 Network
 that is advertised into BGP for that VPN making it a unique VPNv4 route.
 
-- Route Target (RT): This is an extended BGP community append to the VPNv4 route
-in the Import/Export process. When a route passes from the VRF routing table
-into the BGP process it will add the configured export extended community(ies)
-for that VPN. When that route needs to go from BGP into the VRF routing table
-will only pass if that given VPN import policy matches any of the appended
-community(ies) into that prefix.
+- Route Target (RT): This is an extended BGP community append to the VPNv4
+route in the Import/Export process. When a route passes from the VRF routing
+table into the BGP process it will add the configured export extended
+community(ies) for that VPN. When that route needs to go from BGP into the VRF
+routing table will only pass if that given VPN import policy matches any of the
+appended community(ies) into that prefix.
 
 ## Topology
 

--- a/docs/configexamples/inter-vrf-routing-vrf-lite.md
+++ b/docs/configexamples/inter-vrf-routing-vrf-lite.md
@@ -53,10 +53,12 @@ need for MPLS.
 
 MP-BGP or MultiProtocol BGP introduces two main concepts to solve this
 limitation:
-\- Route Distinguisher (RD): Is used to distinguish between different VRFs
+
+- Route Distinguisher (RD): Is used to distinguish between different VRFs
 –called VPNs- inside the BGP Process. The RD is appended to each IPv4 Network
 that is advertised into BGP for that VPN making it a unique VPNv4 route.
-\- Route Target (RT): This is an extended BGP community append to the VPNv4 route
+
+- Route Target (RT): This is an extended BGP community append to the VPNv4 route
 in the Import/Export process. When a route passes from the VRF routing table
 into the BGP process it will add the configured export extended community(ies)
 for that VPN. When that route needs to go from BGP into the VRF routing table


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This fixes an enumeration in https://docs.vyos.io/en/1.5/configexamples/inter-vrf-routing-vrf-lite.html#overview, which didn't render properly

<img width="1090" height="534" alt="image" src="https://github.com/user-attachments/assets/cbbd10c2-749b-4dbe-9b23-bc3be3cbaa22" />


## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document