### PR TITLE
docs: T9202: document the DHCPv4 lease Client ID column

### DIFF
--- a/docs/configuration/service/dhcp-server.md
+++ b/docs/configuration/service/dhcp-server.md
@@ -1043,18 +1043,26 @@ Show statuses of all active leases:
 
 ```none
 vyos@vyos:~$ show dhcp server leases
-IP Address      MAC address        State    Lease start          Lease expiration     Remaining    Pool      Hostname    Origin
---------------  -----------------  -------  -------------------  -------------------  -----------  --------  ----------  --------
-192.168.11.134  00:50:79:66:68:09  active   2023/11/29 09:51:05  2023/11/29 10:21:05  0:24:10      LAN       VPCS1       local
-192.168.11.133  50:00:00:06:00:00  active   2023/11/29 09:51:38  2023/11/29 10:21:38  0:24:43      LAN       VYOS-6      local
-10.11.11.108    50:00:00:05:00:00  active   2023/11/29 09:51:43  2023/11/29 10:21:43  0:24:48      VIF-1001  VYOS5       local
-192.168.11.135  00:50:79:66:68:07  active   2023/11/29 09:55:16  2023/11/29 09:59:16  0:02:21                            remote
+IP Address      MAC address        State    Lease start          Lease expiration     Remaining    Pool      Hostname    Origin    Client ID
+--------------  -----------------  -------  -------------------  -------------------  -----------  --------  ----------  --------  --------------------
+192.168.11.134  00:50:79:66:68:09  active   2023/11/29 09:51:05  2023/11/29 10:21:05  0:24:10      LAN       VPCS1       local     01:00:50:79:66:68:09
+192.168.11.133  50:00:00:06:00:00  active   2023/11/29 09:51:38  2023/11/29 10:21:38  0:24:43      LAN       VYOS-6      local     01:50:00:00:06:00:00
+10.11.11.108    50:00:00:05:00:00  active   2023/11/29 09:51:43  2023/11/29 10:21:43  0:24:48      VIF-1001  VYOS5       local     01:50:00:00:05:00:00
+192.168.11.135  00:50:79:66:68:07  active   2023/11/29 09:55:16  2023/11/29 09:59:16  0:02:21                            remote    01:00:50:79:66:68:07
 vyos@vyos:~$
 ```
 
 :::{hint}
 Static mappings aren't shown. To show all states, use
 `show dhcp server leases state all`.
+:::
+
+:::{hint}
+The Client ID column reports DHCP option 61 as the client sent it. Most clients
+send `01:` followed by their MAC address, as above. A client using
+systemd-networkd sends an {rfc}`4361` identifier instead, of the form
+`ff:<IAID>:<DUID>` — and it is the DUID inside it, not the whole string, that a
+static mapping's `duid` must be set to in order to match.
 :::
 
 ```{opcmd} show dhcp server leases origin [local | remote]
@@ -1066,9 +1074,9 @@ remote (failover server):
 
 ```none
 vyos@vyos:~$ show dhcp server leases origin remote
-IP Address      MAC address        State    Lease start          Lease expiration     Remaining    Pool      Hostname    Origin
---------------  -----------------  -------  -------------------  -------------------  -----------  --------  ----------  --------
-192.168.11.135  00:50:79:66:68:07  active   2023/11/29 09:55:16  2023/11/29 09:59:16  0:02:21                            remote
+IP Address      MAC address        State    Lease start          Lease expiration     Remaining    Pool      Hostname    Origin    Client ID
+--------------  -----------------  -------  -------------------  -------------------  -----------  --------  ----------  --------  --------------------
+192.168.11.135  00:50:79:66:68:07  active   2023/11/29 09:55:16  2023/11/29 09:59:16  0:02:21                            remote    01:00:50:79:66:68:07
 vyos@vyos:~$
 ```
 
@@ -1081,18 +1089,18 @@ Show only leases in the specified pool.
 
 ```none
 vyos@vyos:~$ show dhcp server leases pool LAN
-IP Address      MAC address        State    Lease start          Lease expiration     Remaining    Pool    Hostname    Origin
---------------  -----------------  -------  -------------------  -------------------  -----------  ------  ----------  --------
-192.168.11.134  00:50:79:66:68:09  active   2023/11/29 09:51:05  2023/11/29 10:21:05  0:23:55      LAN     VPCS1       local
-192.168.11.133  50:00:00:06:00:00  active   2023/11/29 09:51:38  2023/11/29 10:21:38  0:24:28      LAN     VYOS-6      local
+IP Address      MAC address        State    Lease start          Lease expiration     Remaining    Pool    Hostname    Origin    Client ID
+--------------  -----------------  -------  -------------------  -------------------  -----------  ------  ----------  --------  --------------------
+192.168.11.134  00:50:79:66:68:09  active   2023/11/29 09:51:05  2023/11/29 10:21:05  0:23:55      LAN     VPCS1       local     01:00:50:79:66:68:09
+192.168.11.133  50:00:00:06:00:00  active   2023/11/29 09:51:38  2023/11/29 10:21:38  0:24:28      LAN     VYOS-6      local     01:50:00:00:06:00:00
 vyos@vyos:~$
 ```
 
 
 ```{opcmd} show dhcp server leases sort \<key\>
 
-Sort the output by the specified key. Possible keys: ip, hardware_address,
-state, start, end, remaining, pool, hostname (default = ip)
+Sort the output by the specified key. Possible keys: client_id, end, hostname,
+ip, mac, pool, remaining, start, state (default = ip)
 ```
 
 


### PR DESCRIPTION
## Change summary

Documents the `Client ID` column that [vyos-1x#5394](https://github.com/vyos/vyos-1x/pull/5394) adds to `show dhcp server leases`, and corrects the sort key list on the same page.

The column is added to the three lease samples on the page, with a note on how to read it — most clients send `01:` followed by their MAC, while a systemd-networkd host sends an {rfc}`4361` identifier of the form `ff:<IAID>:<DUID>`, and it is the DUID *inside* that, not the whole string, that a static mapping's `duid` must be set to in order to match. Getting that wrong produces a reservation the CLI accepts and Kea never matches, so it seemed worth stating explicitly rather than leaving to be inferred from a column of hex.

**The sort key list was already wrong** and is corrected while `client_id` is added to it. It named `hardware_address`, which the command has never accepted:

```
$ show dhcp server leases sort hardware_address
DHCP sort "hardware_address" is invalid!

$ show dhcp server leases sort mac
IP Address      MAC address        State     Lease start          ...
```

The DHCPv6 sort key list a few sections below is stale in the same way — it names `expires`, `iaid_duid` and `last_comm` where the command wants `end`, `duid` and `last_communication`, and omits `hostname` entirely:

```
$ show dhcpv6 server leases sort iaid_duid
DHCPv6 sort "iaid_duid" is invalid!
$ show dhcpv6 server leases sort expires
DHCPv6 sort "expires" is invalid!
$ show dhcpv6 server leases sort last_comm
DHCPv6 sort "last_comm" is invalid!
```

That is deliberately **not** touched here — it is a different command, untouched by this change, and wants its own task. Flagging it so it is not lost.

## Related PR(s)

* vyos/vyos-1x#5394 — the change being documented. This should merge with or after it.

## Related Task(s)

* https://vyos.dev/T9202
