### PR TITLE
docs: T9159: document service ntp source-address option

### DIFF
--- a/docs/configuration/service/ntp.md
+++ b/docs/configuration/service/ntp.md
@@ -108,11 +108,12 @@ commands for each.
 
 Network device used for outgoing NTP client requests, binding the socket to
 this interface (Linux `SO_BINDTODEVICE`) rather than to a source address.
-This is useful in multi-VRF setups or when address ranges overlap between
-routing instances, where a source address alone cannot unambiguously select
-the egress path. Can be combined with `source-address`; only one interface
-can be configured. If `vrf` is also set, the interface must belong to that
-VRF.
+Useful when a source address alone cannot unambiguously select the egress
+path, for example when address ranges overlap between routing instances.
+Since `vrf` binds the NTP client to a single VRF, `source-interface` only
+selects the egress device within that VRF, not across multiple VRFs at
+once. Can be combined with `source-address`; only one interface can be
+configured. If `vrf` is also set, the interface must belong to that VRF.
 ```
 
 

--- a/docs/configuration/service/ntp.md
+++ b/docs/configuration/service/ntp.md
@@ -104,6 +104,18 @@ commands for each.
 ```
 
 
+```{cfgcmd} set service ntp source-interface \<interface\>
+
+Network device used for outgoing NTP client requests, binding the socket to
+this interface (Linux `SO_BINDTODEVICE`) rather than to a source address.
+This is useful in multi-VRF setups or when address ranges overlap between
+routing instances, where a source address alone cannot unambiguously select
+the egress path. Can be combined with `source-address`; only one interface
+can be configured. If `vrf` is also set, the interface must belong to that
+VRF.
+```
+
+
 ```{cfgcmd} set service ntp vrf \<name\>
 
 Specify name of the {abbr}`VRF (Virtual Routing and Forwarding)` instance.

--- a/docs/configuration/service/ntp.md
+++ b/docs/configuration/service/ntp.md
@@ -92,6 +92,18 @@ Multiple networks/client IP addresses can be configured.
 ```
 
 
+```{cfgcmd} set service ntp source-address \<address\>
+
+Source IP address used for outgoing NTP client requests to the configured
+servers, instead of relying on the kernel's default source-address selection
+for whichever route is chosen at query time. Useful on routers with more
+than one usable egress path to a given server, where the interface that
+ends up being selected may not always carry a globally reachable address.
+Only one IPv4 and one IPv6 address can be configured, using separate
+commands for each.
+```
+
+
 ```{cfgcmd} set service ntp vrf \<name\>
 
 Specify name of the {abbr}`VRF (Virtual Routing and Forwarding)` instance.


### PR DESCRIPTION
  ## Change Summary
  
  Companion documentation for vyos/vyos-1x#5371, which adds
  `set service ntp source-address <address>` (rendered as chrony's
  `bindacqaddress` directive — the client-side counterpart to the
  existing `listen-address`/`bindaddress`). Adds a `{cfgcmd}` block
  right after `allow-client`, matching the existing style for this page.
  
  ## Related Task(s)
  * https://vyos.dev/T9159
  
  ## Related PR(s)
  * https://github.com/vyos/vyos-1x/pull/5371
  
  ## Backport
  
  
  ## Checklist:
  - [x] I have read the CONTRIBUTING document