### PR TITLE
docs: fix MyST roles used inside eval-rst blocks

### DIFF
--- a/docs/configuration/firewall/global-options.md
+++ b/docs/configuration/firewall/global-options.md
@@ -132,7 +132,7 @@ Configuration commands covered in this section:
 .. cfgcmd:: set firewall global-options twa-hazards-protection
    [enable | disable]
 
-   Enable or Disable VyOS to be {rfc}`1337` conform.
+   Enable or Disable VyOS to be :rfc:`1337` conform.
    The following system parameter will be altered:
 
    * ``net.ipv4.tcp_rfc1337``

--- a/docs/configuration/interfaces/bridge.md
+++ b/docs/configuration/interfaces/bridge.md
@@ -35,10 +35,10 @@ Spanning Tree Protocol is not enabled by default in VyOS.
 
    Assign `<member>` interface to bridge `<interface>`. A completion
    helper will help you with all allowed interfaces which can be
-   bridged. This includes {ref}`ethernet-interface`,
-   {ref}`bond-interface`, {ref}`l2tpv3-interface`, {ref}`openvpn`,
-   {ref}`vxlan-interface`, {ref}`wireless-interface`,
-   {ref}`tunnel-interface` and {ref}`geneve-interface`.
+   bridged. This includes :ref:`ethernet-interface`,
+   :ref:`bond-interface`, :ref:`l2tpv3-interface`, :ref:`openvpn`,
+   :ref:`vxlan-interface`, :ref:`wireless-interface`,
+   :ref:`tunnel-interface` and :ref:`geneve-interface`.
 
 ```
 

--- a/docs/configuration/interfaces/ethernet.md
+++ b/docs/configuration/interfaces/ethernet.md
@@ -76,7 +76,7 @@ real world.
 
   Enable different types of hardware offloading on the given NIC.
 
-  {abbr}`LRO (Large Receive Offload)` is a technique designed to boost the
+  :abbr:`LRO (Large Receive Offload)` is a technique designed to boost the
   efficiency of how your computer's network interface card (NIC) processes
   incoming network traffic. Typically, network data arrives in smaller chunks
   called packets. Processing each packet individually consumes CPU (central
@@ -92,7 +92,7 @@ real world.
      (Generic Receive Offload) where possible. More information on the
      limitations of LRO can be found here: https://lwn.net/Articles/358910/
 
-  {abbr}`GSO (Generic Segmentation Offload)` is a pure software offload that is
+  :abbr:`GSO (Generic Segmentation Offload)` is a pure software offload that is
   meant to deal with cases where device drivers cannot perform the offloads
   described above. What occurs in GSO is that a given skbuff will have its data
   broken out over multiple skbuffs that have been resized to match the MSS
@@ -102,7 +102,7 @@ real world.
   offload is required in GSO. Otherwise it becomes possible for a frame to be
   re-routed between devices and end up being unable to be transmitted.
 
-  {abbr}`GRO (Generic receive offload)` is the complement to GSO. Ideally any
+  :abbr:`GRO (Generic receive offload)` is the complement to GSO. Ideally any
   frame assembled by GRO should be segmented to create an identical sequence of
   frames using GSO, and any sequence of frames segmented by GSO should be able
   to be reassembled back to the original by GRO. The only exception to this is
@@ -110,8 +110,8 @@ real world.
   value of the IPv4 ID is not sequentially incrementing it will be altered so
   that it is when a frame assembled via GRO is segmented via GSO.
 
-  {abbr}`RPS (Receive Packet Steering)` is logically a software implementation
-  of {abbr}`RSS (Receive Side Scaling)`. Being in software, it is necessarily
+  :abbr:`RPS (Receive Packet Steering)` is logically a software implementation
+  of :abbr:`RSS (Receive Side Scaling)`. Being in software, it is necessarily
   called later in the datapath. Whereas RSS selects the queue and hence CPU that
   will run the hardware interrupt handler, RPS selects the CPU to perform
   protocol processing above the interrupt handler. This is accomplished by

--- a/docs/configuration/interfaces/geneve.md
+++ b/docs/configuration/interfaces/geneve.md
@@ -91,7 +91,7 @@ Geneve Header:
 ```{eval-rst}
 .. cfgcmd:: set interfaces geneve gnv0 vni <vni>
 
-   {abbr}`VNI (Virtual Network Identifier)` is an identifier for a unique
+   :abbr:`VNI (Virtual Network Identifier)` is an identifier for a unique
    element of a virtual network.  In many situations this may represent an L2
    segment, however, the control plane defines the forwarding semantics of
    decapsulated packets. The VNI MAY be used as part of ECMP forwarding

--- a/docs/configuration/interfaces/macsec.md
+++ b/docs/configuration/interfaces/macsec.md
@@ -89,14 +89,14 @@ individual peers.
 .. cfgcmd:: set interfaces macsec <interface> security mka cak <key>
 
   IEEE 802.1X/MACsec pre-shared key mode. This allows configuring MACsec with
-  a pre-shared key using a {abbr}`CAK (MACsec connectivity association key)` and
-  {abbr}`CKN (MACsec connectivity association name)` pair.
+  a pre-shared key using a :abbr:`CAK (MACsec connectivity association key)` and
+  :abbr:`CKN (MACsec connectivity association name)` pair.
 ```
 
 ```{eval-rst}
 .. cfgcmd:: set interfaces macsec <interface> security mka ckn <key>
 
-  {abbr}`CKN (MACsec connectivity association name)` key
+  :abbr:`CKN (MACsec connectivity association name)` key
 ```
 
 ```{eval-rst}
@@ -124,7 +124,7 @@ individual peers.
 ```{eval-rst}
 .. opcmd:: run generate macsec mka cak <gcm-aes-128|gcm-aes-256>
 
-  Generate {abbr}`MKA (MACsec Key Agreement protocol)` CAK key 128 or 256 bits.
+  Generate :abbr:`MKA (MACsec Key Agreement protocol)` CAK key 128 or 256 bits.
 
   .. code-block:: none
 
@@ -135,7 +135,7 @@ individual peers.
 ```{eval-rst}
 .. opcmd:: run generate macsec mka ckn
 
-  Generate {abbr}`MKA (MACsec Key Agreement protocol)` CAK key.
+  Generate :abbr:`MKA (MACsec Key Agreement protocol)` CAK key.
 
   .. code-block:: none
 

--- a/docs/configuration/interfaces/pppoe.md
+++ b/docs/configuration/interfaces/pppoe.md
@@ -158,7 +158,7 @@ vDSL/aDSL understands.
 ```{eval-rst}
 .. cfgcmd:: set interfaces pppoe <interface> mru <mru>
 
-   Set the {abbr}`MRU (Maximum Receive Unit)` to `mru`. PPPd will ask the peer to
+   Set the :abbr:`MRU (Maximum Receive Unit)` to `mru`. PPPd will ask the peer to
    send packets of no more than `mru` bytes. The value of `mru` must be between 128
    and 16384.
 
@@ -259,7 +259,7 @@ vDSL/aDSL understands.
 .. cfgcmd:: set interfaces pppoe <interface> ip source-validation <strict | loose | disable>
 
   Enable policy for source validation by reversed path, as specified in
-  {rfc}`3704`. Current recommended practice in {rfc}`3704` is to enable strict
+  :rfc:`3704`. Current recommended practice in :rfc:`3704` is to enable strict
   mode to prevent IP spoofing from DDos attacks. If using asymmetric routing
   or other complicated routing, then loose mode is recommended.
 

--- a/docs/configuration/interfaces/sstp-client.md
+++ b/docs/configuration/interfaces/sstp-client.md
@@ -117,7 +117,7 @@ VyOS also comes with a build in SSTP server, see {ref}`sstp`.
 .. cfgcmd:: set interfaces sstpc <interface> ip source-validation <strict | loose | disable>
 
   Enable policy for source validation by reversed path, as specified in
-  {rfc}`3704`. Current recommended practice in {rfc}`3704` is to enable strict
+  :rfc:`3704`. Current recommended practice in :rfc:`3704` is to enable strict
   mode to prevent IP spoofing from DDos attacks. If using asymmetric routing
   or other complicated routing, then loose mode is recommended.
 

--- a/docs/configuration/interfaces/vxlan.md
+++ b/docs/configuration/interfaces/vxlan.md
@@ -47,7 +47,7 @@ may be blocked by the hypervisor.
 .. cfgcmd:: set interfaces vxlan <interface> vni <number>
 
   Each VXLAN segment is identified through a 24-bit segment ID, termed the
-  {abbr}`VNI (VXLAN Network Identifier (or VXLAN Segment ID))`, This allows
+  :abbr:`VNI (VXLAN Network Identifier (or VXLAN Segment ID))`, This allows
   up to 16M VXLAN segments to coexist within the same administrative domain.
 ```
 
@@ -82,7 +82,7 @@ may be blocked by the hypervisor.
 .. cfgcmd:: set interfaces vxlan <interface> parameters neighbor-suppress
 
   In order to minimize the flooding of ARP and ND messages in the VXLAN network,
-  EVPN includes provisions {rfc}`7432#section-10` that allow participating VTEPs
+  EVPN includes provisions :rfc:`7432#section-10` that allow participating VTEPs
   to suppress such messages in case they know the MAC-IP binding and can reply
   on behalf of the remote host.
 ```

--- a/docs/configuration/interfaces/wwan.md
+++ b/docs/configuration/interfaces/wwan.md
@@ -88,7 +88,7 @@ VyOS uses the `interfaces wwan` subsystem for configuration.
 ```{eval-rst}
 .. cfgcmd:: set interfaces wwan <interface> apn <apn>
 
-  Every WWAN connection requires an {abbr}`APN (Access Point Name)` which is
+  Every WWAN connection requires an :abbr:`APN (Access Point Name)` which is
   used by the client to dial into the ISPs network. This is a mandatory
   parameter. Contact your Service Provider for correct APN.
 

--- a/docs/configuration/loadbalancing/reverse-proxy.md
+++ b/docs/configuration/loadbalancing/reverse-proxy.md
@@ -62,7 +62,7 @@ to be applied and specifies the real servers to be utilized.
   <facility> level <level>
 
   Specify facility and level for logging.
-  For an explanation on {ref}`syslog_facilities` and {ref}`syslog_severity_level`
+  For an explanation on :ref:`syslog_facilities` and :ref:`syslog_severity_level`
   see tables in syslog configuration section.
 
 ```
@@ -210,7 +210,7 @@ perform action accordingly.
   <facility> level <level>
 
   Specify facility and level for logging.
-  For an explanation on {ref}`syslog_facilities` and {ref}`syslog_severity_level`
+  For an explanation on :ref:`syslog_facilities` and :ref:`syslog_severity_level`
   see tables in syslog configuration section.
 
 ```
@@ -245,7 +245,7 @@ Global parameters
   facility <facility> level <level>
 
   Specify facility and level for logging.
-  For an explanation on {ref}`syslog_facilities` and {ref}`syslog_severity_level`
+  For an explanation on :ref:`syslog_facilities` and :ref:`syslog_severity_level`
   see tables in syslog configuration section.
 ```
 

--- a/docs/configuration/pki/index.md
+++ b/docs/configuration/pki/index.md
@@ -39,14 +39,14 @@ keypairs from an easy to access operational level command.
 ```{eval-rst}
 .. opcmd:: generate pki ca
 
-  Create a new {abbr}`CA (Certificate Authority)` and output the CAs public and
+  Create a new :abbr:`CA (Certificate Authority)` and output the CAs public and
   private key on the console.
 ```
 
 ```{eval-rst}
 .. opcmd:: generate pki ca install <name>
 
-  Create a new {abbr}`CA (Certificate Authority)` and output the CAs public and
+  Create a new :abbr:`CA (Certificate Authority)` and output the CAs public and
   private key on the console.
 
   .. include:: pki_cli_import_help.txt
@@ -55,14 +55,14 @@ keypairs from an easy to access operational level command.
 ```{eval-rst}
 .. opcmd:: generate pki ca sign <ca-name>
 
-  Create a new subordinate {abbr}`CA (Certificate Authority)` and sign it using
+  Create a new subordinate :abbr:`CA (Certificate Authority)` and sign it using
   the private key referenced by `ca-name`.
 ```
 
 ```{eval-rst}
 .. opcmd:: generate pki ca sign <ca-name> install <name>
 
-  Create a new subordinate {abbr}`CA (Certificate Authority)` and sign it using
+  Create a new subordinate :abbr:`CA (Certificate Authority)` and sign it using
   the private key referenced by `name`.
 
   .. include:: pki_cli_import_help.txt
@@ -121,7 +121,7 @@ keypairs from an easy to access operational level command.
 ```{eval-rst}
 .. opcmd:: generate pki dh
 
-  Generate a new set of {abbr}`DH (Diffie-Hellman)` parameters. The key size
+  Generate a new set of :abbr:`DH (Diffie-Hellman)` parameters. The key size
   is requested by the CLI and defaults to 2048 bit.
 
   The generated parameters are then output to the console.
@@ -130,7 +130,7 @@ keypairs from an easy to access operational level command.
 ```{eval-rst}
 .. opcmd:: generate pki dh install <name>
 
-  Generate a new set of {abbr}`DH (Diffie-Hellman)` parameters. The key size
+  Generate a new set of :abbr:`DH (Diffie-Hellman)` parameters. The key size
   is requested by the CLI and defaults to 2048 bit.
 
   .. include:: pki_cli_import_help.txt
@@ -355,7 +355,7 @@ also to display them.
 ```{eval-rst}
 .. opcmd:: show pki ca
 
-  Show a list of installed {abbr}`CA (Certificate Authority)` certificates.
+  Show a list of installed :abbr:`CA (Certificate Authority)` certificates.
 
   .. code-block:: none
 
@@ -398,7 +398,7 @@ also to display them.
 ```{eval-rst}
 .. opcmd:: show pki crl
 
-  Show a list of installed {abbr}`CRLs (Certificate Revocation List)`.
+  Show a list of installed :abbr:`CRLs (Certificate Revocation List)`.
 ```
 
 ```{eval-rst}

--- a/docs/configuration/protocols/bgp.md
+++ b/docs/configuration/protocols/bgp.md
@@ -35,7 +35,7 @@ provides distance vector metric and loop detection to BGP.
 ```{eval-rst}
 .. cfgcmd:: set protocols bgp system-as <asn>
 
-  Set local {abbr}`ASN (Autonomous System Number)` that this router represents.
+  Set local :abbr:`ASN (Autonomous System Number)` that this router represents.
   This is a a mandatory option!
 ```
 
@@ -207,7 +207,7 @@ process. The BGP process starts when the first neighbor is configured.
 .. cfgcmd:: set protocols bgp neighbor <address|interface> local-role
    <role> [strict]
 
-   BGP roles are defined in RFC {rfc}`9234` and provide an easy way to
+   BGP roles are defined in RFC :rfc:`9234` and provide an easy way to
    add route leak prevention, detection and mitigation. The local Role
    value is negotiated with the new BGP Role capability which has a
    built-in check of the corresponding value. In case of a mismatch the
@@ -222,7 +222,7 @@ process. The BGP process starts when the first neighbor is configured.
 
    If {cfgcmd}`strict` is set the BGP session won’t become established
    until the BGP neighbor sets local Role on its side. This
-   configuration parameter is defined in RFC {rfc}`9234` and is used to
+   configuration parameter is defined in RFC :rfc:`9234` and is used to
    enforce the corresponding configuration at your counter-parts side.
 
    Routes that are sent from provider, rs-server, or the peer local-role
@@ -509,7 +509,7 @@ process. The BGP process starts when the first neighbor is configured.
    hops <number>
 
    This command enforces Generalized TTL Security Mechanism (GTSM),
-   as specified in {rfc}`5082`. With this command, only neighbors
+   as specified in :rfc:`5082`. With this command, only neighbors
    that are specified number of hops away will be allowed to
    become neighbors. The number of hops range is 1 to 254. This
    command is mutually exclusive with {cfgcmd}`ebgp-multihop`.
@@ -738,12 +738,12 @@ are treated as belonging to a default peer group, and will share updates.
 .. cfgcmd:: set protocols bgp parameters ebgp-requires-policy
 
    This command changes the eBGP behavior of FRR. By default FRR enables
-   {rfc}`8212` functionality which affects how eBGP routes are advertised,
+   :rfc:`8212` functionality which affects how eBGP routes are advertised,
    namely no routes are advertised across eBGP sessions without some
    sort of egress route-map/policy in place. In VyOS however we have this
    RFC functionality disabled by default so that we can preserve backwards
    compatibility with older versions of VyOS. With this option one can
-   enable {rfc}`8212` functionality to operate.
+   enable :rfc:`8212` functionality to operate.
 ```
 
 ```{eval-rst}
@@ -1029,7 +1029,7 @@ For outbound updates the order of preference is:
 .. cfgcmd:: set protocols bgp neighbor <address|interface> address-family
    <ipv4-unicast|ipv6-unicast> capability orf <receive|send>
 
-   This command enables the ORF capability (described in {rfc}`5291`) on the
+   This command enables the ORF capability (described in :rfc:`5291`) on the
    local router, and enables ORF capability advertisement to the specified BGP
    peer. The {cfgcmd}`receive` keyword configures a router to advertise ORF
    receive capabilities. The {cfgcmd}`send` keyword configures a router to

--- a/docs/configuration/protocols/isis.md
+++ b/docs/configuration/protocols/isis.md
@@ -36,7 +36,7 @@ occur within IS-IS when it comes to said duplication.
 
   This commad sets network entity title (NET) provided in ISO format.
 
-  Here is an example {abbr}`NET (Network Entity Title)` value:
+  Here is an example :abbr:`NET (Network Entity Title)` value:
 
   .. code-block:: none
 
@@ -44,7 +44,7 @@ occur within IS-IS when it comes to said duplication.
 
   The CLNS address consists of the following parts:
 
-  * {abbr}`AFI (Address family authority identifier)` - ``49`` The AFI value
+  * :abbr:`AFI (Address family authority identifier)` - ``49`` The AFI value
     49 is what IS-IS uses for private addressing.
 
   * Area identifier: ``0001`` IS-IS area number (numberical area ``1``)
@@ -57,7 +57,7 @@ occur within IS-IS when it comes to said duplication.
     into ``192.168.001.002``. Then all one has to do is move the dots to have
     four numbers instead of three. This gives us ``1921.6800.1002``.
 
-  * {abbr}`NET (Network Entity Title)` selector: ``00`` Must always be 00. This
+  * :abbr:`NET (Network Entity Title)` selector: ``00`` Must always be 00. This
     setting indicates "this system" or "local system."
 ```
 
@@ -75,7 +75,7 @@ occur within IS-IS when it comes to said duplication.
 .. cfgcmd:: set protocols isis dynamic-hostname
 
   This command enables support for dynamic hostname TLV. Dynamic hostname
-  mapping determined as described in {rfc}`2763`, Dynamic Hostname
+  mapping determined as described in :rfc:`2763`, Dynamic Hostname
   Exchange Mechanism for IS-IS.
 ```
 
@@ -93,7 +93,7 @@ occur within IS-IS when it comes to said duplication.
 .. cfgcmd:: set protocols isis lsp-mtu <size>
 
   This command configures the maximum size of generated
-  {abbr}`LSPs (Link State PDUs)`, in bytes. The size range is 128 to 4352.
+  :abbr:`LSPs (Link State PDUs)`, in bytes. The size range is 128 to 4352.
 ```
 
 ```{eval-rst}
@@ -109,7 +109,7 @@ occur within IS-IS when it comes to said duplication.
 ```{eval-rst}
 .. cfgcmd:: set protocols isis purge-originator
 
-  This command enables {rfc}`6232` purge originator identification. Enable
+  This command enables :rfc:`6232` purge originator identification. Enable
   purge originator identification (POI) by adding the type, length and value
   (TLV) with the Intermediate System (IS) identification to the LSPs that do
   not contain POI information. If an IS generates a purge, VyOS adds this TLV
@@ -119,14 +119,14 @@ occur within IS-IS when it comes to said duplication.
 ```{eval-rst}
 .. cfgcmd:: set protocols isis set-attached-bit
 
-  This command sets ATT bit to 1 in Level1 LSPs. It is described in {rfc}`3787`.
+  This command sets ATT bit to 1 in Level1 LSPs. It is described in :rfc:`3787`.
 ```
 
 ```{eval-rst}
 .. cfgcmd:: set protocols isis set-overload-bit
 
   This command sets overload bit to avoid any transit traffic through this
-  router. It is described in {rfc}`3787`.
+  router. It is described in :rfc:`3787`.
 ```
 
 ```{eval-rst}
@@ -148,7 +148,7 @@ occur within IS-IS when it comes to said duplication.
 .. cfgcmd:: set protocols isis ldp-sync
 
   This command will enable IGP-LDP synchronization globally for ISIS. This
-  requires for LDP to be functional. This is described in {rfc}`5443`. By
+  requires for LDP to be functional. This is described in :rfc:`5443`. By
   default all interfaces operational in IS-IS are enabled for synchronization.
   Loopbacks are exempt.
 ```
@@ -195,7 +195,7 @@ occur within IS-IS when it comes to said duplication.
 
   This command configures padding on hello packets to accommodate asymmetrical
   maximum transfer units (MTUs) from different hosts as described in
-  {rfc}`3719`. This helps to prevent a premature adjacency Up state when one
+  :rfc:`3719`. This helps to prevent a premature adjacency Up state when one
   routing devices MTU does not meet the requirements to establish the adjacency.
 ```
 
@@ -233,7 +233,7 @@ occur within IS-IS when it comes to said duplication.
 .. cfgcmd:: set protocols isis interface <interface> priority <number>
 
   This command sets priority for the interface for
-  {abbr}`DIS (Designated Intermediate System)` election. The priority
+  :abbr:`DIS (Designated Intermediate System)` election. The priority
   range is 0 to 127.
 ```
 
@@ -250,7 +250,7 @@ occur within IS-IS when it comes to said duplication.
   no-three-way-handshake
 
   This command disables Three-Way Handshake for P2P adjacencies which
-  described in {rfc}`5303`. Three-Way Handshake is enabled by default.
+  described in :rfc:`5303`. Three-Way Handshake is enabled by default.
 ```
 
 ```{eval-rst}
@@ -367,7 +367,7 @@ occur within IS-IS when it comes to said duplication.
 
   This commands specifies the Finite State Machine (FSM) intended to
   control the timing of the execution of SPF calculations in response
-  to IGP events. The process described in {rfc}`8405`.
+  to IGP events. The process described in :rfc:`8405`.
 
 ```
 

--- a/docs/configuration/protocols/ospf.md
+++ b/docs/configuration/protocols/ospf.md
@@ -109,7 +109,7 @@ starts when the first ospf enabled interface is configured.
 .. cfgcmd:: set protocols ospf max-metric router-lsa
    <administrative|on-shutdown <seconds>|on-startup <seconds>>
 
-   This enables {rfc}`3137` support, where the OSPF process describes its
+   This enables :rfc:`3137` support, where the OSPF process describes its
    transit links in its router-LSA as having infinite distance so that other
    routers will avoid calculating transit paths through the router while
    still being able to reach networks through the router.
@@ -139,7 +139,7 @@ starts when the first ospf enabled interface is configured.
    area for inter-area connections.
 
    Detailed information about "cisco" and "ibm" models differences can be
-   found in {rfc}`3509`. A "shortcut" model allows ABR to create routes
+   found in :rfc:`3509`. A "shortcut" model allows ABR to create routes
    between areas based on the topology of the areas connected to this router
    but not using a backbone area in case if non-backbone route will be
    cheaper. For more information about "shortcut" model,
@@ -149,7 +149,7 @@ starts when the first ospf enabled interface is configured.
 ```{eval-rst}
 .. cfgcmd:: set protocols ospf parameters rfc1583-compatibility
 
-   {rfc}`2328`, the successor to {rfc}`1583`, suggests according to section
+   :rfc:`2328`, the successor to :rfc:`1583`, suggests according to section
    G.2 (changes) in section 16.4.1 a change to the path preference algorithm
    that prevents possible routing loops that were possible in the old version
    of OSPFv2. More specifically it demands that inter-area paths and
@@ -217,7 +217,7 @@ starts when the first ospf enabled interface is configured.
 .. cfgcmd:: set protocols ospf ldp-sync
 
   This command will enable IGP-LDP synchronization globally for OSPF. This
-  requires for LDP to be functional. This is described in {rfc}`5443`. By
+  requires for LDP to be functional. This is described in :rfc:`5443`. By
   default all interfaces operational in OSPF are enabled for synchronization.
   Loopbacks are exempt.
 ```
@@ -232,7 +232,7 @@ starts when the first ospf enabled interface is configured.
 ```{eval-rst}
 .. cfgcmd:: set protocols ospf capability opaque
 
-   ospfd supports Opaque LSA {rfc}`2370` as partial support for MPLS Traffic
+   ospfd supports Opaque LSA :rfc:`2370` as partial support for MPLS Traffic
    Engineering LSAs. The opaque-lsa capability must be enabled in the
    configuration.
 
@@ -494,7 +494,7 @@ starts when the first ospf enabled interface is configured.
 ```{eval-rst}
 .. cfgcmd:: set protocols ospf interface <interface> bfd
 
-   This command enables {abbr}`BFD (Bidirectional Forwarding Detection)` on
+   This command enables :abbr:`BFD (Bidirectional Forwarding Detection)` on
    this OSPF link interface.
 ```
 
@@ -595,7 +595,7 @@ Route will be originated on-behalf of all matched external LSAs.
 ```{eval-rst}
 .. cfgcmd:: set protocols ospf graceful-restart [grace-period (1-1800)]
 
-   Configure Graceful Restart {rfc}`3623` restarting support. When enabled,
+   Configure Graceful Restart :rfc:`3623` restarting support. When enabled,
    the default grace period is 120 seconds.
 
    To perform a graceful shutdown, the FRR ``graceful-restart prepare ip
@@ -606,7 +606,7 @@ Route will be originated on-behalf of all matched external LSAs.
 ```{eval-rst}
 .. cfgcmd:: set protocols ospf graceful-restart helper enable [router-id A.B.C.D]
 
-   Configure Graceful Restart {rfc}`3623` helper support. By default, helper support
+   Configure Graceful Restart :rfc:`3623` helper support. By default, helper support
    is disabled for all neighbours. This config enables/disables helper support
    on this router for all neighbours.
 
@@ -1351,7 +1351,7 @@ process starts when the first ospf enabled interface is configured.
 ```{eval-rst}
 .. cfgcmd:: set protocols ospfv3 graceful-restart [grace-period (1-1800)]
 
-   Configure Graceful Restart {rfc}`3623` restarting support. When enabled,
+   Configure Graceful Restart :rfc:`3623` restarting support. When enabled,
    the default grace period is 120 seconds.
 
    To perform a graceful shutdown, the FRR ``graceful-restart prepare ip
@@ -1362,7 +1362,7 @@ process starts when the first ospf enabled interface is configured.
 ```{eval-rst}
 .. cfgcmd:: set protocols ospfv3 graceful-restart helper enable [router-id A.B.C.D]
 
-   Configure Graceful Restart {rfc}`3623` helper support. By default, helper support
+   Configure Graceful Restart :rfc:`3623` helper support. By default, helper support
    is disabled for all neighbours. This config enables/disables helper support
    on this router for all neighbours.
 

--- a/docs/configuration/protocols/pim.md
+++ b/docs/configuration/protocols/pim.md
@@ -32,7 +32,7 @@ source-specific multicast).
 .. cfgcmd:: set protocols pim ecmp
 
    If PIM has the a choice of ECMP nexthops for a particular
-   {abbr}`RPF (Reverse Path Forwarding)`, PIM will cause S,G flows to be
+   :abbr:`RPF (Reverse Path Forwarding)`, PIM will cause S,G flows to be
    spread out amongst the nexthops. If this command is not specified then
    the first nexthop found will be used.
 ```
@@ -97,7 +97,7 @@ source-specific multicast).
 ```{eval-rst}
 .. cfgcmd:: set protocols pim rp <address> group <group>
 
-   In order to use PIM, it is necessary to configure a {abbr}`RP (Rendezvous Point)`
+   In order to use PIM, it is necessary to configure a :abbr:`RP (Rendezvous Point)`
    for join messages to be sent to. Currently the only methodology to do this is
    via static rendezvous point commands.
 
@@ -111,8 +111,8 @@ source-specific multicast).
 .. cfgcmd:: set protocols pim rp keep-alive-timer <n>
 
    Modify the time out value for a S,G flow from 1-65535 seconds at
-   {abbr}`RP (Rendezvous Point)`. The normal keepalive period for the KAT(S,G)
-   defaults to 210 seconds. However, at the {abbr}`RP (Rendezvous Point)`, the
+   :abbr:`RP (Rendezvous Point)`. The normal keepalive period for the KAT(S,G)
+   defaults to 210 seconds. However, at the :abbr:`RP (Rendezvous Point)`, the
    keepalive period must be at least the Register_Suppression_Time, or the RP
    may time out the (S,G) state before the next Null-Register arrives.
    Thus, the KAT(S,G) is set to max(Keepalive_Period, RP_Keepalive_Period)
@@ -121,7 +121,7 @@ source-specific multicast).
    If choosing a value below 31 seconds be aware that some hardware platforms
    cannot see data flowing in better than 30 second chunks.
 
-   See {rfc}`7761#section-4.1` for details.
+   See :rfc:`7761#section-4.1` for details.
 ```
 
 ```{eval-rst}
@@ -129,7 +129,7 @@ source-specific multicast).
 
    When sending PIM hello packets tell PIM to not send any v6 secondary
    addresses on the interface. This information is used to allow PIM to use v6
-   nexthops in it's decision for {abbr}`RPF (Reverse Path Forwarding)` lookup
+   nexthops in it's decision for :abbr:`RPF (Reverse Path Forwarding)` lookup
    if this option is not set (default).
 ```
 
@@ -148,7 +148,7 @@ source-specific multicast).
 .. cfgcmd:: set protocols pim ssm prefix-list <list>
 
    Specify a range of group addresses via a prefix-list that forces PIM to never
-   do {abbr}`SSM (Source-Specific Multicast)` over.
+   do :abbr:`SSM (Source-Specific Multicast)` over.
 ```
 
 ### Interface specific commands
@@ -168,7 +168,7 @@ source-specific multicast).
 ```{eval-rst}
 .. cfgcmd:: set protocols pim interface <interface> dr-priority <n>
 
-   Set the {abbr}`DR (Designated Router)` Priority for the interface.
+   Set the :abbr:`DR (Designated Router)` Priority for the interface.
    This command is useful to allow the user to influence what node becomes
    the DR for a LAN segment.
 ```
@@ -241,7 +241,7 @@ source-specific multicast).
    Use this command to configure in the selected interface the IGMP
    query response timeout value (10-250) in deciseconds. If a report is
    not returned in the specified time, it will be assumed the (S,G) or
-   (\*,G) state {rfc}`7761#section-4.1` has timed out.
+   (\*,G) state :rfc:`7761#section-4.1` has timed out.
 ```
 
 ```{eval-rst}

--- a/docs/configuration/service/dhcp-server.md
+++ b/docs/configuration/service/dhcp-server.md
@@ -702,7 +702,7 @@ section.
 .. cfgcmd:: set service dhcpv6-server shared-network-name <name> subnet
    <prefix> nis-domain <domain-name>
 
-   A {abbr}`NIS (Network Information Service)` domain can be set to be used for
+   A :abbr:`NIS (Network Information Service)` domain can be set to be used for
    DHCPv6 clients.
 ```
 
@@ -710,7 +710,7 @@ section.
 .. cfgcmd:: set service dhcpv6-server shared-network-name <name> subnet
    <prefix> nisplus-domain <domain-name>
 
-   The procedure to specify a {abbr}`NIS+ (Network Information Service Plus)`
+   The procedure to specify a :abbr:`NIS+ (Network Information Service Plus)`
    domain is similar to the NIS domain one:
 ```
 
@@ -732,7 +732,7 @@ section.
 .. cfgcmd:: set service dhcpv6-server shared-network-name <name> subnet
    <prefix> sip-server <address | fqdn>
 
-   Specify a {abbr}`SIP (Session Initiation Protocol)` server by IPv6
+   Specify a :abbr:`SIP (Session Initiation Protocol)` server by IPv6
    address of Fully Qualified Domain Name for all DHCPv6 clients.
 ```
 

--- a/docs/configuration/service/https.md
+++ b/docs/configuration/service/https.md
@@ -31,7 +31,7 @@ Please take a look at the {ref}`vyosapi` page for an detailed how-to.
 ```{eval-rst}
 .. cfgcmd:: set service https certificates dh-params <name>
 
-   Use {abbr}`DH (Diffie–Hellman)` parameters from PKI subsystem.
+   Use :abbr:`DH (Diffie–Hellman)` parameters from PKI subsystem.
    Must be at least 2048 bits in length.
 ```
 

--- a/docs/configuration/service/ntp.md
+++ b/docs/configuration/service/ntp.md
@@ -42,7 +42,7 @@ the `allow-client` directive.
 .. cfgcmd:: set service ntp server <address>
 
    Configure one or more servers for synchronisation. Server name can be either
-   an IP address or {abbr}`FQDN (Fully Qualified Domain Name)`.
+   an IP address or :abbr:`FQDN (Fully Qualified Domain Name)`.
 
    There are 3 default NTP server set. You are able to change them.
 
@@ -60,7 +60,7 @@ the `allow-client` directive.
      server is discarded by the selection algorithm.
 
    * ``nts`` enables Network Time Security (NTS) for the server as specified
-     in {rfc}`8915`
+     in :rfc:`8915`
 
    * ``pool`` mobilizes persistent client mode association with a number of
      remote servers.
@@ -90,7 +90,7 @@ the `allow-client` directive.
 ```{eval-rst}
 .. cfgcmd:: set service ntp vrf <name>
 
-   Specify name of the {abbr}`VRF (Virtual Routing and Forwarding)` instance.
+   Specify name of the :abbr:`VRF (Virtual Routing and Forwarding)` instance.
 ```
 
 ```{eval-rst}

--- a/docs/configuration/service/pppoe-server.md
+++ b/docs/configuration/service/pppoe-server.md
@@ -610,7 +610,7 @@ set service pppoe-server default-ipv6-pool IPv6-POOL
 ```{eval-rst}
 .. cfgcmd:: set service pppoe-server ppp-options mppe <require | prefer | deny>
 
-  Specifies {abbr}`MPPE (Microsoft Point-to-Point Encryption)` negotiation
+  Specifies :abbr:`MPPE (Microsoft Point-to-Point Encryption)` negotiation
   preference.
 
   * **require** - ask client for mppe, if it rejects drop connection

--- a/docs/configuration/service/router-advert.md
+++ b/docs/configuration/service/router-advert.md
@@ -51,9 +51,9 @@ Supported interface types:
 ```{eval-rst}
 .. cfgcmd:: set service router-advert interface <interface> prefix <prefix/mask>
 
-   .. note:: You can also opt for using `::/64` as prefix for your {abbr}`RAs (Router
-    Advertisements)`. This will take the IPv6 GUA prefix assigned to the interface,
-    which comes in handy when using DHCPv6-PD.
+   .. note:: You can also opt for using `::/64` as prefix for your
+      :abbr:`RAs (Router Advertisements)`. This will take the IPv6 GUA prefix
+      assigned to the interface, which comes in handy when using DHCPv6-PD.
 ```
 
 
@@ -75,7 +75,7 @@ Supported interface types:
 ```{eval-rst}
 .. cfgcmd:: set service router-advert interface <interface> nat64prefix <prefix/mask>
 
-   Enable PREF64 option as outlined in {rfc}`8781`.
+   Enable PREF64 option as outlined in :rfc:`8781`.
 
    NAT64 prefix mask must be one of: /32, /40, /48, /56, /64 or 96.
 

--- a/docs/configuration/service/ssh.md
+++ b/docs/configuration/service/ssh.md
@@ -31,7 +31,7 @@ to tighter security in VyOS 1.2.
 :::
 
 ```{eval-rst}
-.. seealso:: SSH {ref}`ssh_key_based_authentication`
+.. seealso:: SSH :ref:`ssh_key_based_authentication`
 ```
 
 ## Configuration
@@ -79,7 +79,7 @@ to tighter security in VyOS 1.2.
 ```{eval-rst}
 .. cfgcmd:: set service ssh mac <mac>
 
-  Specifies the available {abbr}`MAC (Message Authentication Code)` algorithms.
+  Specifies the available :abbr:`MAC (Message Authentication Code)` algorithms.
   The MAC algorithm is used in protocol version 2 for data integrity protection.
   Multiple algorithms can be provided by using multiple commands, defining
   one algorithm per command.
@@ -111,7 +111,7 @@ to tighter security in VyOS 1.2.
 ```{eval-rst}
 .. cfgcmd:: set service ssh key-exchange <kex>
 
-  Specify allowed {abbr}`KEX (Key Exchange)` algorithms.
+  Specify allowed :abbr:`KEX (Key Exchange)` algorithms.
 
   List of supported algorithms: ``diffie-hellman-group1-sha1``,
   ``diffie-hellman-group14-sha1``, ``diffie-hellman-group14-sha256``,
@@ -131,7 +131,7 @@ to tighter security in VyOS 1.2.
 ```{eval-rst}
 .. cfgcmd:: set service ssh vrf <name>
 
-  Specify name of the {abbr}`VRF (Virtual Routing and Forwarding)` instance.
+  Specify name of the :abbr:`VRF (Virtual Routing and Forwarding)` instance.
 ```
 
 ## Dynamic-protection
@@ -233,7 +233,7 @@ offending IP is blocked. Offenders are unblocked after a set interval.
 .. opcmd:: generate public-key-command user <username> path <location>
 
    Generate the configuration mode commands to add a public key for
-   {ref}`ssh_key_based_authentication`.
+   :ref:`ssh_key_based_authentication`.
    ``<location>`` can be a local path or a URL pointing at a remote file.
 
    Supported remote protocols are FTP, FTPS, HTTP, HTTPS, SCP/SFTP and TFTP.

--- a/docs/configuration/system/flow-accounting.md
+++ b/docs/configuration/system/flow-accounting.md
@@ -113,7 +113,7 @@ exported them to a collection server.
 
    * **5** - Most common version, but restricted to IPv4 flows only
    * **9** - NetFlow version 9 (default)
-   * **10** - {abbr}`IPFIX (IP Flow Information Export)` as per {rfc}`3917`
+   * **10** - :abbr:`IPFIX (IP Flow Information Export)` as per :rfc:`3917`
 ```
 
 ```{eval-rst}

--- a/docs/configuration/system/frr.md
+++ b/docs/configuration/system/frr.md
@@ -9,7 +9,7 @@ but require either a restart of the routing daemon, or a reboot of the system.
 ```{eval-rst}
 .. cfgcmd:: set system frr bmp
 
-   Enable {abbr}`BMP (BGP Monitoring Protocol)` support
+   Enable :abbr:`BMP (BGP Monitoring Protocol)` support
 ```
 
 ```{eval-rst}

--- a/docs/configuration/system/lcd.md
+++ b/docs/configuration/system/lcd.md
@@ -20,7 +20,7 @@ connectivity of the display to your system. This can be any serial port
    display. Tab completion is supported and it will list you all available
    serial interface.
 
-   For serial via USB port information please refor to: :ref:`hardware_usb`.
+   For serial via USB port information please refer to: :ref:`hardware_usb`.
 ```
 
 ```{eval-rst}

--- a/docs/configuration/system/lcd.md
+++ b/docs/configuration/system/lcd.md
@@ -20,7 +20,7 @@ connectivity of the display to your system. This can be any serial port
    display. Tab completion is supported and it will list you all available
    serial interface.
 
-   For serial via USB port information please refor to: {ref}`hardware_usb`.
+   For serial via USB port information please refor to: :ref:`hardware_usb`.
 ```
 
 ```{eval-rst}

--- a/docs/configuration/system/login.md
+++ b/docs/configuration/system/login.md
@@ -65,7 +65,7 @@ lines. Be attentive when you paste it that it only pastes as a single line.
 The third part is simply an identifier, and is for your own reference.
 
 ```{eval-rst}
-.. seealso:: SSH {ref}`ssh_operation`
+.. seealso:: SSH :ref:`ssh_operation`
 ```
 
 ```{eval-rst}

--- a/docs/configuration/system/syslog.md
+++ b/docs/configuration/system/syslog.md
@@ -20,7 +20,7 @@ server which is reached via {abbr}`IP (Internet Protocol)` UDP/TCP.
 .. cfgcmd:: set system syslog console facility <keyword> level <keyword>
 
    Log syslog messages to ``/dev/console``, for an explanation on
-   {ref}`syslog_facilities` keywords and {ref}`syslog_severity_level` keywords
+   :ref:`syslog_facilities` keywords and :ref:`syslog_severity_level` keywords
    see tables below.
 ```
 
@@ -32,7 +32,7 @@ server which is reached via {abbr}`IP (Internet Protocol)` UDP/TCP.
 .. cfgcmd:: set system syslog file <filename> facility <keyword> level <keyword>
 
    Log syslog messages to file specified via `<filename>`, for an explanation on
-   {ref}`syslog_facilities` keywords and {ref}`syslog_severity_level` keywords
+   :ref:`syslog_facilities` keywords and :ref:`syslog_severity_level` keywords
    see tables below.
 ```
 
@@ -65,7 +65,7 @@ sending the messages via port 514/UDP.
 
    Log syslog messages to remote host specified by `<address>`. The address
    can be specified by either FQDN or IP address. For an explanation on
-   {ref}`syslog_facilities` keywords and {ref}`syslog_severity_level`
+   :ref:`syslog_facilities` keywords and :ref:`syslog_severity_level`
    keywords see tables below.
 
 ```
@@ -82,7 +82,7 @@ sending the messages via port 514/UDP.
 ```{eval-rst}
 .. cfgcmd:: set system syslog vrf <name>
 
-  Specify name of the {abbr}`VRF (Virtual Routing and Forwarding)` instance.
+  Specify name of the :abbr:`VRF (Virtual Routing and Forwarding)` instance.
 ```
 
 #### {abbr}`TLS (Transport Layer Security)`-encrypted remote logging
@@ -90,8 +90,9 @@ sending the messages via port 514/UDP.
 VyOS supports {abbr}`TLS (Transport Layer Security)`-encrypted remote logging
 over TCP to ensure secure transmission of syslog data to remote syslog servers.
 
-**Prerequisites**: Before configuring {abbr}`TLS (Transport Layer
-Security)`-encrypted remote logging, ensure you have:
+**Prerequisites**: Before configuring
+{abbr}`TLS (Transport Layer Security)`-encrypted remote logging,
+ensure you have:
 
 - A valid remote syslog server address.
 
@@ -118,12 +119,12 @@ Security)`-encrypted remote logging, ensure you have:
 ```{eval-rst}
 .. cfgcmd:: set system syslog remote <address> tls ca-certificate <ca_name>
 
-   **Configure the** {abbr}`CA (Certificate Authority)` **certificate.**
+   **Configure the** :abbr:`CA (Certificate Authority)` **certificate.**
 
-   The syslog client uses the {abbr}`CA (Certificate Authority)` certificate to
+   The syslog client uses the :abbr:`CA (Certificate Authority)` certificate to
    verify the identity of the remote syslog server.
 
-   The {abbr}`CA (Certificate Authority)` certificate is required for **all**
+   The :abbr:`CA (Certificate Authority)` certificate is required for **all**
    authentication modes except ``anon``.
 ```
 
@@ -152,7 +153,7 @@ Security)`-encrypted remote logging, ensure you have:
 
    * ``anon`` **(default)**: Allows encrypted connections without verifying the syslog
      server's identity. This mode is **not recommended**, as it is vulnerable to
-     {abbr}`MITM (Man-in-the-Middle)` attacks.
+     :abbr:`MITM (Man-in-the-Middle)` attacks.
    * ``fingerprint``: Verifies the server’s certificate fingerprint against the
      value preconfigured with:
 
@@ -161,12 +162,12 @@ Security)`-encrypted remote logging, ensure you have:
         set system syslog remote <address> tls permitted-peer <peer>
 
    * ``certvalid``: Verifies the server certificate is signed by a trusted
-     {abbr}`CA (Certificate Authority)`, skipping {abbr}`CN (Common Name)` check.
+     :abbr:`CA (Certificate Authority)`, skipping :abbr:`CN (Common Name)` check.
    * ``name``: Verifies that:
 
-     * The server’s certificate is signed by a trusted {abbr}`CA (Certificate
-       Authority)`.
-     * The {abbr}`CN (Common Name)` in the certificate matches the value
+     * The server’s certificate is signed by a trusted
+       :abbr:`CA (Certificate Authority)`.
+     * The :abbr:`CN (Common Name)` in the certificate matches the value
        preconfigured with:
 
      .. code-block:: none
@@ -185,7 +186,7 @@ Security)`-encrypted remote logging, ensure you have:
 
    * ``fingerprint``: Enter the expected certificate fingerprints (SHA-1 or
      SHA-256).
-   * ``name``: Enter the expected certificate {abbr}`CNs (Common Names)`.
+   * ``name``: Enter the expected certificate :abbr:`CNs (Common Names)`.
 
    For ``anon`` and ``certvalid`` authentication modes, certificate identifiers
    are not required.
@@ -243,7 +244,7 @@ set system syslog host graylog.example.com tls permitted-peer 'graylog.example.c
    If logging to a local user account is configured, all defined log messages
    are display on the console if the local user is logged in, if the user is not
    logged in, no messages are being displayed. For an explanation on
-   {ref}`syslog_facilities` keywords and {ref}`syslog_severity_level` keywords
+   :ref:`syslog_facilities` keywords and :ref:`syslog_severity_level` keywords
    see tables below.
 ```
 

--- a/docs/configuration/vpn/dmvpn.md
+++ b/docs/configuration/vpn/dmvpn.md
@@ -54,7 +54,7 @@ Baseline DMVPN topology
 .. cfgcmd:: set protocols nhrp tunnel <tunnel> dynamic-map <address>
   nbma-domain-name <fqdn>
 
-  Specifies that the {abbr}`NBMA (Non-broadcast multiple-access network)`
+  Specifies that the :abbr:`NBMA (Non-broadcast multiple-access network)`
   addresses of the next hop servers are defined in the domain name
   nbma-domain-name. For each A record opennhrp creates a dynamic NHS entry.
 
@@ -87,8 +87,8 @@ Baseline DMVPN topology
 ```{eval-rst}
 .. cfgcmd:: set protocols nhrp tunnel <tunnel> map nbma-address <address>
 
-  Creates static peer mapping of protocol-address to {abbr}`NBMA (Non-broadcast
-  multiple-access network)` address.
+  Creates static peer mapping of protocol-address to
+  :abbr:`NBMA (Non-broadcast multiple-access network)` address.
 
   If the IP prefix mask is present, it directs opennhrp to use this peer as a
   next hop server when sending Resolution Requests matching this subnet.

--- a/docs/configuration/vpn/l2tp.md
+++ b/docs/configuration/vpn/l2tp.md
@@ -545,7 +545,7 @@ set vpn l2tp remote-access default-ipv6-pool IPv6-POOL
 ```{eval-rst}
 .. cfgcmd:: set vpn l2tp remote-access ppp-options mppe <require | prefer | deny>
 
-  Specifies {abbr}`MPPE (Microsoft Point-to-Point Encryption)` negotiation
+  Specifies :abbr:`MPPE (Microsoft Point-to-Point Encryption)` negotiation
   preference.
 
   * **require** - ask client for mppe, if it rejects drop connection

--- a/docs/configuration/vpn/pptp.md
+++ b/docs/configuration/vpn/pptp.md
@@ -461,7 +461,7 @@ set vpn pptp remote-access default-ipv6-pool IPv6-POOL
 ```{eval-rst}
 .. cfgcmd:: set vpn pptp remote-access ppp-options mppe <require | prefer | deny>
 
-  Specifies {abbr}`MPPE (Microsoft Point-to-Point Encryption)` negotiation
+  Specifies :abbr:`MPPE (Microsoft Point-to-Point Encryption)` negotiation
   preference.
 
   * **require** - ask client for mppe, if it rejects drop connection

--- a/docs/configuration/vpn/sstp.md
+++ b/docs/configuration/vpn/sstp.md
@@ -503,7 +503,7 @@ set vpn sstp default-ipv6-pool IPv6-POOL
 ```{eval-rst}
 .. cfgcmd:: set vpn sstp ppp-options mppe <require | prefer | deny>
 
-  Specifies {abbr}`MPPE (Microsoft Point-to-Point Encryption)` negotiation
+  Specifies :abbr:`MPPE (Microsoft Point-to-Point Encryption)` negotiation
   preference.
 
   * **require** - ask client for mppe, if it rejects drop connection

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,43 +9,55 @@
    .. grid-item-card:: Get / Build VyOS
 
 
-      Quickly {ref}`Build<contributing/build-vyos:build vyos>` your own Image or take a look at how to {ref}`download<installation/install:download>` a free or supported version.
+      Quickly :ref:`Build <contributing/build-vyos:build vyos>` your own
+      Image or take a look at how to
+      :ref:`download <installation/install:download>` a free or supported
+      version.
 
 
    .. grid-item-card:: Install VyOS
 
-      Read about how to install VyOS on {ref}`Bare Metal<installation/install:installation>` or in a
-      {ref}`Virtual Environment<installation/virtual/index:running vyos in virtual environments>` and
-      how to use an image with the usual {ref}`cloud<installation/cloud/index:running VyOS in Cloud Environments>` providers
+      Read about how to install VyOS on
+      :ref:`Bare Metal <installation/install:installation>` or in a
+      :ref:`Virtual Environment <installation/virtual/index:running vyos in virtual environments>`
+      and how to use an image with the usual
+      :ref:`cloud <installation/cloud/index:running VyOS in Cloud Environments>`
+      providers
 
 
    .. grid-item-card:: Configuration and Operation
 
-      Use the {ref}`Quickstart Guide<quick-start:Quick Start>`, to have a fast overview. Or go deeper and
-      set up {ref}`advanced routing<configuration/protocols/index:protocols>`,
-      {ref}`VRFs<configuration/vrf/index:vrf>`, or
-      {ref}`VPNs<configuration/vpn/index:vpn>` for example.
+      Use the :ref:`Quickstart Guide <quick-start:Quick Start>`, to have a
+      fast overview. Or go deeper and
+      set up :ref:`advanced routing <configuration/protocols/index:protocols>`,
+      :ref:`VRFs <configuration/vrf/index:vrf>`, or
+      :ref:`VPNs <configuration/vpn/index:vpn>` for example.
 
 
    .. grid-item-card:: Automate
 
       Integrate VyOS in your automation Workflow with
-      {ref}`Ansible<vyos-ansible>`,
-      have your own {ref}`local scripts<command-scripting>`, or configure VyOS with the {ref}`HTTPS-API<vyosapi>`.
+      :ref:`Ansible <vyos-ansible>`,
+      have your own :ref:`local scripts <command-scripting>`, or configure
+      VyOS with the :ref:`HTTPS-API <vyosapi>`.
 
 
    .. grid-item-card::  Examples
 
-      Get some inspiration from the {ref}`Configuration Blueprints<configexamples/index:Configuration Blueprints>`
+      Get some inspiration from the
+      :ref:`configexamples/index:Configuration Blueprints`
       to build your infrastructure.
 
 
    .. grid-item-card:: Contribute and Community
 
       | There are many ways to contribute to the project.
-      | Add missing parts or improve the {ref}`Documentation<documentation:Write Documentation>`.
-      | Discuss in `Slack <https://slack.vyos.io/>`_ or the `Forum <https://forum.vyos.io>`_.
-      | Or you can pick up a `Task <https://vyos.dev/>`_ and fix the {ref}`code<contributing/development:development>`.
+      | Add missing parts or improve the
+        :ref:`Documentation <documentation:Write Documentation>`.
+      | Discuss in `Slack <https://slack.vyos.io/>`_ or the
+        `Forum <https://forum.vyos.io>`_.
+      | Or you can pick up a `Task <https://vyos.dev/>`_ and fix the
+        :ref:`code <contributing/development:development>`.
 
 ```
 


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
### Problem

On `sagitta`, several pages use MyST roles like `{ref}` inside ` ```{eval-rst} ` blocks. Inside `eval-rst`, MyST does not process these roles, they leak through to the RST parser as-is and render as plain text on docs.vyos.io.

Most visible on `docs/index.md`, where all six landing cards show raw `{ref}` syntax instead of links.

### Fix

This PR replaces MyST role syntax with the equivalent RST syntax inside `eval-rst` blocks:

```diff
- {ref}`text<target>`         → :ref:`text <target>`
- {abbr}`ABBR (Full form)`    → :abbr:`ABBR (Full form)`
- {rfc}`1234`                 → :rfc:`1234`
```


## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
VD-4632

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document