### PR TITLE
docs: exclude superpowers/ from the Sphinx build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,6 +123,7 @@ gettext_uuid = False
 exclude_patterns = [
     u'_build', 'Thumbs.db', '.DS_Store', '_include/vyos-1x',
     '_rst_legacy',
+    'superpowers',
 ]
 
 # The name of the Pygments (syntax highlighting) style to use.


### PR DESCRIPTION
## What / why

`docs/superpowers/` is a Claude Code plugin-generated directory holding internal design specs and implementation plans. It is not user documentation and must never be published to docs.vyos.io.

The content itself was already removed from every build branch by commits `3ab97e71` and `abb8be5b`. This PR adds a defence-in-depth guard so that, if the directory is ever recreated in a working tree, Sphinx will not pick it up and build it into the site.

## What changed

One line in `docs/conf.py` — `'superpowers'` added to `exclude_patterns`:

```python
exclude_patterns = [
    u'_build', 'Thumbs.db', '.DS_Store', '_include/vyos-1x',
    '_rst_legacy',
    'superpowers',
]
```

Nothing else in the file is touched. No content is deleted by this PR.

## Companion guard

`.gitignore` already carries the `docs/superpowers/` entry on `rolling` and `circinus`, which stops the directory being committed in the first place. This change closes the remaining gap on the build side.

🤖 Generated by [robots](https://vyos.io)