### PR TITLE
docs:T8598: Add IPv6 peer-IID secret configuration for calling-sid option

### DIFF
--- a/docs/configuration/service/pppoe-server.md
+++ b/docs/configuration/service/pppoe-server.md
@@ -441,28 +441,46 @@ set service pppoe-server default-ipv6-pool IPv6-POOL
 
 ```{cfgcmd} set service pppoe-server ppp-options ipv6-accept-peer-interface-id
 
-Accept peer interface identifier. By default is not defined.
+Accept peer interface identifier. By default this is not defined.
 ```
 
 
 ```{cfgcmd} set service pppoe-server ppp-options ipv6-interface-id \<random | x:x:x:x\>
 
-Specifies fixed or random interface identifier for IPv6.
-By default is fixed.
+Specifies Fixed or Random interface identifier for IPv6.
+By default, a Fixed (deterministic) interface identifier is used.
 
 * **random** - Random interface identifier for IPv6
 * **x:x:x:x** - Specify interface identifier for IPv6
 ```
 
 
-```{cfgcmd} set service pppoe-server ppp-options ipv6-interface-id \<random | x:x:x:x\>
+```{cfgcmd} set service pppoe-server ppp-options ipv6-peer-interface-id \<random | x:x:x:x | ipv4-addr | calling-sid\>
 
-Specifies peer interface identifier for IPv6. By default is fixed.
+Specifies peer interface identifier for IPv6. By default, a Fixed
+(deterministic) peer interface identifier is used.
 
-* **random** - Random interface identifier for IPv6
-* **x:x:x:x** - Specify interface identifier for IPv6
+* **random** - Random interface identifier for IPv6.
+* **x:x:x:x** - Specify a Fixed peer interface identifier for IPv6.
 * **ipv4-addr** - Calculate interface identifier from IPv4 address.
 * **calling-sid** - Calculate interface identifier from calling-station-id.
+```
+
+```{cfgcmd} set service pppoe-server ppp-options ipv6-peer-interface-id-secret \<secret-key\>
+
+Secret key used to generate the IPv6 peer interface identifier (IID) when
+``ipv6-peer-interface-id`` is set to ``calling-sid``. This key is combined
+with the calling-station-id to derive a stable, non-predictable IID.
+
+* Required when ``ipv6-peer-interface-id`` is set to ``calling-sid``.
+* Must be 16 to 128 printable non-whitespace ASCII characters.
+
+For example:
+
+~~~none
+set service pppoe-server ppp-options ipv6-peer-interface-id calling-sid
+set service pppoe-server ppp-options ipv6-peer-interface-id-secret 'exampleSecret123!'
+~~~
 ```
 
 ## Scripting

--- a/docs/configuration/service/pppoe-server.md
+++ b/docs/configuration/service/pppoe-server.md
@@ -6,7 +6,7 @@ lastproofread: '2022-09-17'
 
 # PPPoE Server
 
-VyOS utilizes [accel-ppp](https://accel-ppp.org/) to provide PPPoE server
+VyOS utilizes [accel-ppp-ng](https://accel-ppp.org/) to provide PPPoE server
 functionality. It can be used with local authentication or a connected
 RADIUS server.
 

--- a/docs/configuration/service/pppoe-server.md
+++ b/docs/configuration/service/pppoe-server.md
@@ -6,8 +6,9 @@ lastproofread: '2022-09-17'
 
 # PPPoE Server
 
-VyOS utilizes [accel-ppp](https://accel-ppp.org/) to provide PPPoE server functionality. It can
-be used with local authentication or a connected RADIUS server.
+VyOS utilizes [accel-ppp](https://accel-ppp.org/) to provide PPPoE server
+functionality. It can be used with local authentication or a connected
+RADIUS server.
 
 :::{note}
 Please be aware, due to an upstream bug, config
@@ -767,5 +768,7 @@ vyos@pppoe-server:~$ sh pppoe-server sessions
  ppp0   | test     | 192.168.0.1 | 2001:db8:8002:0:200::/64 | 2001:db8:8003::1/56 | 00:53:00:12:42:eb |            | active | 00:00:49 | 875 B    | 2.1 KiB
 ```
 
+% stop_vyoslinter
 [accel-ppp attribute]: https://github.com/accel-ppp/accel-ppp/blob/master/accel-pppd/radius/dict/dictionary.accel
 [dictionary]: https://github.com/accel-ppp/accel-ppp/blob/master/accel-pppd/radius/dict/dictionary.rfc6911
+% start_vyoslinter

--- a/docs/configuration/vpn/l2tp.md
+++ b/docs/configuration/vpn/l2tp.md
@@ -361,19 +361,37 @@ Accept peer interface identifier. By default this is not defined.
 
 ```{cfgcmd} set vpn l2tp remote-access ppp-options ipv6-interface-id \<random | x:x:x:x\>
 
-Specifies if a fixed or random interface identifier is used for IPv6. The
-default is fixed.
+Specifies if a Fixed or Random interface identifier is used for IPv6. The
+default is a Fixed (deterministic) interface identifier.
 * **random** - Random interface identifier for IPv6
 * **x:x:x:x** - Specify interface identifier for IPv6
 ```
 
-```{cfgcmd} set vpn l2tp remote-access ppp-options ipv6-interface-id \<random | x:x:x:x\>
+```{cfgcmd} set vpn l2tp remote-access ppp-options ipv6-peer-interface-id \<random | x:x:x:x | ipv4-addr | calling-sid\>
 
-Specifies the peer interface identifier for IPv6. The default is fixed.
-* **random** - Random interface identifier for IPv6
-* **x:x:x:x** - Specify interface identifier for IPv6
+Specifies the peer interface identifier for IPv6. The default is a Fixed
+(deterministic) peer interface identifier.
+* **random** - Random interface identifier for IPv6.
+* **x:x:x:x** - Specify a Fixed peer interface identifier for IPv6.
 * **ipv4-addr** - Calculate interface identifier from IPv4 address.
 * **calling-sid** - Calculate interface identifier from calling-station-id.
+```
+
+```{cfgcmd} set vpn l2tp remote-access ppp-options ipv6-peer-interface-id-secret \<secret-key\>
+
+Secret key used to generate the IPv6 peer interface identifier (IID) when
+``ipv6-peer-interface-id`` is set to ``calling-sid``. This key is combined
+with the calling-station-id to derive a stable, non-predictable IID.
+
+* Required when ``ipv6-peer-interface-id`` is set to ``calling-sid``.
+* Must be 16 to 128 printable non-whitespace ASCII characters.
+
+For example:
+
+~~~none
+set vpn l2tp remote-access ppp-options ipv6-peer-interface-id calling-sid
+set vpn l2tp remote-access ppp-options ipv6-peer-interface-id-secret 'exampleSecret123!'
+~~~
 ```
 
 

--- a/docs/configuration/vpn/l2tp.md
+++ b/docs/configuration/vpn/l2tp.md
@@ -631,9 +631,11 @@ l2tp:
 ```
 
 [accel-ppp]: https://accel-ppp.org/
+% stop_vyoslinter
 [accel-ppp attribute]: https://github.com/accel-ppp/accel-ppp/blob/master/accel-pppd/radius/dict/dictionary.accel
 [cloudflare]: https://blog.cloudflare.com/announcing-1111
 [dictionary]: https://github.com/accel-ppp/accel-ppp/blob/master/accel-pppd/radius/dict/dictionary.rfc6911
+% start_vyoslinter
 [freeradius]: https://freeradius.org
 [google public dns]: https://developers.google.com/speed/public-dns
 [network policy server]: <https://en.wikipedia.org/wiki/Network_Policy_Server>

--- a/docs/configuration/vpn/pptp.md
+++ b/docs/configuration/vpn/pptp.md
@@ -276,19 +276,37 @@ Accept peer interface identifier. By default is not defined.
 
 ```{cfgcmd} set vpn pptp remote-access ppp-options ipv6-interface-id \<random | x:x:x:x\>
 
-Specifies fixed or random interface identifier for IPv6.
-By default is fixed.
+Specifies Fixed or Random interface identifier for IPv6.
+By default, a Fixed (deterministic) interface identifier is used.
 * **random** - Random interface identifier for IPv6
 * **x:x:x:x** - Specify interface identifier for IPv6
 ```
 
-```{cfgcmd} set vpn pptp remote-access ppp-options ipv6-interface-id \<random | x:x:x:x\>
+```{cfgcmd} set vpn pptp remote-access ppp-options ipv6-peer-interface-id \<random | x:x:x:x | ipv4-addr | calling-sid\>
 
-Specifies peer interface identifier for IPv6. By default is fixed.
-* **random** - Random interface identifier for IPv6
-* **x:x:x:x** - Specify interface identifier for IPv6
+Specifies peer interface identifier for IPv6. By default, a Fixed
+(deterministic) peer interface identifier is used.
+* **random** - Random interface identifier for IPv6.
+* **x:x:x:x** - Specify a Fixed peer interface identifier for IPv6.
 * **ipv4-addr** - Calculate interface identifier from IPv4 address.
 * **calling-sid** - Calculate interface identifier from calling-station-id.
+```
+
+```{cfgcmd} set vpn pptp remote-access ppp-options ipv6-peer-interface-id-secret \<secret-key\>
+
+Secret key used to generate the IPv6 peer interface identifier (IID) when
+``ipv6-peer-interface-id`` is set to ``calling-sid``. This key is combined
+with the calling-station-id to derive a stable, non-predictable IID.
+
+* Required when ``ipv6-peer-interface-id`` is set to ``calling-sid``.
+* Must be 16 to 128 printable non-whitespace ASCII characters.
+
+For example:
+
+~~~none
+set vpn pptp remote-access ppp-options ipv6-peer-interface-id calling-sid
+set vpn pptp remote-access ppp-options ipv6-peer-interface-id-secret 'exampleSecret123!'
+~~~
 ```
 
 

--- a/docs/configuration/vpn/pptp.md
+++ b/docs/configuration/vpn/pptp.md
@@ -194,14 +194,15 @@ the CLI configuration, refer to the explanation below.
 ### Allocation clients ip addresses by RADIUS
 
 If the RADIUS server sends the attribute `Framed-IP-Address` then this IP
-address will be allocated to the client and the option `default-pool` within the CLI
-config is being ignored.
+address will be allocated to the client and the option `default-pool`
+within the CLI config is being ignored.
 
-If the RADIUS server sends the attribute `Framed-Pool`, IP address will be allocated
-from a predefined IP pool whose name equals the attribute value.
+If the RADIUS server sends the attribute `Framed-Pool`, IP address will be
+allocated from a predefined IP pool whose name equals the attribute value.
 
-If the RADIUS server sends the attribute `Stateful-IPv6-Address-Pool`, IPv6 address
-will be allocated from a predefined IPv6 pool `prefix` whose name equals the attribute value.
+If the RADIUS server sends the attribute `Stateful-IPv6-Address-Pool`,
+IPv6 address will be allocated from a predefined IPv6 pool `prefix`
+whose name equals the attribute value.
 
 If the RADIUS server sends the attribute `Delegated-IPv6-Prefix-Pool`, IPv6
 delegation prefix will be allocated from a predefined IPv6 pool `delegate`
@@ -212,9 +213,10 @@ whose name equals the attribute value.
 RFC6911. If they are not defined in your RADIUS server, add new [dictionary].
 :::
 
-User interface can be put to VRF context via RADIUS Access-Accept packet, or change
-it via RADIUS CoA. `Accel-VRF-Name` is used from these purposes. It is custom [ACCEL-PPP attribute].
-Define it in your RADIUS server.
+User interface can be put to VRF context via RADIUS Access-Accept packet,
+or change it via RADIUS CoA. `Accel-VRF-Name` is used from these
+purposes. It is custom [ACCEL-PPP attribute]. Define it in your RADIUS
+server.
 
 ### Renaming clients interfaces by RADIUS
 
@@ -608,5 +610,7 @@ Feb 29 14:59:00 vyos accel-pptp[4629]: pptp0:test: pptp: ppp started
 ```
 
 [accel-ppp]: https://accel-ppp.org/
+% stop_vyoslinter
 [accel-ppp attribute]: https://github.com/accel-ppp/accel-ppp/blob/master/accel-pppd/radius/dict/dictionary.accel
 [dictionary]: https://github.com/accel-ppp/accel-ppp/blob/master/accel-pppd/radius/dict/dictionary.rfc6911
+% start_vyoslinter

--- a/docs/configuration/vpn/sstp.md
+++ b/docs/configuration/vpn/sstp.md
@@ -315,19 +315,37 @@ Accept peer interface identifier. By default this is not defined.
 
 ```{cfgcmd} set vpn sstp ppp-options ipv6-interface-id \<random | x:x:x:x\>
 
-Specifies if a fixed or random interface identifier is used for IPv6. The
-default is fixed.
+Specifies if a Fixed or Random interface identifier is used for IPv6. The
+default is a Fixed (deterministic) interface identifier.
 * **random** - Random interface identifier for IPv6
 * **x:x:x:x** - Specify interface identifier for IPv6
 ```
 
-```{cfgcmd} set vpn sstp ppp-options ipv6-interface-id \<random | x:x:x:x\>
+```{cfgcmd} set vpn sstp ppp-options ipv6-peer-interface-id \<random | x:x:x:x | ipv4-addr | calling-sid\>
 
-Specifies the peer interface identifier for IPv6. The default is fixed.
-* **random** - Random interface identifier for IPv6
-* **x:x:x:x** - Specify interface identifier for IPv6
+Specifies the peer interface identifier for IPv6. The default is a Fixed
+(deterministic) peer interface identifier.
+* **random** - Random interface identifier for IPv6.
+* **x:x:x:x** - Specify a Fixed peer interface identifier for IPv6.
 * **ipv4-addr** - Calculate interface identifier from IPv4 address.
 * **calling-sid** - Calculate interface identifier from calling-station-id.
+```
+
+```{cfgcmd} set vpn sstp ppp-options ipv6-peer-interface-id-secret \<secret-key\>
+
+Secret key used to generate the IPv6 peer interface identifier (IID) when
+``ipv6-peer-interface-id`` is set to ``calling-sid``. This key is combined
+with the calling-station-id to derive a stable, non-predictable IID.
+
+* Required when ``ipv6-peer-interface-id`` is set to ``calling-sid``.
+* Must be 16 to 128 printable non-whitespace ASCII characters.
+
+For example:
+
+~~~none
+set vpn sstp ppp-options ipv6-peer-interface-id calling-sid
+set vpn sstp ppp-options ipv6-peer-interface-id-secret 'exampleSecret123!'
+~~~
 ```
 
 

--- a/docs/configuration/vpn/sstp.md
+++ b/docs/configuration/vpn/sstp.md
@@ -11,8 +11,8 @@ and proxy servers except for authenticated web proxies.
 
 SSTP is available for Linux, BSD, and Windows.
 
-VyOS utilizes [accel-ppp](https://accel-ppp.org/) to provide SSTP server functionality. We support both
-local and RADIUS authentication.
+VyOS utilizes [accel-ppp](https://accel-ppp.org/) to provide SSTP server
+functionality. We support both local and RADIUS authentication.
 
 As SSTP provides PPP via a SSL/TLS channel the use of either publicly signed
 certificates or private PKI is required.
@@ -21,7 +21,8 @@ certificates or private PKI is required.
 
 ### Certificates
 
-Using our documentation chapter - {ref}`pki` generate and install CA and Server certificate
+Using our documentation chapter - {ref}`pki` generate and install CA and
+Server certificate
 
 ```none
 vyos@vyos:~$ generate pki ca install CA
@@ -551,7 +552,8 @@ Once you have setup your SSTP server there comes the time to do some basic
 testing. The Linux client used for testing is called [sstpc]. [sstpc] requires a
 PPP configuration/peer file.
 
-If you use a self-signed certificate, do not forget to install CA on the client side.
+If you use a self-signed certificate, do not forget to install CA on the
+client side.
 
 The following PPP configuration tests MSCHAP-v2:
 
@@ -711,6 +713,8 @@ Feb 28 17:03:07 vyos accel-sstp[2492]: ppp0:test: rename interface to 'sstp0'
 Feb 28 17:03:07 vyos accel-sstp[2492]: sstp0:test: sstp: ppp: started
 ```
 
+% stop_vyoslinter
 [accel-ppp attribute]: https://github.com/accel-ppp/accel-ppp/blob/master/accel-pppd/radius/dict/dictionary.accel
 [dictionary]: https://github.com/accel-ppp/accel-ppp/blob/master/accel-pppd/radius/dict/dictionary.rfc6911
+% start_vyoslinter
 [sstpc]: https://github.com/reliablehosting/sstp-client

--- a/docs/configuration/vpn/sstp.md
+++ b/docs/configuration/vpn/sstp.md
@@ -11,7 +11,7 @@ and proxy servers except for authenticated web proxies.
 
 SSTP is available for Linux, BSD, and Windows.
 
-VyOS utilizes [accel-ppp](https://accel-ppp.org/) to provide SSTP server
+VyOS utilizes [accel-ppp-ng](https://accel-ppp.org/) to provide SSTP server
 functionality. We support both local and RADIUS authentication.
 
 As SSTP provides PPP via a SSL/TLS channel the use of either publicly signed


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Updated the IPv6 Peer-IID section in the PPoE, L2TP, PPTP and SSTP documentation to include the details about secret-key which is to be configured when calling-sid mode is chosen for `ipv-peer-interface-id`

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
https://vyos.dev/T8598

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->
https://github.com/VyOS-Networks/vyos-1x/pull/2188

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document