### PR TITLE
docs(Installation): Remove outdated portal link and Proxmox/KVM cloud…

### DIFF
--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -449,7 +449,6 @@ option, and type CTRL-X to boot.
 
 Installation can then continue as outlined above.
 
-[article]: https://customers.support.vyos.com/servicedesk/customer/portal/1/article/159055913
 [balenaetcher]: https://www.balena.io/etcher/
 [configuration]: https://wiki.syslinux.org/wiki/index.php?title=Config
 [default]: https://wiki.syslinux.org/wiki/index.php?title=PXELINUX#Configuration

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -84,14 +84,7 @@ Registered subscribers can log into <https://support.vyos.io/> to access
 a variety of different downloads via the "Downloads" link. These
 downloads include LTS (Long-Term Support), the associated hot-fix releases,
 early public access releases, pre-built VM images, as well as device
-specific installation ISOs. See this [article] for more information on
-downloads.
-
-:::{note}
-The `.qcow2` image provided for Proxmox deployment can also be
-used to deploy VyOS on KVM environments. This image includes cloud-init
-support.
-:::
+specific installation ISOs. 
 
 :::{figure} /_static/images/vyosnew-downloads.webp
 :::


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR makes two removals from the Download section of the Installation page:

1. Dropped "See this article for more information on downloads." It linked to a now-archived internal portal article. Its content is already covered by this Installation page.
2. Removed the Note about reusing the Proxmox .qcow2 image for KVM. VyOS now publishes a dedicated KVM image with cloud-init support, so the workaround is no longer needed.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->


## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document