### PR TITLE
docs: render diagrams in PDF builds (imgconverter + ImageMagick/librsvg)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,9 @@ RUN apt-get update && apt-get install -y \
     gosu \
     graphviz \
     curl \
-    dos2unix
+    dos2unix \
+    imagemagick \
+    librsvg2-bin
 
 RUN pip3 install --break-system-packages \
     Sphinx \
@@ -53,5 +55,13 @@ COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 #     standard_init_linux.go:175: exec user process caused
 #     "no such file or directory"
 RUN dos2unix /usr/local/bin/entrypoint.sh
+
+# sphinx.ext.imgconverter's `image_converter` command (docs/conf.py sets
+# image_converter = 'im-convert'). Routes .svg sources to rsvg-convert
+# directly, since Debian's imagemagick package is built --without-rsvg and
+# its built-in SVG coder can't handle embedded base64 raster <image>
+# elements. See docker/im-convert.sh for the full rationale.
+COPY im-convert.sh /usr/local/bin/im-convert
+RUN dos2unix /usr/local/bin/im-convert && chmod +x /usr/local/bin/im-convert
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,13 @@ RUN apt-get update && apt-get install -y \
     gosu \
     graphviz \
     curl \
-    dos2unix \
+    dos2unix
+
+# Image-conversion toolchain for the PDF build (sphinx.ext.imgconverter via
+# docker/im-convert.sh). Installed with --no-install-recommends (Trivy
+# DS-0029) on a separate line: the texlive line above deliberately keeps
+# recommends, which carry font packages LaTeX needs.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     imagemagick \
     librsvg2-bin
 

--- a/docker/im-convert.sh
+++ b/docker/im-convert.sh
@@ -18,6 +18,21 @@
 # Route .svg sources through rsvg-convert directly; everything else (webp,
 # gif, pdf, ...) goes through ImageMagick's `convert` as before — webp support
 # is compiled into this ImageMagick build, so that path needs no delegate.
+#
+# Output size is constrained: the docs pipeline's per-file size gate
+# (scripts/docs_gates/gates.py) enforces the Cloudflare Workers 25 MiB
+# asset cap on the built PDF, and naive full-resolution truecolor PNG
+# conversion inflates it to ~183 MiB (the ~170 source .webp files are
+# lossy-compressed; decoded to truecolor PNG they explode ~6x). The raster
+# policy below (cap at 1000px on the long edge — only shrinking, never
+# enlarging — plus non-dithered 128-color palette quantization and max PNG
+# compression) brings the summed image payload to ~10 MiB (~15 MiB final
+# PDF). Sphinx's imgconverter fixes the destination extension to .png (from
+# the conversion rule's target mimetype) and pdflatex picks its decoder by
+# extension, so switching photographic sources to JPEG is not available
+# here — resolution + palette are the levers. 1000px at the PDF's ~6.3in
+# text width is ~158 dpi; spot-checked legible on screenshots, diagrams,
+# and photos alike.
 set -euo pipefail
 
 # sphinx.ext.imgconverter's is_available() probes the converter with a
@@ -42,6 +57,12 @@ case "$plain_src" in
         exec rsvg-convert -o "$dst" "$plain_src"
         ;;
     *)
-        exec convert "$src" "$dst"
+        # See the size-cap rationale in the header comment. `1000x1000>`
+        # only shrinks images larger than 1000px on either edge; `+dither`
+        # disables dithering (IM6 semantics: -dither enables, +dither
+        # disables), which quantizes flat UI colors cleanly AND compresses
+        # far better than dithered output; `-quality 95` for PNG means
+        # zlib level 9 + adaptive row filtering.
+        exec convert "$src" -resize '1000x1000>' -strip +dither -colors 128 -quality 95 "$dst"
         ;;
 esac

--- a/docker/im-convert.sh
+++ b/docker/im-convert.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Wrapper invoked by sphinx.ext.imgconverter as the `image_converter` command
+# (docs/conf.py sets image_converter = 'im-convert').
+#
+# Sphinx calls it as: im-convert "<src>[0]" "<dst>" (the "[0]" frame-index
+# suffix is ImageMagick syntax for "first frame/page", appended unconditionally
+# by sphinx/ext/imgconverter.py).
+#
+# Debian's `imagemagick` package is built --without-rsvg (LGPL licensing), so
+# its own SVG coder is a minimal libxml2-based renderer rather than a wrapper
+# around librsvg. That built-in coder cannot handle SVGs with an embedded
+# base64-encoded raster <image> element (common in diagrams exported from
+# draw.io/diagrams.net): it fails with
+#   "convert-im6.q16: unable to open image `image/png;base64,...'"
+# because it tries to open the data-URI payload as if it were a file path.
+# `rsvg-convert` (from librsvg2-bin) handles the same file correctly.
+#
+# Route .svg sources through rsvg-convert directly; everything else (webp,
+# gif, pdf, ...) goes through ImageMagick's `convert` as before — webp support
+# is compiled into this ImageMagick build, so that path needs no delegate.
+set -euo pipefail
+
+# sphinx.ext.imgconverter's is_available() probes the converter with a
+# single-arg call (`im-convert -version`) before ever doing a real
+# conversion. Delegate straight to ImageMagick's own -version so the probe
+# succeeds — is_available()'s result is cached at the class level for the
+# whole build, so a failed probe here silently disables ALL conversion
+# (webp included), not just SVG.
+if [ "$#" -lt 2 ]; then
+    exec convert "$@"
+fi
+
+src=$1
+dst=$2
+
+# Strip ImageMagick's trailing frame-index suffix, e.g.
+# "/path/to/file.svg[0]" -> "/path/to/file.svg".
+plain_src=${src%\[*\]}
+
+case "$plain_src" in
+    *.svg|*.SVG)
+        exec rsvg-convert -o "$dst" "$plain_src"
+        ;;
+    *)
+        exec convert "$src" "$dst"
+        ;;
+esac

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,18 @@ extensions = ['sphinx.ext.intersphinx',
               'sphinx.ext.todo',
               'sphinx.ext.ifconfig',
               'sphinx.ext.graphviz',
+              # LaTeX-only: converts image formats the LaTeX/PDF builder can't
+              # embed natively (webp, svg, ...) to PNG at build time. The
+              # LaTeX builder's supported_image_types is ['application/pdf',
+              # 'image/png', 'image/jpeg'] — without this, unsupported
+              # images (nearly all of ours are .webp) are silently dropped
+              # from the PDF output. No effect on the HTML builder, which
+              # supports webp/svg natively in the browser; imgconverter
+              # only fires post-transforms when the active builder's
+              # supported_image_types doesn't already cover the source
+              # format. See `image_converter` below + docker/im-convert.sh
+              # for the conversion command this depends on.
+              'sphinx.ext.imgconverter',
               'notfound.extension',
               'autosectionlabel',
               'myst_parser',
@@ -61,6 +73,20 @@ extensions = ['sphinx.ext.intersphinx',
               'sphinx_llms_txt',
               'sphinx_sitemap',
 ]
+
+# sphinx.ext.imgconverter: use a thin wrapper (docker/im-convert.sh, installed
+# on PATH as `im-convert`) instead of ImageMagick's `convert` directly.
+# Debian's `imagemagick` package is built --without-rsvg, so its built-in SVG
+# coder (a minimal libxml2-based renderer, not a librsvg wrapper) can't
+# rasterize SVGs that embed a base64 raster <image> element — common in
+# diagrams exported from draw.io/diagrams.net — and fails with "unable to
+# open image `image/png;base64,...'". The wrapper routes .svg sources to
+# `rsvg-convert` (from librsvg2-bin) directly and everything else (webp,
+# gif, pdf, ...) through ImageMagick's `convert` as usual. If `im-convert`
+# isn't on PATH (e.g. a build environment other than docker/Dockerfile),
+# imgconverter's own `is_available()` check logs a warning and skips
+# conversion rather than failing the build.
+image_converter = 'im-convert'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
## Gap

The LaTeX/PDF build silently drops nearly all diagrams. The live RTD `rolling` PDF has only **2 image objects** across **2056 pages** (out of 167 in-scope `.webp` + 1 `.svg` references under `docs/`). The LaTeX builder's `supported_image_types` is `['application/pdf', 'image/png', 'image/jpeg']` — `.webp`/`.svg` aren't in that list, so Sphinx silently drops them from PDF output while HTML renders them fine (browsers support both natively).

## Fix

- `docs/conf.py`: enable `sphinx.ext.imgconverter` (LaTeX-builder-only post-transform; converts unsupported source formats to PNG before the LaTeX writer runs — no effect on the HTML builder, confirmed below). Point `image_converter` at a wrapper (`im-convert`, see below) instead of `convert` directly.
- `docker/Dockerfile`: add `imagemagick` + `librsvg2-bin`.
- `docker/im-convert.sh`: thin wrapper around ImageMagick's `convert`, needed for three reasons found during local verification:
  1. Debian's `imagemagick` package is built `--without-rsvg`, so its built-in SVG coder is a minimal libxml2-based renderer rather than a librsvg wrapper — it can't handle the one in-scope SVG (`vyos_vpp_integration.svg`), which embeds a base64 raster `<image>` element (common in diagrams exported from draw.io/diagrams.net). It fails with `unable to open image 'image/png;base64,...'`, treating the data-URI payload as a filename. Direct `rsvg-convert` (from `librsvg2-bin`) handles the same file correctly, so the wrapper routes `.svg` sources to `rsvg-convert` and everything else (webp, gif, pdf, ...) to `convert` as before.
  2. `sphinx.ext.imgconverter`'s availability probe calls the converter with a single arg (`im-convert -version`) before any real conversion. The probe's result is cached at the class level for the whole build — a failed probe silently disables *all* conversion, not just SVG. The wrapper delegates straight to `convert -version` for single-arg invocations so the probe succeeds.
  3. **Size-gate constraint:** the docs pipeline's per-file size gate (`scripts/docs_gates/gates.py`) enforces the Cloudflare Workers **25 MiB asset cap** on the built PDF. Naive full-resolution truecolor PNG conversion inflates the PDF to ~183 MiB (the ~170 source `.webp` files are lossy-compressed; decoded to truecolor PNG they explode ~6x). The wrapper therefore caps rasters at **1000px on the long edge** (shrink-only, never enlarge) with **non-dithered 128-color palette quantization** + max PNG compression, bringing the final PDF to **14.2 MiB** — under the gate with headroom. JPEG output isn't available as a lever: imgconverter fixes the destination extension to `.png` (from the conversion rule's target mimetype) and pdflatex picks its decoder by extension. Quality was spot-checked on a screenshot, a diagram, and a hardware photo at this policy — all legible (1000px at the PDF's ~6.3in text width ≈ 158 dpi).

This composes independently with #2143 (PDF-step tolerance / artifact-check) — no workflow files touched here.

## Local verification (docker build, mirroring `docs-build.yml`'s tolerant flags)

`docker build -t docs-build:imgtest docker/` then `make html && make latexpdf LATEXMKOPTS=-f LATEXOPTS=-interaction=nonstopmode`.

| | Before (baseline, this branch's changes reverted) | After (this PR) |
|---|---|---|
| Image objects in PDF (`pdfimages -list`) | 2 | 183 |
| PDF size | 5.4 MB | **14.2 MiB** (14,908,435 bytes — under the 25 MiB Workers asset cap, and under the 15 MiB internal target) |
| Pages | 2056 | 2136 |
| `make html` | clean (101 pre-existing warnings, unrelated) | clean, identical warning count — confirms no HTML-builder side effect |

Also verified rendering: extracted page 10 of the built PDF (Downloads-screenshot page) via `pdftoppm` — image embedded and legible.

`pdflatex` still exits nonzero on a pre-existing, unrelated issue ("missing or unavailable character(s)" + 31 multiply-defined refs) present identically in the baseline — the PDF is still produced under `-f` force mode either way, and is out of scope here (covered by #2143's tolerance).

Advances: IS-572