### PR TITLE
T9184: adds documentation for chown and other missing options

### DIFF
--- a/docs/configuration/container/index.md
+++ b/docs/configuration/container/index.md
@@ -231,7 +231,7 @@ Set container capabilities or permissions.
 - **mknod**: Permission to create special files
 - **setpcap**: Capability sets (from bounded or inherited set)
 - **sys-admin**: Administration operations (quotactl, mount, sethostname,
-setdomainame)
+setdomainname)
 - **sys-module**: Load, unload and delete kernel modules
 - **sys-nice**: Permission to set process nice value
 - **sys-time**: Permission to set system clock

--- a/docs/configuration/container/index.md
+++ b/docs/configuration/container/index.md
@@ -227,9 +227,13 @@ Set container capabilities or permissions.
 - **net-bind-service**: Bind a socket to privileged ports
 (port numbers less than 1024)
 - **net-raw**: Permission to create raw network sockets
+- **chown**: Permission to set file UIDs and GIDs
+- **mknod**: Permission to create special files
 - **setpcap**: Capability sets (from bounded or inherited set)
 - **sys-admin**: Administration operations (quotactl, mount, sethostname,
 setdomainame)
+- **sys-module**: Load, unload and delete kernel modules
+- **sys-nice**: Permission to set process nice value
 - **sys-time**: Permission to set system clock
 ```
 


### PR DESCRIPTION
## Change Summary
Adds documentation for new and missing container capabilities

## Related Task(s)
* https://vyos.dev/T9184

## Related PR(s)
vyos/vyos-1x#5387

## Backport


## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document