### PR TITLE
docs: update AGENTS.md bot-review section to current CodeRabbit reality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,6 +292,13 @@ serves and crawlers skip the redirect hop.
   changed files under `docs/` only. Repo-root meta files
   (README.md, AGENTS.md, `.github/copilot-instructions.md`) are out
   of scope.
+- **AI Validation** (`.github/workflows/ai-validation.yml`) —
+  cross-checks the changed `docs/**/*.md` against the VyOS CLI
+  definitions in the `vyos-1x` source tree for the corresponding
+  branch, and posts findings as inline review comments plus a summary
+  comment on the PR. Only runs when a PR touches Markdown under
+  `docs/`. Skips — with a notice — when the required repository
+  secrets aren't configured, and on Mergify-authored backport PRs.
 - **Sphinx build** — runs on Read the Docs for every PR; preview URL
   appears as a check.
 - **CLA check** — contributors must sign the VyOS CLA before merge.
@@ -299,22 +306,22 @@ serves and crawlers skip the redirect hop.
 
 ### Bot review workflow
 
-Two bots run at separate stages — do not mix them:
+CodeRabbit is the automated reviewer on this repo. It runs on its own —
+in the normal case there is nothing to invoke by hand. Iterate in draft
+while the work is in flux, then flip to ready when you want review.
 
-| Bot | When to trigger | How |
-|-----|-----------------|-----|
-| **Copilot** | Draft PRs only | Comment `@copilot review` |
-| **CodeRabbit** | Ready-for-review PRs only | Comment `@coderabbitai review` |
+- **Drafts are skipped.** CodeRabbit ignores draft PRs entirely.
+- **Review fires automatically** when a PR is flipped to ready
+  (`gh pr ready <num>`), and again on every subsequent push.
+- **The walkthrough comment is edited in place.** CodeRabbit usually
+  updates its existing comment rather than posting a new one — for
+  example to "no actionable comments". No new comment does not mean no
+  new review; re-read the existing one.
+- **Rate limits silently drop a review.** If CodeRabbit is rate-limited
+  when an event fires, that review is skipped with no error. Comment
+  `@coderabbitai review` once the limit window resets. This is the only
+  case where triggering it by hand is appropriate.
 
-Auto-reviews are disabled on this repo — both bots are triggered
-manually via the comments shown above.
-
-Workflow:
-1. Open PR as draft (`gh pr create --draft`).
-2. Iterate; when complete, comment `@copilot review`.
-3. Address Copilot threads, re-request after each fix round until
-   Copilot is silent.
-4. Flip to ready (`gh pr ready <num>`), then comment `@coderabbitai review`.
-5. Address CodeRabbit threads the same way.
-
-Never trigger `@copilot review` on a ready-for-review PR.
+Copilot is not part of this workflow — do not invoke `@copilot review`.
+If Copilot threads do appear because someone invoked it manually,
+address them like any other reviewer feedback.

--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ Output lands in `docs/_build/html/`.
 See [AGENTS.md](AGENTS.md) for the full contributor guide — MyST source
 conventions, the VyOS command directives (`cfgcmd` / `opcmd` /
 `cmdincludemd`), IP-address rules, the linter and its suppression markers,
-and the Copilot/CodeRabbit bot review workflow.
+and the CodeRabbit bot review workflow.


### PR DESCRIPTION
## What

The `### Bot review workflow` section of `AGENTS.md` documented a
manual-invocation flow that no longer matches how this repository
actually works, and the `## CI` list was missing the AI Validation
workflow. This PR corrects both.

`.github/copilot-instructions.md` is a symlink to `AGENTS.md`, so it
picks up the same correction automatically — no separate edit.

## Why

The section told contributors to comment `@copilot review` on a draft,
iterate until Copilot went silent, then flip to ready and comment
`@coderabbitai review`. It also asserted that "auto-reviews are disabled
on this repo". Following those instructions today produces the wrong
behavior: the manual CodeRabbit trigger is redundant with the automatic
review, and the Copilot invocation is not part of the review flow at
all. New contributors and coding agents read this file as authoritative.

## Before / after — bot review section

**Before:** a two-row table pairing Copilot with draft PRs and
CodeRabbit with ready PRs, a statement that auto-reviews are disabled
and both bots are triggered manually, a 5-step workflow built around
`@copilot review`, and a closing rule about never triggering Copilot on
a ready PR.

**After:** CodeRabbit is described as the automated reviewer that runs
on its own, followed by four behavior bullets — drafts are skipped;
review fires automatically on the draft to ready flip and on every
subsequent push; the walkthrough comment is commonly edited in place
rather than re-posted, so no new comment does not mean no new review;
a rate-limited CodeRabbit silently drops that review, and
`@coderabbitai review` after the window resets is the only case where a
manual trigger is appropriate. Copilot is covered in two sentences: not
part of the workflow, do not invoke it, and address any threads from a
third-party manual invocation like other reviewer feedback.

The table was dropped — with one bot and behavior rather than triggers
to describe, a bullet list carries it better.

## CI list addition

Added an **AI Validation** entry (`.github/workflows/ai-validation.yml`)
between doc-linter and the Sphinx build. It cross-checks changed
`docs/**/*.md` against the VyOS CLI definitions in the `vyos-1x` source
tree for the corresponding branch and posts findings as inline review
comments plus a summary comment. It runs only when a PR touches Markdown
under `docs/`, and skips with a notice when the required repository
secrets are not configured or when the PR is a Mergify-authored
backport. The other four CI bullets were checked against
`.github/workflows/` and `scripts/doc-linter.py` and are accurate as
written — the doc-linter scoping claim is confirmed by the comment at
`scripts/doc-linter.py:28`, and the Read the Docs preview check still
reports on PRs.

`README.md` points at `AGENTS.md` for "the Copilot/CodeRabbit bot review
workflow"; that phrase is updated to name CodeRabbit only, so the
pointer does not contradict the section it points to.

## Review

Local CodeRabbit review against `origin/rolling` completed with **0
findings** across both reviewed files (`AGENTS.md`, `README.md`).

## Backport

`circinus` carries the same stale section and needs this change.
`sagitta`'s `AGENTS.md` predates the bot-review section entirely and has
nothing to correct. Backport will be requested by post-merge comment.

🤖 Generated by [robots](https://vyos.io)