### PR TITLE
docs: T9200: note no-ipv6-auto-ra doesn't stop already-active RA

### DIFF
--- a/docs/configuration/protocols/bgp.md
+++ b/docs/configuration/protocols/bgp.md
@@ -1513,8 +1513,10 @@ This only prevents router advertisements from starting on sessions
 established *after* the setting takes effect. It does not stop router
 advertisements already active on an established session - neither a soft
 nor a hard `clear`/`reset bgp` on the neighbor will stop them. To silence
-an already-active session, remove and re-add `remote-as` on that
-neighbor, or restart the `bgpd`/`frr` process.
+one already-active neighbor, remove and re-add `remote-as` on that
+neighbor. Restarting the `bgpd`/`frr` process also clears it, but drops
+every BGP session on the router, not just the affected one - reserve
+that for a planned maintenance window rather than a routine fix.
 :::
 ```
 

--- a/docs/configuration/protocols/bgp.md
+++ b/docs/configuration/protocols/bgp.md
@@ -1507,6 +1507,15 @@ for BGP.**
 By default, FRR sends RAs on an interface when its BGP session has
 negotiated the Extended Next Hop capability, or when a BGP neighbor is
 configured by interface name (Unnumbered BGP).
+
+:::{note}
+This only prevents router advertisements from starting on sessions
+established *after* the setting takes effect. It does not stop router
+advertisements already active on an established session - neither a soft
+nor a hard `clear`/`reset bgp` on the neighbor will stop them. To silence
+an already-active session, remove and re-add `remote-as` on that
+neighbor, or restart the `bgpd`/`frr` process.
+:::
 ```
 
 ```{note}


### PR DESCRIPTION
## Change Summary

`no-ipv6-auto-ra` only prevents future RA initiation; it doesn't
retroactively silence router advertisements already sent on an
established session. Confirmed on VyOS 1.5.1: neither a soft nor a
hard `clear`/`reset bgp` on the neighbor stopped it. Per FRR's
`bgp_zebra_terminate_radv()`/upstream PR
[FRRouting/frr#19487](https://github.com/FRRouting/frr/pull/19487),
that only runs when the neighbor's `remote-as` is removed and re-added.

## Related Task(s)

* https://vyos.dev/T9200

## Related PR(s)

None.

## Backport

None.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document