### PR TITLE
bgp: T6573: add input/output queue limit CLI commands

### DIFF
--- a/docs/configuration/protocols/bgp.md
+++ b/docs/configuration/protocols/bgp.md
@@ -781,6 +781,26 @@ installed into the kernel.
 :::
 ```
 
+##### BGP message queue limits
+
+```{cfgcmd} set protocols bgp parameters input-queue-limit \<messages\>
+
+   Set the BGP Input Queue limit for all peers during message parsing.
+   Increase this only if you have the memory to handle large queues of
+   messages at once.
+
+   The default is 10000.
+```
+
+```{cfgcmd} set protocols bgp parameters output-queue-limit \<messages\>
+
+   Set the BGP Output Queue limit for all peers during message parsing.
+   Increase this only if you have the memory to handle large queues of
+   messages at once.
+
+   The default is 10000.
+```
+
 ##### Timers
 
 ```{cfgcmd} set protocols bgp timers holdtime \<seconds\>


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add input-queue-limit and output-queue-limit CLI nodes to expose global FRR bgp input-queue-limit and bgp output-queue-limit commands via our CLI.

Parameters control the maximum number of queued messages for all BGP peers during message parsing. FRR default is 10000 which we honor.

Note that this is a global option and can only be set for the global/default BGP instance.



## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/T6573

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

* https://github.com/vyos/vyos-1x/pull/5295

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document