### PR TITLE
ci: bump REVIEWER_REF to reviewer-v1.0.3 (fix AI Validation on rolling)

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REVIEWER_REF: reviewer-v1.0.2
+  REVIEWER_REF: reviewer-v1.0.3
   # Force JavaScript actions to run on Node 24. Some pinned action SHAs
   # we rely on still ship with Node 20 ABI; this env var opts the whole
   # workflow into Node 24 without per-action version churn.


### PR DESCRIPTION
## What

Bump `REVIEWER_REF` in the AI Validation workflow from `reviewer-v1.0.2` to `reviewer-v1.0.3`.

## Why

AI Validation fails on every rolling-based PR at the "Checkout vyos-1x at mapped branch" step (first observed: [run 30565684480](https://github.com/vyos/vyos-documentation/actions/runs/30565684480) on [#2177](https://github.com/vyos/vyos-documentation/pull/2177)).

Root cause chain:

1. The workflow sparse-checks-out `branches.json` from `VyOS-Networks/vyos-docs-opus-reviewer` at the pinned `REVIEWER_REF` tag.
2. At `reviewer-v1.0.2` that file maps docs branch `rolling` → vyos-1x branch `current`.
3. `vyos-networks/vyos-1x` renamed `current` → `rolling` (between 2026-07-12 and 2026-07-19, per the reviewer repo's `rebuild-reference` run history: last green 07-12, failing weekly since 07-19 on the same fetch).
4. Checkout of the nonexistent `current` ref exits 1 → job fails before any validation runs.

`reviewer-v1.0.3` (tagged 2026-08-03) carries the corrected mapping `rolling` → `rolling`. The v1.0.2→v1.0.3 diff contains only `branches.json` + CI/docs/config changes — no reviewer Python source changes, so Pass 1 / Pass 2 behavior is unchanged.

## Reference DB (companion fix, already done)

The fail-closed gate also needs a `reference-db-rolling.tar.gz` asset in the latest `ref-db-*` release; the weekly `rebuild-reference` cron had been failing since 07-19 for the same stale-mapping reason, so none existed. A full rebuild was dispatched after the reviewer-side fix landed: [run 30832960046](https://github.com/VyOS-Networks/vyos-docs-opus-reviewer/actions/runs/30832960046) → release `ref-db-20260803-093807` now carries `reference-db-rolling.tar.gz` + `circinus` + `sagitta`. No further action needed there; the weekly cron is unblocked going forward.

## Phase 0 (local CodeRabbit) disposition

One finding: pin `REVIEWER_REF` to a 40-char commit SHA instead of the mutable tag. **Not applied** — tag-based `REVIEWER_REF` is the deliberate existing design (v1.0.0→v1.0.2 history, the workflow's own comment about `reviewer-v1.x.x` release pinning, and the reviewer repo's deployment guide all assume tag semantics). Switching the pinning convention is out of scope for this one-line outage fix; if wanted, it should be a deliberate follow-up across workflow + deployment docs.

## Backport

After merge, backport to `circinus` and `sagitta`: their mappings are unaffected today (`circinus→circinus`, `sagitta→sagitta` are identical in both tags), but keeping all three branches on the same reviewer tag avoids divergence at the next bump.

🤖 Generated by [robots](https://vyos.io)
