### PR TITLE
chore: ignore superpowers generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,9 @@ __pycache__
 .env
 .envrc
 
+# superpowers generated files
+.superpowers/
+docs/superpowers/
+
 # os specific
 .DS_Store


### PR DESCRIPTION
## What / why

`docs/superpowers/` is a Claude Code plugin-generated directory holding internal design specs and implementation plans. It is not user documentation and must never be committed or published to docs.vyos.io.

The content itself was already removed from every build branch by commits `3ab97e71` and `abb8be5b`. This PR adds the defence-in-depth guard that stops the directory being committed again in the first place.

## What changed

Four lines added to `.gitignore`, placed after the `# dotenv` block and before `# os specific`:

```gitignore
# superpowers generated files
.superpowers/
docs/superpowers/
```

Nothing else in the file is touched. No content is deleted by this PR.

## Why sagitta-only — not backportable

`rolling` and `circinus` already carry this exact block, so there is nothing to port to them. `sagitta` was the only build branch still missing it. The block added here is byte-identical to the one on `rolling`, bringing all three branches into agreement.

## Companion guard

A separate PR against `rolling` adds `superpowers` to `exclude_patterns` in `docs/conf.py`, closing the build-side gap so Sphinx cannot publish the directory even if it reappears in a working tree.

🤖 Generated by [robots](https://vyos.io)