### PR TITLE
chore: ignore Claude Code local settings and git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ docs/superpowers/
 
 # os specific
 .DS_Store
+
+# claude code local settings (may contain secrets)
+.claude/settings.local.json
+
+# git worktrees
+.worktrees/


### PR DESCRIPTION
Brings `circinus`'s `.gitignore` to parity with `rolling` by adding the two ignore blocks that only `rolling` carried.

## What changed

Two blocks appended after the existing `# os specific` block:

- **`.claude/settings.local.json`** — the security-relevant entry. That file is Claude Code's per-machine local settings and can hold secrets (API keys, tokens, local credentials). It must never be committable on an LTS branch.
- **`.worktrees/`** — hygiene only. Local git-worktree scratch space that has no business in the tree.

## Scope

Additive only. No existing line is removed, reordered, or edited, and no other file is touched — the diff is six added lines and zero deletions.

After this change the file is **byte-identical** to `rolling`'s `.gitignore`:

```
$ git show origin/rolling:.gitignore | diff - .gitignore
$ echo $?
0
```

Both files hash to `a268c54d86141702e4aa72f073089ba982dfc3f4d83dd5d74d4891f6142c04ce`.

Companion PR for the other LTS branch: [vyos-documentation#2170](https://github.com/vyos/vyos-documentation/pull/2170) (`sagitta`).

🤖 Generated by [robots](https://vyos.io)