### PR TITLE
docs: T9157: document firewall fib-type match

### DIFF
--- a/docs/configuration/firewall/ipv4.md
+++ b/docs/configuration/firewall/ipv4.md
@@ -491,33 +491,33 @@ set firewall ipv4 name FOO rule 100 destination address-mask 0.255.0.255
 :::
 ```
 
-```{cfgcmd} set firewall ipv4 forward filter rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 forward filter rule \<1-999999\> source fib type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv4 input filter rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 input filter rule \<1-999999\> source fib type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv4 output filter rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 output filter rule \<1-999999\> source fib type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv4 name \<name\> rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 name \<name\> rule \<1-999999\> source fib type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv4 forward filter rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 forward filter rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv4 input filter rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 input filter rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv4 output filter rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 output filter rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv4 name \<name\> rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 name \<name\> rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
 
 Match based on the result of a Forwarding Information Base (FIB) lookup for
 the source/destination address instead of its literal value. ``type`` is one
 of ``local``, ``unicast``, ``broadcast``, ``multicast``, ``anycast``,
-``blackhole``, ``unreachable`` or ``prohibited``. The ``!`` character
+``blackhole``, ``unreachable`` or ``prohibit``. The ``!`` character
 negates the match.
 
 This is particularly useful in ``prerouting raw`` to distinguish traffic
@@ -526,7 +526,7 @@ without needing to enumerate every locally configured address in a
 network-group by hand:
 
 :::{code-block} none
-set firewall ipv4 prerouting raw rule 1 destination fib-type local
+set firewall ipv4 prerouting raw rule 1 destination fib type local
 set firewall ipv4 prerouting raw rule 1 action accept
 set firewall ipv4 prerouting raw rule 2 action notrack
 :::

--- a/docs/configuration/firewall/ipv4.md
+++ b/docs/configuration/firewall/ipv4.md
@@ -513,14 +513,20 @@ set firewall ipv4 name FOO rule 100 destination address-mask 0.255.0.255
 ```
 
 ```{cfgcmd} set firewall ipv4 name \<name\> rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv4 prerouting raw rule \<1-999999\> source fib type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv4 prerouting raw rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
 
 Match based on the result of a Forwarding Information Base (FIB) lookup for
-the source/destination address instead of its literal value. ``type`` is one
-of ``local``, ``unicast``, ``broadcast``, ``multicast``, ``anycast``,
-``blackhole``, ``unreachable`` or ``prohibit``. The ``!`` character
+the source/destination address instead of its literal value. `type` is one
+of `local`, `unicast`, `broadcast`, `multicast`, `anycast`,
+`blackhole`, `unreachable` or `prohibit`. The `!` character
 negates the match.
 
-This is particularly useful in ``prerouting raw`` to distinguish traffic
+This is particularly useful in `prerouting raw` to distinguish traffic
 destined to the router itself from traffic being forwarded through it,
 without needing to enumerate every locally configured address in a
 network-group by hand:

--- a/docs/configuration/firewall/ipv4.md
+++ b/docs/configuration/firewall/ipv4.md
@@ -491,40 +491,43 @@ set firewall ipv4 name FOO rule 100 destination address-mask 0.255.0.255
 :::
 ```
 
-```{cfgcmd} set firewall ipv4 forward filter rule \<1-999999\> source fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 forward filter rule \<1-999999\> fib lookup [source-address | destination-address]
 ```
 
-```{cfgcmd} set firewall ipv4 input filter rule \<1-999999\> source fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 input filter rule \<1-999999\> fib lookup [source-address | destination-address]
 ```
 
-```{cfgcmd} set firewall ipv4 output filter rule \<1-999999\> source fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 output filter rule \<1-999999\> fib lookup [source-address | destination-address]
 ```
 
-```{cfgcmd} set firewall ipv4 name \<name\> rule \<1-999999\> source fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 name \<name\> rule \<1-999999\> fib lookup [source-address | destination-address]
 ```
 
-```{cfgcmd} set firewall ipv4 forward filter rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 prerouting raw rule \<1-999999\> fib lookup [source-address | destination-address]
 ```
 
-```{cfgcmd} set firewall ipv4 input filter rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 forward filter rule \<1-999999\> fib match route-type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv4 output filter rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 input filter rule \<1-999999\> fib match route-type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv4 name \<name\> rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 output filter rule \<1-999999\> fib match route-type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv4 prerouting raw rule \<1-999999\> source fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 name \<name\> rule \<1-999999\> fib match route-type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv4 prerouting raw rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv4 prerouting raw rule \<1-999999\> fib match route-type [\<type\> | !\<type\>]
 
-Match based on the result of a Forwarding Information Base (FIB) lookup for
-the source/destination address instead of its literal value. `type` is one
-of `local`, `unicast`, `broadcast`, `multicast`, `anycast`,
-`blackhole`, `unreachable` or `prohibit`. The `!` character
-negates the match.
+Match based on the result of a Forwarding Information Base (FIB) lookup
+instead of the packet's literal address. `lookup` selects which address to
+look up: `source-address` performs a reverse-path lookup, `destination-address`
+a normal route lookup. `match route-type` compares the resulting address
+type; both `lookup` and `match route-type` must be configured together.
+`type` is one of `local`, `unicast`, `broadcast`, `multicast`, `anycast`,
+`blackhole`, `unreachable` or `prohibit`. The `!` character negates the
+match.
 
 This is particularly useful in `prerouting raw` to distinguish traffic
 destined to the router itself from traffic being forwarded through it,
@@ -532,7 +535,8 @@ without needing to enumerate every locally configured address in a
 network-group by hand:
 
 :::{code-block} none
-set firewall ipv4 prerouting raw rule 1 destination fib type local
+set firewall ipv4 prerouting raw rule 1 fib lookup destination-address
+set firewall ipv4 prerouting raw rule 1 fib match route-type local
 set firewall ipv4 prerouting raw rule 1 action accept
 set firewall ipv4 prerouting raw rule 2 action notrack
 :::

--- a/docs/configuration/firewall/ipv4.md
+++ b/docs/configuration/firewall/ipv4.md
@@ -491,6 +491,47 @@ set firewall ipv4 name FOO rule 100 destination address-mask 0.255.0.255
 :::
 ```
 
+```{cfgcmd} set firewall ipv4 forward filter rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv4 input filter rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv4 output filter rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv4 name \<name\> rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv4 forward filter rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv4 input filter rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv4 output filter rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv4 name \<name\> rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+
+Match based on the result of a Forwarding Information Base (FIB) lookup for
+the source/destination address instead of its literal value. ``type`` is one
+of ``local``, ``unicast``, ``broadcast``, ``multicast``, ``anycast``,
+``blackhole``, ``unreachable`` or ``prohibited``. The ``!`` character
+negates the match.
+
+This is particularly useful in ``prerouting raw`` to distinguish traffic
+destined to the router itself from traffic being forwarded through it,
+without needing to enumerate every locally configured address in a
+network-group by hand:
+
+:::{code-block} none
+set firewall ipv4 prerouting raw rule 1 destination fib-type local
+set firewall ipv4 prerouting raw rule 1 action accept
+set firewall ipv4 prerouting raw rule 2 action notrack
+:::
+```
+
 ```{cfgcmd} set firewall ipv4 forward filter rule \<1-999999\> source fqdn \<fqdn\>
 ```
 

--- a/docs/configuration/firewall/ipv6.md
+++ b/docs/configuration/firewall/ipv6.md
@@ -492,33 +492,33 @@ set firewall ipv6 forward filter rule 200 source address-mask ::ffff:ffff:ffff:f
 :::
 ```
 
-```{cfgcmd} set firewall ipv6 forward filter rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 forward filter rule \<1-999999\> source fib type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv6 input filter rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 input filter rule \<1-999999\> source fib type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv6 output filter rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 output filter rule \<1-999999\> source fib type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv6 name \<name\> rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 name \<name\> rule \<1-999999\> source fib type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv6 forward filter rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 forward filter rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv6 input filter rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 input filter rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv6 output filter rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 output filter rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv6 name \<name\> rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 name \<name\> rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
 
 Match based on the result of a Forwarding Information Base (FIB) lookup for
 the source/destination address instead of its literal value. ``type`` is one
 of ``local``, ``unicast``, ``broadcast``, ``multicast``, ``anycast``,
-``blackhole``, ``unreachable`` or ``prohibited``. The ``!`` character
+``blackhole``, ``unreachable`` or ``prohibit``. The ``!`` character
 negates the match.
 
 This is particularly useful in ``prerouting raw`` to distinguish traffic
@@ -527,7 +527,7 @@ without needing to enumerate every locally configured address in a
 network-group by hand:
 
 :::{code-block} none
-set firewall ipv6 prerouting raw rule 1 destination fib-type local
+set firewall ipv6 prerouting raw rule 1 destination fib type local
 set firewall ipv6 prerouting raw rule 1 action accept
 set firewall ipv6 prerouting raw rule 2 action notrack
 :::

--- a/docs/configuration/firewall/ipv6.md
+++ b/docs/configuration/firewall/ipv6.md
@@ -492,40 +492,43 @@ set firewall ipv6 forward filter rule 200 source address-mask ::ffff:ffff:ffff:f
 :::
 ```
 
-```{cfgcmd} set firewall ipv6 forward filter rule \<1-999999\> source fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 forward filter rule \<1-999999\> fib lookup [source-address | destination-address]
 ```
 
-```{cfgcmd} set firewall ipv6 input filter rule \<1-999999\> source fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 input filter rule \<1-999999\> fib lookup [source-address | destination-address]
 ```
 
-```{cfgcmd} set firewall ipv6 output filter rule \<1-999999\> source fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 output filter rule \<1-999999\> fib lookup [source-address | destination-address]
 ```
 
-```{cfgcmd} set firewall ipv6 name \<name\> rule \<1-999999\> source fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 name \<name\> rule \<1-999999\> fib lookup [source-address | destination-address]
 ```
 
-```{cfgcmd} set firewall ipv6 forward filter rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 prerouting raw rule \<1-999999\> fib lookup [source-address | destination-address]
 ```
 
-```{cfgcmd} set firewall ipv6 input filter rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 forward filter rule \<1-999999\> fib match route-type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv6 output filter rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 input filter rule \<1-999999\> fib match route-type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv6 name \<name\> rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 output filter rule \<1-999999\> fib match route-type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv6 prerouting raw rule \<1-999999\> source fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 name \<name\> rule \<1-999999\> fib match route-type [\<type\> | !\<type\>]
 ```
 
-```{cfgcmd} set firewall ipv6 prerouting raw rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
+```{cfgcmd} set firewall ipv6 prerouting raw rule \<1-999999\> fib match route-type [\<type\> | !\<type\>]
 
-Match based on the result of a Forwarding Information Base (FIB) lookup for
-the source/destination address instead of its literal value. `type` is one
-of `local`, `unicast`, `broadcast`, `multicast`, `anycast`,
-`blackhole`, `unreachable` or `prohibit`. The `!` character
-negates the match.
+Match based on the result of a Forwarding Information Base (FIB) lookup
+instead of the packet's literal address. `lookup` selects which address to
+look up: `source-address` performs a reverse-path lookup, `destination-address`
+a normal route lookup. `match route-type` compares the resulting address
+type; both `lookup` and `match route-type` must be configured together.
+`type` is one of `local`, `unicast`, `broadcast`, `multicast`, `anycast`,
+`blackhole`, `unreachable` or `prohibit`. The `!` character negates the
+match.
 
 This is particularly useful in `prerouting raw` to distinguish traffic
 destined to the router itself from traffic being forwarded through it,
@@ -533,7 +536,8 @@ without needing to enumerate every locally configured address in a
 network-group by hand:
 
 :::{code-block} none
-set firewall ipv6 prerouting raw rule 1 destination fib type local
+set firewall ipv6 prerouting raw rule 1 fib lookup destination-address
+set firewall ipv6 prerouting raw rule 1 fib match route-type local
 set firewall ipv6 prerouting raw rule 1 action accept
 set firewall ipv6 prerouting raw rule 2 action notrack
 :::

--- a/docs/configuration/firewall/ipv6.md
+++ b/docs/configuration/firewall/ipv6.md
@@ -492,6 +492,47 @@ set firewall ipv6 forward filter rule 200 source address-mask ::ffff:ffff:ffff:f
 :::
 ```
 
+```{cfgcmd} set firewall ipv6 forward filter rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv6 input filter rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv6 output filter rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv6 name \<name\> rule \<1-999999\> source fib-type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv6 forward filter rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv6 input filter rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv6 output filter rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv6 name \<name\> rule \<1-999999\> destination fib-type [\<type\> | !\<type\>]
+
+Match based on the result of a Forwarding Information Base (FIB) lookup for
+the source/destination address instead of its literal value. ``type`` is one
+of ``local``, ``unicast``, ``broadcast``, ``multicast``, ``anycast``,
+``blackhole``, ``unreachable`` or ``prohibited``. The ``!`` character
+negates the match.
+
+This is particularly useful in ``prerouting raw`` to distinguish traffic
+destined to the router itself from traffic being forwarded through it,
+without needing to enumerate every locally configured address in a
+network-group by hand:
+
+:::{code-block} none
+set firewall ipv6 prerouting raw rule 1 destination fib-type local
+set firewall ipv6 prerouting raw rule 1 action accept
+set firewall ipv6 prerouting raw rule 2 action notrack
+:::
+```
+
 ```{cfgcmd} set firewall ipv6 forward filter rule \<1-999999\> source fqdn \<fqdn\>
 ```
 

--- a/docs/configuration/firewall/ipv6.md
+++ b/docs/configuration/firewall/ipv6.md
@@ -514,14 +514,20 @@ set firewall ipv6 forward filter rule 200 source address-mask ::ffff:ffff:ffff:f
 ```
 
 ```{cfgcmd} set firewall ipv6 name \<name\> rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv6 prerouting raw rule \<1-999999\> source fib type [\<type\> | !\<type\>]
+```
+
+```{cfgcmd} set firewall ipv6 prerouting raw rule \<1-999999\> destination fib type [\<type\> | !\<type\>]
 
 Match based on the result of a Forwarding Information Base (FIB) lookup for
-the source/destination address instead of its literal value. ``type`` is one
-of ``local``, ``unicast``, ``broadcast``, ``multicast``, ``anycast``,
-``blackhole``, ``unreachable`` or ``prohibit``. The ``!`` character
+the source/destination address instead of its literal value. `type` is one
+of `local`, `unicast`, `broadcast`, `multicast`, `anycast`,
+`blackhole`, `unreachable` or `prohibit`. The `!` character
 negates the match.
 
-This is particularly useful in ``prerouting raw`` to distinguish traffic
+This is particularly useful in `prerouting raw` to distinguish traffic
 destined to the router itself from traffic being forwarded through it,
 without needing to enumerate every locally configured address in a
 network-group by hand:


### PR DESCRIPTION
 ## Change Summary
  
  Companion documentation for vyos/vyos-1x#5372, which adds `fib-type`
  as a source/destination match option (nftables' `fib daddr`/`saddr type`
  expression) for the forward/input/output/name rule sets, IPv4 and IPv6.
  Adds a `{cfgcmd}` block per rule-set/side right after `address-mask`,
  matching the existing style for these pages, plus a `prerouting raw`
  usage example in the prose.
  
  ## Related Task(s)
  * https://vyos.dev/T9157
  
  ## Related PR(s)
  * https://github.com/vyos/vyos-1x/pull/5372
  
  ## Backport
  
  
  ## Checklist:
  - [x] I have read the CONTRIBUTING document
