### PR TITLE
docs: document flow-accounting NetFlow VRF export and source options

### DIFF
--- a/docs/configuration/system/flow-accounting.md
+++ b/docs/configuration/system/flow-accounting.md
@@ -114,13 +114,43 @@ versions are supported:
 
 ```{cfgcmd} set system flow-accounting netflow server \<address\>
 
-Configure address of NetFlow collector. NetFlow server at \<address\> can
-be both listening on an IPv4 or IPv6 address.
+Configure the address of a NetFlow collector. The collector at \<address\>
+can listen on either an IPv4 or IPv6 address. Multiple collectors may be
+configured, and flows are exported to each of them independently.
 ```
 
-```{cfgcmd} set system flow-accounting netflow source-ip \<address\>
+```{cfgcmd} set system flow-accounting netflow server \<address\> port \<port\>
 
-IPv4 or IPv6 source address of NetFlow packets
+Configure the UDP port of the NetFlow collector \<address\>. The default
+port is 2055.
+```
+
+```{cfgcmd} set system flow-accounting netflow server \<address\> source-address \<source\>
+
+Source IPv4 or IPv6 address of the NetFlow packets exported to collector
+\<address\>. The address must be present on the system and, when a VRF is
+configured (see below), must belong to that VRF.
+```
+
+```{cfgcmd} set system flow-accounting netflow server \<address\> source-interface \<interface\>
+
+Export the NetFlow packets for collector \<address\> from \<interface\>.
+The export is bound to that interface, which selects the egress routing
+path. This option is mutually exclusive with ``source-address``. When a
+VRF is configured, \<interface\> must be a member of that VRF. A VRF
+name cannot be used as \<interface\>; use the ``vrf`` command instead.
+```
+
+```{cfgcmd} set system flow-accounting vrf \<name\>
+
+Export all NetFlow data through VRF \<name\>. The export packets are then
+routed using that VRF's routing table, which is required when the
+collector is only reachable inside the VRF, such as on an out-of-band
+management network.
+
+When a collector uses ``source-interface``, that interface must be a
+member of \<name\> and is used to source the packets. Otherwise the VRF
+device itself is used, and any ``source-address`` must belong to the VRF.
 ```
 
 ```{cfgcmd} set system flow-accounting netflow engine-id \<id\>
@@ -165,6 +195,14 @@ NetFlow v5 example:
 set system flow-accounting netflow engine-id 100
 set system flow-accounting netflow version 5
 set system flow-accounting netflow server 192.168.2.10 port 2055
+```
+
+NetFlow export via a management VRF:
+
+```none
+set system flow-accounting netflow interface eth1
+set system flow-accounting netflow server 192.0.2.10 source-address 198.51.100.1
+set system flow-accounting vrf MGMT
 ```
 
 

--- a/docs/configuration/system/flow-accounting.md
+++ b/docs/configuration/system/flow-accounting.md
@@ -136,9 +136,9 @@ configured (see below), must belong to that VRF.
 
 Export the NetFlow packets for collector \<address\> from \<interface\>.
 The export is bound to that interface, which selects the egress routing
-path. This option is mutually exclusive with ``source-address``. When a
+path. This option is mutually exclusive with `source-address`. When a
 VRF is configured, \<interface\> must be a member of that VRF. A VRF
-name cannot be used as \<interface\>; use the ``vrf`` command instead.
+name cannot be used as \<interface\>; use the `vrf` command instead.
 ```
 
 ```{cfgcmd} set system flow-accounting vrf \<name\>
@@ -148,9 +148,9 @@ routed using that VRF's routing table, which is required when the
 collector is only reachable inside the VRF, such as on an out-of-band
 management network.
 
-When a collector uses ``source-interface``, that interface must be a
+When a collector uses `source-interface`, that interface must be a
 member of \<name\> and is used to source the packets. Otherwise the VRF
-device itself is used, and any ``source-address`` must belong to the VRF.
+device itself is used, and any `source-address` must belong to the VRF.
 ```
 
 ```{cfgcmd} set system flow-accounting netflow engine-id \<id\>


### PR DESCRIPTION
## Change Summary

Document the per-server NetFlow collector options and the `vrf` node for
`system flow-accounting`, which were previously undocumented:

- `netflow server <address> port <port>`
- `netflow server <address> source-address <address>`
- `netflow server <address> source-interface <interface>`
- `flow-accounting vrf <name>` — exporting NetFlow within a VRF, and how
  `source-interface` / `source-address` interact with it

This also removes the stale `netflow source-ip` command (replaced by the
per-server `source-address` after the pmacct → ipt_NETFLOW migration) and adds
a management-VRF example.

Note: the page still carries other pre-migration staleness that is unrelated to
this change (`disable-imt`, `buffer-size`, `syslog-facility`,
`timeout expiry-interval`, and the engine-id "0 to 255" range). That is out of
scope here and would make a good separate refresh.

## Related Task(s)
* https://vyos.dev/T9122

## Related PR(s)
* vyos/vyos-1x#5347 — the implementation this documents.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document
