### PR TITLE
T9208: add scutum to docs CI branch enumerations

### DIFF
--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -1,12 +1,13 @@
 name: Context7 refresh
 
 # Refreshes the Context7 variant for the pushed branch. Context7 indexes
-# three variants of this library, all tracking a branch HEAD directly:
+# four variants of this library, all tracking a branch HEAD directly:
 #   - rolling  → default variant       (omit both `branch` and `tag`)
+#   - scutum   → branch variant        `branch: "scutum"`   (VyOS 1.6)
 #   - circinus → branch variant        `branch: "circinus"` (VyOS 1.5)
 #   - sagitta  → branch variant        `branch: "sagitta"`  (VyOS 1.4)
 #
-# The circinus/sagitta variants are declared as branch entries in
+# The scutum/circinus/sagitta variants are declared as branch entries in
 # context7.json `previousVersions`. There is no longer any git-tag
 # indirection — Context7 re-crawls the branch HEAD on refresh, so the
 # variant always reflects current branch content.
@@ -16,7 +17,7 @@ name: Context7 refresh
 # README, etc.) never trigger a refresh — Context7 only ingests `docs/**`
 # (per context7.json `folders`) plus the config file itself.
 #
-# NOTE: circinus/sagitta must be registered as BRANCH variants in the
+# NOTE: scutum/circinus/sagitta must be registered as BRANCH variants in the
 # Context7 dashboard (driven by the context7.json `previousVersions`
 # branch entries on the default branch). A refresh with `branch: "<name>"`
 # returns 404 until Context7 has crawled the config and registered the
@@ -26,6 +27,7 @@ on:
   push:
     branches:
       - rolling
+      - scutum
       - circinus
       - sagitta
     paths:
@@ -34,9 +36,9 @@ on:
   workflow_dispatch:
     inputs:
       variant:
-        description: "Context7 variant to refresh (rolling = default; circinus = 1.5; sagitta = 1.4)"
+        description: "Context7 variant to refresh (rolling = default; scutum = 1.6; circinus = 1.5; sagitta = 1.4)"
         type: choice
-        options: [rolling, circinus, sagitta]
+        options: [rolling, scutum, circinus, sagitta]
         default: rolling
 
 permissions: {}
@@ -75,11 +77,11 @@ jobs:
           # Defense-in-depth: the type:choice UI constraint is bypassable when
           # workflow_dispatch is invoked via API (`gh workflow run -f variant=…`).
           case "$VARIANT" in
-            rolling|circinus|sagitta) ;;
-            *) echo "Invalid variant: '${VARIANT}'. Expected one of: rolling, circinus, sagitta." >&2; exit 1 ;;
+            rolling|scutum|circinus|sagitta) ;;
+            *) echo "Invalid variant: '${VARIANT}'. Expected one of: rolling, scutum, circinus, sagitta." >&2; exit 1 ;;
           esac
           echo "Refreshing Context7 variant: $VARIANT"
-          # rolling = default variant (no field). circinus/sagitta = branch-backed.
+          # rolling = default variant (no field). scutum/circinus/sagitta = branch-backed.
           if [[ "$VARIANT" == "rolling" ]]; then
             PAYLOAD="$(jq -nc --arg lib "/$REPO" \
               '{libraryName: $lib}')"

--- a/context7.json
+++ b/context7.json
@@ -26,7 +26,7 @@
     "Documentation sources are MyST Markdown (.md). Cite and link to the .md form.",
     "VyOS has two CLI modes: configuration mode (entered via `configure`; for `set`/`delete`/`commit`/`save` and config-state `show`) and operational mode (default after login; for `show`, `monitor`, plus image-mgmt like `add system image`). Do not mix.",
     "Configuration commands are wrapped in `cfgcmd` fenced blocks; operational commands in `opcmd` fenced blocks. Treat these as authoritative command syntax.",
-    "Branch-to-version mapping (cite version-appropriate docs): `rolling` = rolling / next major, 1.6+ (default); `circinus` = 1.5.x (current LTS); `sagitta` = 1.4.x (previous LTS); `equuleus` = 1.3.x (legacy); `crux` = 1.2.x (legacy).",
+    "Branch-to-version mapping (cite version-appropriate docs): `rolling` = rolling / next major (default); `scutum` = 1.6.x; `circinus` = 1.5.x (current LTS); `sagitta` = 1.4.x (previous LTS); `equuleus` = 1.3.x (legacy); `crux` = 1.2.x (legacy).",
     "Do not invent CLI commands. If a command isn't in the docs, say so rather than guess — VyOS syntax is strict and unknown commands fail validation at commit time.",
     "Use reserved documentation IP space in examples: 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24 (RFC 5737), 2001:db8::/32 (RFC 3849). Never use real or RFC1918 addresses.",
     "`commit` activates pending `set`/`delete` changes and runs validation (errors = no change applied); `save` persists across reboot. Verify with `show <node>` (config mode) or `show configuration commands` (op mode). Always include `commit` and `save`.",

--- a/context7.json
+++ b/context7.json
@@ -36,6 +36,7 @@
     "Routing protocols (BGP, OSPF, IS-IS, RIP) are FRR-backed, but not every FRR knob is exposed through the VyOS CLI. Confirm a command exists in the VyOS docs before suggesting it — synthesizing from FRR documentation produces invalid VyOS commands."
   ],
   "previousVersions": [
+    { "branch": "scutum" },
     { "branch": "circinus" },
     { "branch": "sagitta" }
   ]


### PR DESCRIPTION
## What

Adds the new `scutum` docs branch (VyOS 1.6 train, cut from `circinus` on 2026-08-13) to the branch enumerations that live on the default branch:

| File | Change |
|------|--------|
| `.github/workflows/context7-refresh.yml` | `scutum` added to the `push:` branch list, the `workflow_dispatch` choice options + description, and the defence-in-depth variant allow-list (`case`). Header comments updated to match the enumeration they document. |
| `context7.json` | `{ "branch": "scutum" }` added to `previousVersions`, and `scutum` = 1.6.x added to the branch-to-version mapping rule (which previously claimed `rolling` covers "1.6+" — the version `scutum` now serves). |

## Why

Without the trigger entry, a docs push on `scutum` refreshes nothing and the Context7 variant for the new train silently goes stale. The `context7.json` entry is the other half: per the workflow's own note, Context7 registers branch variants from `previousVersions` **on the default branch**, and a refresh with `branch: "scutum"` returns 404 until that registration has been crawled. This PR therefore lands the registration; the companion PR against the `scutum` branch itself carries the same enumeration change so the trigger actually fires there.

Enumerations and comments only — no behaviour change for the existing `rolling`, `circinus` and `sagitta` variants.

## Deliberately not in this PR

- **`.github/workflows/docs-build.yml`** (`branches: [rolling, circinus, sagitta]`) — the workflow's first step resolves `github.ref_name` against `workers/matrix.json` and hard-fails with `branch not in matrix` for anything unlisted, and its deploy step selects the Wrangler config through an inline `case '<slug>' in rolling|1.5|1.4` arm with no 1.6 branch. A working `scutum` entry therefore needs the whole publishing chain provisioned together: a `vyos-docs-v16-en` Worker, a `branch/wrangler.*.jsonc` config, a `workers/versions.json` slug + binding, the apex worker list in `apex-deploy.yml`, plus the `docs-canary-qa.yml --slugs` and `scripts/docs_gates/parity.py` slug lists. Adding only the trigger would be *worse* than omitting it — it would be the one enumerated branch the file's own internals cannot honour. That belongs to the docs-publishing workstream, not to a CI-trigger change.
- **`.github/workflows/submodules.yml`** — the file has no `circinus` job to model a `scutum` one on (it carries `update_rolling`, `update_sagitta`, `update_equuleus` only), `docs/_ext/releasenotes.py` raises `given branch not defined` for any branch outside its hard-coded `equuleus`/`sagitta`/`circinus` project map, and there is no `scutum` branch in `vyos/vyos-1x` to check the submodule out at. Adding a job would be inventing new behaviour, not extending a pattern.
- **`.github/workflows/ai-validation.yml`** — the only `sagitta` occurrences are prose in a comment and in the reviewer prompt, and the workflow has no branch filter, so it already fires on `scutum` PRs. Its docs-branch → vyos-1x mapping lives in `branches.json` in `VyOS-Networks/vyos-docs-opus-reviewer`, and the resolve step hard-errors for an unknown docs branch.

  ⚠️ **Known cut-day gap:** that reviewer checkout is pinned (`REVIEWER_REF: reviewer-v1.0.3`), so publishing a mapping on the reviewer repo's default branch is *not* sufficient — a new immutable `reviewer-v1.x.x` ref must carry the `scutum` entry and `REVIEWER_REF` must then be bumped here. The mapping *value* is also unresolved: `vyos/vyos-1x` has no `scutum` branch (its `sagitta`/`circinus` were renamed to `*-public-unmaintained`), so which vyos-1x ref `scutum` docs validate against is a decision for that workstream. Until then, AI Validation hard-fails on any PR targeting `scutum` — including the companion PR to this one. Tracked under IS-654.

## Review

Phase-0 CodeRabbit: clean (0 findings) on `ff71bbd`.
Adversarial review (Codex + agy, trusted): 2 findings — the `context7.json` mapping-rule inconsistency is fixed in `ff71bbd`; the `REVIEWER_REF` pinning gap is documented above rather than fixed, since no reviewer ref carrying a `scutum` mapping exists yet to bump to.

Advances: IS-654

T9208

🤖 Generated by [robots](https://vyos.io)
