### PR TITLE
docs: Update Conntrack sync page to VyOS 1.5 standards

### DIFF
--- a/docs/configuration/service/conntrack-sync.md
+++ b/docs/configuration/service/conntrack-sync.md
@@ -2,8 +2,8 @@
 myst:
   html_meta:
     description: |
-      Conntrack Sync preserves active sessions during failover between
-      Master and Backup routers in a VyOS high-availability pair by
+      Conntrack sync preserves active sessions during failover between
+      active and backup routers in a VyOS high-availability pair by
       continuously syncing conntrack entries between them.
     keywords: conntrack-sync, connection-tracking, ha, high-availability, vrrp
 ---
@@ -13,24 +13,24 @@ myst:
 # Conntrack sync
 
 Conntrack Sync (Connection Tracking Synchronization) is used to
-preserve active sessions during a failover between the Master and
-Backup routers in a high-availability
+preserve active sessions during a failover between the active and
+backup routers in a high-availability
 ({abbr}`HA (High Availability)`) pair.
 
-Each active session on the Master is tracked as a local conntrack
+Each active session on the active router is tracked as a local conntrack
 entry, and for some protocols, expect entries are also created for
 anticipated follow-up connections (for example, the FTP data channel
-or SIP media streams). Conntrack Sync continuously copies these
-entries to the Backup over one or more dedicated interfaces, so it
+or SIP media streams). Conntrack sync continuously copies these
+entries to backup routers over one or more dedicated interfaces, so it
 holds a current picture of every active session in near real time.
 This traffic is carried over IPv4, either as multicast (the default)
 or unicast to a configured peer address.
 
-When a failover occurs, the Backup router takes over all active
+When a failover occurs, a backup router takes over all active
 sessions and maintains them in their current state, without dropping
 or resetting them. A takeover is triggered by VRRP (Virtual Router
-Redundancy Protocol), which detects when the Master becomes
-unavailable and transitions the Backup to Master.
+Redundancy Protocol), which detects when the current active becomes
+unavailable and transitions one of the backup routers to active.
 
 ## Configuration
 
@@ -131,7 +131,7 @@ set service conntrack-sync listen-address 192.0.2.1
 to exchange sync traffic.**
 
 The command applies only when conntrack sync operates in multicast
-mode. Both routers must be configured with the same group.
+mode. All routers must be configured with the same group.
 
 The default is 225.0.0.50.
 ```
@@ -201,8 +201,7 @@ set service conntrack-sync expect-sync sip
 
 ```{cfgcmd} set service conntrack-sync event-listen-queue-size \<0-4294967295\>
 
-**Configure the maximum size, in MB, to which the receive buffer for
-conntrack events may grow.**
+**Configure the maximum size of the conntrack event buffer (in megabytes).**
 
 The buffer starts at 2 MB and grows up to the specified value if
 events arrive faster than they can be processed.
@@ -218,8 +217,7 @@ set service conntrack-sync event-listen-queue-size 16
 
 ```{cfgcmd} set service conntrack-sync sync-queue-size \<0-4294967295\>
 
-**Configure the size, in MB, of the send and receive buffers that
-queue sync messages to and from the HA peer.**
+**Configure the size of the queue that holds sync messages sent between peers (in megabytes)**
 
 The same value is applied to both directions, in either multicast or
 unicast mode.
@@ -242,9 +240,9 @@ The default is 60.
 ```
 
 ```{note}
-If your setup allows a recovered router to reclaim the Master role,
+If your setup allows a recovered router to reclaim the active role,
 set the VRRP `preempt-delay` to at least this value on the VRRP
-sync-group bound to the conntrack-sync service. This gives the
+`sync-group` bound to the conntrack sync service. This gives the
 recovered router time to receive the current conntrack entries before
 taking over.
 ```
@@ -259,7 +257,7 @@ set service conntrack-sync purge-timeout 60
 
 ```{cfgcmd} set service conntrack-sync disable-external-cache
 
-**Inject conntrack entries directly to the Backup's kernel connection
+**Inject conntrack entries directly to backup routers' kernel connection
 tracking table as they arrive, rather than holding them in the
 external cache used by default.**
 ```
@@ -284,7 +282,7 @@ set service conntrack-sync disable-syslog
 ```{cfgcmd} set service conntrack-sync startup-resync
 
 **Request a full copy of conntrack entries from the HA peer when the
-conntrack-sync service starts.**
+conntrack sync service starts.**
 ```
 
 Example:
@@ -348,7 +346,7 @@ The `main` keyword is optional and produces the same output.
 
 ```{opcmd} show conntrack-sync statistics
 
-**Show operational statistics for the conntrack-sync service.**
+**Show operational statistics for the conntrack sync service.**
 ```
 
 Example output:
@@ -389,7 +387,7 @@ subsystem.**
 
 ```{opcmd} show conntrack-sync status
 
-**Show the current operational status of the conntrack-sync
+**Show the current operational status of the conntrack sync
 service.**
 ```
 
@@ -407,7 +405,7 @@ ExpectationSync       : disabled
 
 ```{opcmd} restart conntrack-sync
 
-**Restart the conntrack-sync service. On restart, the local cache is
+**Restart the conntrack sync service. On restart, the local cache is
 cleared.**
 ```
 
@@ -426,7 +424,7 @@ entries from the HA peer.**
 ## Example
 
 The following shows how to configure a two-node HA pair with
-conntrack-sync.
+conntrack sync.
 
 :::{figure} /_static/images/service_conntrack_sync-schema.webp
 :alt: Conntrack sync example
@@ -436,8 +434,8 @@ Conntrack sync example
 
 Apply the following configuration on both `router1` and `router2`. The
 only difference between the two nodes is the VRRP priority: use `200`
-on `router1` (which becomes Master) and `100` on `router2` (which
-becomes Backup).
+on `router1` (which becomes VRRP master, i.e., active) and `100` on `router2` (which
+becomes backup).
 
 ```none
 set high-availability vrrp group internal interface 'eth1'
@@ -453,12 +451,12 @@ set service conntrack-sync interface 'eth0'
 set service conntrack-sync mcast-group '225.0.0.50'
 ```
 
-After commit, the Master router populates its internal cache with
-local conntrack entries and sends them to the Backup, which stores
+After commit, the active router populates its internal cache with
+local conntrack entries and sends them to the backup, which stores
 them in its external cache. Running `show conntrack-sync statistics`
 on each peer reflects this asymmetry.
 
-On the Master router:
+On the active router:
 
 ```none
 $ show conntrack-sync statistics
@@ -489,7 +487,7 @@ message tracking:
                    0 Malformed msgs                    0 Lost msgs
 ```
 
-On the Backup router:
+On the backup router:
 
 ```none
 $ show conntrack-sync statistics

--- a/docs/configuration/service/conntrack-sync.md
+++ b/docs/configuration/service/conntrack-sync.md
@@ -476,6 +476,17 @@ current active connections:                0
 connections created:                       0    failed:            0
 connections updated:                       0    failed:            0
 connections destroyed:                     0    failed:            0
+
+traffic processed:
+                   0 Bytes                         0 Pckts
+
+multicast traffic (active device=eth0):
+              868780 Bytes sent               224136 Bytes recv
+               20595 Pckts sent                14034 Pckts recv
+                   0 Error send                    0 Error recv
+
+message tracking:
+                   0 Malformed msgs                    0 Lost msgs
 ```
 
 On the Backup router:
@@ -496,4 +507,15 @@ current active connections:               10
 connections created:                     888    failed:            0
 connections updated:                     134    failed:            0
 connections destroyed:                   878    failed:            0
+
+traffic processed:
+                   0 Bytes                         0 Pckts
+
+multicast traffic (active device=eth0):
+              234184 Bytes sent               907504 Bytes recv
+               14663 Pckts sent                21495 Pckts recv
+                   0 Error send                    0 Error recv
+
+message tracking:
+                   0 Malformed msgs                    0 Lost msgs
 ```

--- a/docs/configuration/service/conntrack-sync.md
+++ b/docs/configuration/service/conntrack-sync.md
@@ -235,8 +235,8 @@ set service conntrack-sync sync-queue-size 4
 
 ```{cfgcmd} set service conntrack-sync purge-timeout \<1-2147483647\>
 
-**Configure the time, in seconds, that a synchronized entry may
-remain unrefreshed before it is removed.**
+**Configure the delay, in seconds, before synchronized entries are
+purged after a handover.**
 
 The default is 60.
 ```

--- a/docs/configuration/service/conntrack-sync.md
+++ b/docs/configuration/service/conntrack-sync.md
@@ -1,200 +1,359 @@
+---
+myst:
+  html_meta:
+    description: |
+      Conntrack Sync preserves active sessions during failover between
+      Master and Backup routers in a VyOS high-availability pair by
+      continuously syncing conntrack entries between them.
+    keywords: conntrack-sync, connection-tracking, ha, high-availability, vrrp
+---
+
 (conntrack-sync)=
 
-# Conntrack Sync
+# Conntrack sync
 
-One of the important features built on top of the Netfilter framework is
-connection tracking. Connection tracking allows the kernel to keep track of all
-logical network connections or sessions, and thereby relate all of the packets
-which may make up that connection. NAT relies on this information to translate
-all related packets in the same way, and iptables can use this information to
-act as a stateful firewall.
+Conntrack Sync (Connection Tracking Synchronization) is used to
+preserve active sessions during a failover between the Master and
+Backup routers in a high-availability
+({abbr}`HA (High Availability)`) pair.
 
-The connection state however is completely independent of any upper-level
-state, such as TCP's or SCTP's state. Part of the reason for this is that when
-merely forwarding packets, i.e. no local delivery, the TCP engine may not
-necessarily be invoked at all. Even connectionless-mode transmissions such as
-UDP, IPsec (AH/ESP), GRE and other tunneling protocols have, at least, a pseudo
-connection state. The heuristic for such protocols is often based upon a preset
-timeout value for inactivity, after whose expiration a Netfilter connection is
-dropped.
+Each active session on the Master is tracked as a local conntrack
+entry, and for some protocols, expect entries are also created for
+anticipated follow-up connections (for example, the FTP data channel
+or SIP media streams). Conntrack Sync continuously copies these
+entries to the Backup over one or more dedicated interfaces, so it
+holds a current picture of every active session in near real time.
+This traffic is carried over IPv4, either as multicast (the default)
+or unicast to a configured peer address.
 
-Each Netfilter connection is uniquely identified by a (layer-3 protocol, source
-address, destination address, layer-4 protocol, layer-4 key) tuple. The layer-4
-key depends on the transport protocol; for TCP/UDP it is the port numbers, for
-tunnels it can be their tunnel ID, but otherwise is just zero, as if it were
-not part of the tuple. To be able to inspect the TCP port in all cases, packets
-will be mandatorily defragmented.
-
-It is possible to use either Multicast or Unicast to sync conntrack traffic.
-Most examples below show Multicast, but unicast can be specified by using the
-"peer" keyword after the specified interface, as in the following example:
-
-{cfgcmd}`set service conntrack-sync interface eth0 peer 192.168.0.250`
+When a failover occurs, the Backup router takes over all active
+sessions and maintains them in their current state, without dropping
+or resetting them. A takeover is triggered by VRRP (Virtual Router
+Redundancy Protocol), which detects when the Master becomes
+unavailable and transitions the Backup to Master.
 
 ## Configuration
 
-```{cfgcmd} set service conntrack-sync accept-protocol
+### Failover integration
 
-Accept only certain protocols: You may want to replicate the state of flows
-depending on their layer 4 protocol.
+```{cfgcmd} set service conntrack-sync failover-mechanism vrrp sync-group \<name\>
 
-Protocols are: tcp, sctp, dccp, udp, icmp and ipv6-icmp.
+**Bind the conntrack-sync service to the specified VRRP sync-group.**
+
+This setting is mandatory. The referenced group must already be
+configured under `high-availability vrrp sync-group`.
 ```
 
+Example:
 
-```{cfgcmd} set service conntrack-sync event-listen-queue-size \<size\>
-
-The daemon doubles the size of the netlink event socket buffer size if it
-detects netlink event message dropping. This clause sets the maximum buffer
-size growth that can be reached.
-
-Queue size for listening to local conntrack events in MB.
+```none
+set service conntrack-sync failover-mechanism vrrp sync-group syncgrp
 ```
 
-
-```{cfgcmd} set service conntrack-sync expect-sync \<all|ftp|h323|nfs|sip|sqlnet\>
-
-Protocol for which expect entries need to be synchronized.
-```
-
-
-```{cfgcmd} set service conntrack-sync failover-mechanism vrrp sync-group \<group\>
-
-Failover mechanism to use for conntrack-sync.
-
-Only VRRP is supported. Required option.
-```
-
-
-```{cfgcmd} set service conntrack-sync ignore-address \<x.x.x.x\>
-
-IP addresses or networks for which local conntrack entries will not be synced
-```
-
+### Sync transport
 
 ```{cfgcmd} set service conntrack-sync interface \<name\>
 
-Interface to use for syncing conntrack entries.
+**Configure the interface used to exchange conntrack state with the
+peer.**
+
+The interface must have an IPv4 address assigned.
+
+Repeat the command to configure multiple interfaces. In this case,
+interfaces must use the same transport mode (either all multicast or
+all unicast).
 ```
 
+Example:
 
-```{cfgcmd} set service conntrack-sync interface \<name\> port \<port\>
-
-Port number used by connection.
+```none
+set service conntrack-sync interface eth1
 ```
-
-
-```{cfgcmd} set service conntrack-sync listen-address \<ipv4address\>
-
-Local IPv4 addresses for service to listen on.
-```
-
-
-```{cfgcmd} set service conntrack-sync mcast-group \<x.x.x.x\>
-
-Multicast group to use for syncing conntrack entries.
-
-Defaults to 225.0.0.50.
-```
-
 
 ```{cfgcmd} set service conntrack-sync interface \<name\> peer \<address\>
 
-Peer to send unicast UDP conntrack sync entries to, if not using Multicast
-configuration from above.
+**Configure the peer's IPv4 address for unicast sync on the specified
+interface.**
+
+Setting `peer` switches this interface from multicast (the default) to
+unicast mode.
+
+Repeat the command for all interfaces configured for conntrack state
+exchange, since mixing unicast and multicast interfaces causes commit
+to fail.
 ```
 
+Example:
 
-```{cfgcmd} set service conntrack-sync sync-queue-size \<size\>
-
-Queue size for syncing conntrack entries in MB.
+```none
+set service conntrack-sync interface eth1 peer 192.0.2.2
 ```
 
+```{cfgcmd} set service conntrack-sync interface \<name\> port \<1-65535\>
+
+**Configure the UDP port used on the specified sync interface.**
+
+In multicast mode, it is the UDP port used by the multicast group. In
+unicast mode, it is the UDP destination port on the peer.
+
+The default port is 3780.
+```
+
+Example:
+
+```none
+set service conntrack-sync interface eth1 port 3781
+```
+
+```{cfgcmd} set service conntrack-sync listen-address \<address\>
+
+**Configure the local IPv4 address the router listens on for unicast
+sync traffic.**
+
+The command applies only when conntrack sync operates in unicast mode.
+
+The listen address must be assigned to the sync interface. Using an
+address from another interface may cause conntrack sync to fail
+silently.
+
+Repeat the command to configure multiple listen addresses.
+```
+
+Example:
+
+```none
+set service conntrack-sync listen-address 192.0.2.1
+```
+
+```{cfgcmd} set service conntrack-sync mcast-group \<ipv4-multicast-address\>
+
+**Configure the IPv4 multicast group both routers in the HA pair join
+to exchange sync traffic.**
+
+The command applies only when conntrack sync operates in multicast
+mode. Both routers must be configured with the same group.
+
+The default is 225.0.0.50.
+```
+
+Example:
+
+```none
+set service conntrack-sync mcast-group 225.0.0.60
+```
+
+### Sync scope
+
+```{cfgcmd} set service conntrack-sync accept-protocol \<tcp | udp | icmp | icmp6 | sctp | dccp\>
+
+**Configure the protocol whose local conntrack entries are
+synchronized with the HA peer.**
+
+Repeat the command to configure multiple protocols. When omitted,
+conntrack entries for all tracked protocols are synchronized.
+```
+
+Example:
+
+```none
+set service conntrack-sync accept-protocol tcp
+set service conntrack-sync accept-protocol udp
+set service conntrack-sync accept-protocol icmp
+```
+
+```{cfgcmd} set service conntrack-sync ignore-address \<address | prefix\>
+
+**Exclude local conntrack entries involving the specified IP address
+or prefix from being synchronized with the HA peer.**
+
+Accepts IPv4 and IPv6 addresses or prefixes.
+
+Repeat the command to configure multiple values.
+```
+
+Example:
+
+```none
+set service conntrack-sync ignore-address 192.0.2.0/24
+set service conntrack-sync ignore-address 2001:db8::/32
+```
+
+```{cfgcmd} set service conntrack-sync expect-sync \<all | ftp | h323 | nfs | sip | sqlnet\>
+
+**Configure the protocol whose expect entries are synchronized with
+the HA peer.**
+
+Repeat the command to configure multiple protocols. Use `all` to
+synchronize expect entries for all supported protocols. `all` cannot
+be combined with any other value.
+
+When omitted, no expect entries are synchronized.
+```
+
+Example:
+
+```none
+set service conntrack-sync expect-sync ftp
+set service conntrack-sync expect-sync sip
+```
+
+### Buffers and timers
+
+```{cfgcmd} set service conntrack-sync event-listen-queue-size \<0-4294967295\>
+
+**Configure the maximum size, in MB, to which the receive buffer for
+conntrack events may grow.**
+
+The buffer starts at 2 MB and grows up to the specified value if
+events arrive faster than they can be processed.
+
+The default is 8.
+```
+
+Example:
+
+```none
+set service conntrack-sync event-listen-queue-size 16
+```
+
+```{cfgcmd} set service conntrack-sync sync-queue-size \<0-4294967295\>
+
+**Configure the size, in MB, of the send and receive buffers that
+queue sync messages to and from the HA peer.**
+
+The same value is applied to both directions, in either multicast or
+unicast mode.
+
+The default is 1.
+```
+
+Example:
+
+```none
+set service conntrack-sync sync-queue-size 4
+```
+
+```{cfgcmd} set service conntrack-sync purge-timeout \<1-2147483647\>
+
+**Configure the time, in seconds, that a synchronized entry may
+remain unrefreshed before it is removed.**
+
+The default is 60.
+```
+
+```{note}
+If your setup allows a recovered router to reclaim the Master role,
+set the VRRP `preempt-delay` to at least this value on the VRRP
+sync-group bound to the conntrack-sync service. This gives the
+recovered router time to receive the current conntrack entries before
+taking over.
+```
+
+Example:
+
+```none
+set service conntrack-sync purge-timeout 60
+```
+
+### Behavior
 
 ```{cfgcmd} set service conntrack-sync disable-external-cache
 
-This disables the external cache and directly injects the flow-states into the
-in-kernel Connection Tracking System of the backup firewall.
+**Inject conntrack entries directly to the Backup's kernel connection
+tracking table as they arrive, rather than holding them in the
+external cache used by default.**
 ```
 
+Example:
 
-```{cfgcmd} set service conntrack-sync purge-timeout \<timeout\>
-
-Timeout (in seconds) for purging synchronized entries on handover events.
-
-On handover, ``conntrackd -t`` is invoked, which schedules a conntrack table
-flush after ``<timeout>`` seconds to purge stale (“zombie”) entries and
-reduce clashes when multiple handovers occur in a short period.
-The default is 60 seconds.
+```none
+set service conntrack-sync disable-external-cache
 ```
-
-:::{note}
-In VRRP stateful firewall deployments, align VRRP timing with this
-behavior: because synchronized conntrack state is purged after the purge
-timeout, set **VRRP preempt-delay** to ≥ **purge-timeout** so mastership
-can be restored before conntrack state is purged.
-:::
 
 ```{cfgcmd} set service conntrack-sync disable-syslog
 
-Disable connection logging via Syslog.
+**Disable syslog logging of conntrack-sync operational events.**
 ```
 
+Example:
+
+```none
+set service conntrack-sync disable-syslog
+```
 
 ```{cfgcmd} set service conntrack-sync startup-resync
 
-Order conntrackd to request a complete conntrack table resync against
-the other node at startup.
+**Request a full copy of conntrack entries from the HA peer when the
+conntrack-sync service starts.**
+```
+
+Example:
+
+```none
+set service conntrack-sync startup-resync
 ```
 
 ## Operation
 
-```{opcmd} show conntrack table \<ipv4|ipv6\>
+### Show
 
-Make sure conntrack is enabled by running and show connection tracking table.
+```{opcmd} show conntrack table \<ipv4 | ipv6\>
 
-:::{code-block} none
+**Show conntrack entries for the specified address family (IPv4 or
+IPv6).**
+```
+
+Example output:
+
+```none
 vyos@vyos:~$ show conntrack table ipv4
-Id          Original src    Original dst    Original packets    Original bytes    Reply src     Reply dst       Reply packets    Reply bytes    Protocol    State        Timeout    Mark    Zone
-----------  --------------  --------------  ------------------  ----------------  ------------  --------------  ---------------  -------------  ----------  -----------  ---------  ------  ------
-282920088   10.0.2.2:41724  10.0.2.15:22    79                  8741              10.0.2.15:22  10.0.2.2:41724  52               8495           tcp         TIME_WAIT    3          0
-102466872   192.168.50.1    192.168.50.4    31953               2684052           192.168.50.4  192.168.50.1    31953            2684052        icmp                     29         0       110
-1445684978  10.0.2.2:37762  10.0.2.15:22    111                 9969              10.0.2.15:22  10.0.2.2:37762  86               13323          tcp         ESTABLISHED  431999     0
-3302843234  10.0.2.2:37758  10.0.2.15:22    2612                3845685           10.0.2.15:22  10.0.2.2:37758  254              17447          tcp         TIME_WAIT    11         0
-:::
-:::{note}
-If the table is empty and you have a warning message, it means
-conntrack is not enabled. To enable conntrack, just create a NAT or a firewall
-rule.
-{cfgcmd}`set firewall global-options state-policy established action accept`
-:::
+Id          Original src      Original dst      Original packets    Original bytes    Reply src         Reply dst         Reply packets    Reply bytes    Protocol    State        Timeout    Mark    Zone
+----------  ----------------  ----------------  ------------------  ----------------  ----------------  ----------------  ---------------  -------------  ----------  -----------  ---------  ------  ------
+282920088   192.0.2.2:41724   192.0.2.15:22     79                  8741              192.0.2.15:22     192.0.2.2:41724   52               8495           tcp         TIME_WAIT    3          0
+102466872   198.51.100.1      198.51.100.4      31953               2684052           198.51.100.4      198.51.100.1      31953            2684052        icmp                     29         0       110
+1445684978  192.0.2.2:37762   192.0.2.15:22     111                 9969              192.0.2.15:22     192.0.2.2:37762   86               13323          tcp         ESTABLISHED  431999     0
+3302843234  192.0.2.2:37758   192.0.2.15:22     2612                3845685           192.0.2.15:22     192.0.2.2:37758   254              17447          tcp         TIME_WAIT    11         0
 ```
 
-
-```{opcmd} show conntrack table \<ipv4|ipv6\> vrf \<vrf-name\>
-
-Show connection tracking table filtered by VRF name. Only entries originating
-from the specified VRF are displayed.
+```{note}
+If the table is empty and you see a warning message, conntrack is
+not enabled. To enable it, create a NAT or a firewall rule, for
+example: `set firewall global-options state-policy established
+action accept`.
 ```
 
+```{opcmd} show conntrack-sync cache external [main]
 
-```{opcmd} show conntrack-sync cache external
+**Show the regular conntrack entries in the external cache.**
 
-Show connection syncing external cache entries
+The `main` keyword is optional and produces the same output.
 ```
 
+```{opcmd} show conntrack-sync cache external expect
 
-```{opcmd} show conntrack-sync cache internal
-
-Show connection syncing internal cache entries
+**Show the expect entries in the external cache.**
 ```
 
+```{opcmd} show conntrack-sync cache internal [main]
+
+**Show the regular conntrack entries in the internal cache.**
+
+The `main` keyword is optional and produces the same output.
+```
+
+```{opcmd} show conntrack-sync cache internal expect
+
+**Show the expect entries in the internal cache.**
+```
 
 ```{opcmd} show conntrack-sync statistics
 
-Retrieve current statistics of connection tracking subsystem.
+**Show operational statistics for the conntrack-sync service.**
+```
 
-:::{code-block} none
+Example output:
+
+```none
 vyos@vyos:~$ show conntrack-sync statistics
 Main Table Statistics:
 
@@ -220,34 +379,71 @@ multicast traffic (active device=eth0.5):
 
 message tracking:
 0 Malformed msgs                  263 Lost msgs
-:::
 ```
+
+```{opcmd} show conntrack statistics
+
+**Show operational statistics for the kernel connection tracking
+subsystem.**
+```
+
 ```{opcmd} show conntrack-sync status
 
-Retrieve current status of connection tracking subsystem.
+**Show the current operational status of the conntrack-sync
+service.**
+```
 
-:::{code-block} none
+Example output:
+
+```none
 vyos@vyos:~$ show conntrack-sync status
 sync-interface        : eth0.5
 failover-mechanism    : vrrp [sync-group GEFOEKOM]
 last state transition : no transition yet!
 ExpectationSync       : disabled
-:::
+```
+
+### Restart/reset
+
+```{opcmd} restart conntrack-sync
+
+**Restart the conntrack-sync service. On restart, the local cache is
+cleared.**
+```
+
+```{opcmd} reset conntrack-sync external-cache
+
+**Clear the external cache and request a fresh copy of conntrack
+entries from the HA peer.**
+```
+
+```{opcmd} reset conntrack-sync internal-cache
+
+**Clear the internal cache and request a fresh copy of conntrack
+entries from the HA peer.**
 ```
 
 ## Example
 
-The next example is a simple configuration of conntrack-sync.
+The following shows how to configure a two-node HA pair with
+conntrack-sync.
 
 :::{figure} /_static/images/service_conntrack_sync-schema.webp
-:alt: Conntrack Sync Example
-:scale: 60 %
+:alt: Conntrack sync example
+:scale: 80 %
+Conntrack sync example
 :::
 
-Now configure conntrack-sync service on `router1` **and** `router2`
+Apply the following configuration on both `router1` and `router2`. The
+only difference between the two nodes is the VRRP priority: use `200`
+on `router1` (which becomes Master) and `100` on `router2` (which
+becomes Backup).
 
 ```none
-set high-availability vrrp group internal virtual-address ... etc ...
+set high-availability vrrp group internal interface 'eth1'
+set high-availability vrrp group internal vrid '10'
+set high-availability vrrp group internal priority '200'
+set high-availability vrrp group internal virtual-address '192.0.2.254/24'
 set high-availability vrrp sync-group syncgrp member 'internal'
 set service conntrack-sync accept-protocol 'tcp'
 set service conntrack-sync accept-protocol 'udp'
@@ -257,11 +453,12 @@ set service conntrack-sync interface 'eth0'
 set service conntrack-sync mcast-group '225.0.0.50'
 ```
 
-On the active router, you should have information in the internal-cache of
-conntrack-sync. The same current active connections number should be shown in
-the external-cache of the standby router
+After commit, the Master router populates its internal cache with
+local conntrack entries and sends them to the Backup, which stores
+them in its external cache. Running `show conntrack-sync statistics`
+on each peer reflects this asymmetry.
 
-On active router run:
+On the Master router:
 
 ```none
 $ show conntrack-sync statistics
@@ -279,20 +476,9 @@ current active connections:                0
 connections created:                       0    failed:            0
 connections updated:                       0    failed:            0
 connections destroyed:                     0    failed:            0
-
-traffic processed:
-                   0 Bytes                         0 Pckts
-
-multicast traffic (active device=eth0):
-              868780 Bytes sent               224136 Bytes recv
-               20595 Pckts sent                14034 Pckts recv
-                   0 Error send                    0 Error recv
-
-message tracking:
-                   0 Malformed msgs                    0 Lost msgs
 ```
 
-On standby router run:
+On the Backup router:
 
 ```none
 $ show conntrack-sync statistics
@@ -310,15 +496,4 @@ current active connections:               10
 connections created:                     888    failed:            0
 connections updated:                     134    failed:            0
 connections destroyed:                   878    failed:            0
-
-traffic processed:
-                   0 Bytes                         0 Pckts
-
-multicast traffic (active device=eth0):
-              234184 Bytes sent               907504 Bytes recv
-               14663 Pckts sent                21495 Pckts recv
-                   0 Error send                    0 Error recv
-
-message tracking:
-                   0 Malformed msgs                    0 Lost msgs
 ```


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR refactors the Conntrack sync page to comply with the current VyOS documentation style guide.
Changes:

* AI & SEO Context: Added :description: and :keywords: metadata tags.
* Content: Proofread and improved. The Configuration and Operation sections were restructured into logical subgroups.
* Technical accuracy: Verified commands against VyOS 1.5.
* Added examples for all commands.
* The style guide checklist was applied.

Added new op-mode commands:
show conntrack-sync cache external expect
show conntrack-sync cache internal expect
show conntrack statistics
restart conntrack-sync
reset conntrack-sync external-cache
reset conntrack-sync internal-cache

Added value range for:
set service conntrack-sync event-listen-queue-size <0-4294967295>
set service conntrack-sync interface  port <1-65535>
set service conntrack-sync mcast-group 
set service conntrack-sync purge-timeout <1-2147483647>
set service conntrack-sync sync-queue-size <0-4294967295>

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
VD-3775

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document