### PR TITLE
docs: T9175: document dns forwarding options security-status-poll-domain

### DIFF
--- a/docs/configuration/service/dns.md
+++ b/docs/configuration/service/dns.md
@@ -429,6 +429,33 @@ set service dns forwarding options edns-subnet-allow-list example.com
 set service dns forwarding options edns-subnet-allow-list 192.0.2.0/24
 ```
 
+```{cfgcmd} set service dns forwarding options security-poll-suffix \<domain-suffix\>
+
+**Configure the domain suffix used by the PowerDNS recursor to
+periodically poll for known security issues in the running version.**
+
+Disabled by default, since VyOS ships its own patched/backported
+package that is not updated in-place, making the poll result
+meaningless. Only takes effect once a non-empty suffix is configured;
+delete the option to disable polling again.
+
+`secpoll.powerdns.com` is PowerDNS' own security-status poll domain,
+not a VyOS default - set it explicitly to use it, or point this at a
+custom domain suffix operated by your own organization.
+```
+
+Example:
+
+```none
+set service dns forwarding options security-poll-suffix secpoll.powerdns.com
+```
+
+To disable polling again:
+
+```none
+delete service dns forwarding options security-poll-suffix
+```
+
 ### Per-domain forwarding
 
 ```{cfgcmd} set service dns forwarding domain \<domain-name\> name-server \<address\>
@@ -487,19 +514,6 @@ Example:
 
 ```none
 set service dns forwarding domain example.com recursion-desired
-```
-
-
-```{cfgcmd} set service dns forwarding options security-poll-suffix \<domain-suffix\>
-
-The PowerDNS recursor can periodically poll a domain to check whether the
-running version has any known security issues. This is disabled by default,
-as VyOS ships its own patched/backported package which is not updated
-in-place, making the check result meaningless.
-
-Set this to ``secpoll.powerdns.com`` to use PowerDNS' own security status
-poll domain, or point it at a custom domain suffix operated by your own
-organization.
 ```
 
 ### Authoritative zones

--- a/docs/configuration/service/dns.md
+++ b/docs/configuration/service/dns.md
@@ -489,6 +489,19 @@ Example:
 set service dns forwarding domain example.com recursion-desired
 ```
 
+
+```{cfgcmd} set service dns forwarding options security-poll-suffix \<domain-suffix\>
+
+The PowerDNS recursor can periodically poll a domain to check whether the
+running version has any known security issues. This is disabled by default,
+as VyOS ships its own patched/backported package which is not updated
+in-place, making the check result meaningless.
+
+Set this to ``secpoll.powerdns.com`` to use PowerDNS' own security status
+poll domain, or point it at a custom domain suffix operated by your own
+organization.
+```
+
 ### Authoritative zones
 
 DNS forwarding can host authoritative records for a domain, answering

--- a/docs/configuration/service/dns.md
+++ b/docs/configuration/service/dns.md
@@ -429,31 +429,31 @@ set service dns forwarding options edns-subnet-allow-list example.com
 set service dns forwarding options edns-subnet-allow-list 192.0.2.0/24
 ```
 
-```{cfgcmd} set service dns forwarding options security-poll-suffix \<domain-suffix\>
+```{cfgcmd} set service dns forwarding options security-status-poll-domain \<domain-name\>
 
-**Configure the domain suffix used by the PowerDNS recursor to
-periodically poll for known security issues in the running version.**
+**Configure the domain used by the PowerDNS recursor to periodically
+poll for known vulnerabilities in the running version.**
 
 Disabled by default, since VyOS ships its own patched/backported
 package that is not updated in-place, making the poll result
-meaningless. Only takes effect once a non-empty suffix is configured;
-delete the option to disable polling again.
+meaningless. Only takes effect once a domain is configured; delete
+the option to disable polling again.
 
 `secpoll.powerdns.com` is PowerDNS' own security-status poll domain,
 not a VyOS default - set it explicitly to use it, or point this at a
-custom domain suffix operated by your own organization.
+custom domain operated by your own organization.
 ```
 
 Example:
 
 ```none
-set service dns forwarding options security-poll-suffix secpoll.powerdns.com
+set service dns forwarding options security-status-poll-domain secpoll.powerdns.com
 ```
 
 To disable polling again:
 
 ```none
-delete service dns forwarding options security-poll-suffix
+delete service dns forwarding options security-status-poll-domain
 ```
 
 ### Per-domain forwarding


### PR DESCRIPTION
## Change Summary
  
  Document the new opt-in `service dns forwarding options
  security-status-poll-domain` setting that controls the PowerDNS recursor's
  periodic security status poll, disabled by default (VyOS ships a
  patched/backported `pdns-recursor` package that's never updated
  in-place, so the poll result is meaningless — see T9175).
  
  ## Related Task(s)
  * https://vyos.dev/T9175
  
  ## Related PR(s)
  * vyos/vyos-1x#5389
  
  ## Backport
  <!-- none -->
  
  ## Checklist:
  - [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document

