### PR TITLE
vyos-api: clarify comment regarding commit failure and partial commits

### DIFF
--- a/docs/automation/vyos-api.md
+++ b/docs/automation/vyos-api.md
@@ -517,10 +517,10 @@ response:
 ```
 
 A list of operations is applied and committed as a single transaction: if
-any operation fails, nothing is committed. The error message may not
-identify which operation in the list failed, so if a large list fails
-validation, retry the operations in smaller lists (or one per request) to
-locate the offending one.
+any operation fails, nothing is committed *for that component*; partial
+commits are possible for a list of operations comprising more than one
+component. The error message will indicate the component and the missing
+information or conflict.
 
 :::{note}
 The `/configure` endpoint commits changes to the running configuration but


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Clarify comment included in
https://github.com/vyos/vyos-documentation/pull/2152
before proceeding with backport
https://github.com/vyos/vyos-documentation/pull/2157

I had missed this originally in the review for rolling; correct now, and add to backport.

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document