### PR TITLE
docs: expand Context7 branch-to-version mapping rule

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -26,7 +26,7 @@
     "Documentation sources are MyST Markdown (.md). Cite and link to the .md form.",
     "VyOS has two CLI modes: configuration mode (entered via `configure`; for `set`/`delete`/`commit`/`save` and config-state `show`) and operational mode (default after login; for `show`, `monitor`, plus image-mgmt like `add system image`). Do not mix.",
     "Configuration commands are wrapped in `cfgcmd` fenced blocks; operational commands in `opcmd` fenced blocks. Treat these as authoritative command syntax.",
-    "Branch-to-version mapping (cite version-appropriate docs): `rolling` = rolling / 1.5+ (default); `circinus` = 1.5.x (current LTS); `sagitta` = 1.4.x (previous LTS); `equuleus` = 1.3.x (legacy); `crux` = 1.2.x (legacy).",
+    "Branch-to-version mapping (cite version-appropriate docs): `rolling` = rolling / next major, 1.6+ (default); `circinus` = 1.5.x (current LTS); `sagitta` = 1.4.x (previous LTS); `equuleus` = 1.3.x (legacy); `crux` = 1.2.x (legacy).",
     "Do not invent CLI commands. If a command isn't in the docs, say so rather than guess — VyOS syntax is strict and unknown commands fail validation at commit time.",
     "Use reserved documentation IP space in examples: 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24 (RFC 5737), 2001:db8::/32 (RFC 3849). Never use real or RFC1918 addresses.",
     "`commit` activates pending `set`/`delete` changes and runs validation (errors = no change applied); `save` persists across reboot. Verify with `show <node>` (config mode) or `show configuration commands` (op mode). Always include `commit` and `save`.",

--- a/context7.json
+++ b/context7.json
@@ -26,7 +26,7 @@
     "Documentation sources are MyST Markdown (.md). Cite and link to the .md form.",
     "VyOS has two CLI modes: configuration mode (entered via `configure`; for `set`/`delete`/`commit`/`save` and config-state `show`) and operational mode (default after login; for `show`, `monitor`, plus image-mgmt like `add system image`). Do not mix.",
     "Configuration commands are wrapped in `cfgcmd` fenced blocks; operational commands in `opcmd` fenced blocks. Treat these as authoritative command syntax.",
-    "Branch `rolling` tracks the rolling release and the next stable line. Branch `circinus` tracks 1.5.x. Branch `sagitta` tracks 1.4.x. Always cite version-appropriate documentation.",
+    "Branch-to-version mapping (cite version-appropriate docs): `rolling` = rolling / 1.5+ (default); `circinus` = 1.5.x (current LTS); `sagitta` = 1.4.x (previous LTS); `equuleus` = 1.3.x (legacy); `crux` = 1.2.x (legacy).",
     "Do not invent CLI commands. If a command isn't in the docs, say so rather than guess — VyOS syntax is strict and unknown commands fail validation at commit time.",
     "Use reserved documentation IP space in examples: 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24 (RFC 5737), 2001:db8::/32 (RFC 3849). Never use real or RFC1918 addresses.",
     "`commit` activates pending `set`/`delete` changes and runs validation (errors = no change applied); `save` persists across reboot. Verify with `show <node>` (config mode) or `show configuration commands` (op mode). Always include `commit` and `save`.",


### PR DESCRIPTION
## Change

Expand the Context7 AI-instructions branch-to-version mapping rule in `context7.json` (rule 29) to the full table, matching the canonical mapping in `AGENTS.md`:

- `rolling` = rolling / next major, 1.6+ (default)
- `circinus` = 1.5.x (current LTS)
- `sagitta` = 1.4.x (previous LTS)
- `equuleus` = 1.3.x (legacy)
- `crux` = 1.2.x (legacy)

Previously the rule only listed circinus (1.5.x) and sagitta (1.4.x), and described `rolling` as "1.5+" — stale, since circinus **is** the 1.5 LTS line.

## Why

Context7's `rules` array is the AI-instruction set surfaced to assistants querying the VyOS docs corpus. A complete, accurate branch→version map lets them cite version-appropriate documentation for all supported release lines, not just the two LTS branches.

## Scope

Single-line edit to `context7.json`. No docs content, no build/CI impact. JSON validated.

## Backport

`@Mergifyio backport circinus sagitta` (to be posted as a comment after merge)

🤖 Generated by [robots](https://vyos.io)