### PR TITLE
docs(Traffic Engineering): Clarify OSPF advertisement is not yet supported

### DIFF
--- a/docs/configuration/protocols/traffic-engineering.md
+++ b/docs/configuration/protocols/traffic-engineering.md
@@ -29,7 +29,7 @@ information is distributed across the network.
 ## Common link parameters
 
 The following commands define link-level TE attributes that can be advertised
-by both IS-IS and OSPF (not supported yet).
+by both IS-IS and OSPF (although OSPF advertisement is not supported yet).
 
 ```{cfgcmd} set protocols traffic-engineering admin-group \<admin-group-name\> bit-position \<0-31\>
 


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR rewrites the note in the Common link parameters section of the Traffic Engineering page to make clear that OSPF advertisement of link-level TE attributes is not yet supported.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->


## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document