### PR TITLE
T9208: enable scutum CI triggers in scutum branch workflows

### DIFF
--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -1,12 +1,13 @@
 name: Context7 refresh
 
 # Refreshes the Context7 variant for the pushed branch. Context7 indexes
-# three variants of this library, all tracking a branch HEAD directly:
+# four variants of this library, all tracking a branch HEAD directly:
 #   - rolling  → default variant       (omit both `branch` and `tag`)
+#   - scutum   → branch variant        `branch: "scutum"`   (VyOS 1.6)
 #   - circinus → branch variant        `branch: "circinus"` (VyOS 1.5)
 #   - sagitta  → branch variant        `branch: "sagitta"`  (VyOS 1.4)
 #
-# The circinus/sagitta variants are declared as branch entries in
+# The scutum/circinus/sagitta variants are declared as branch entries in
 # context7.json `previousVersions`. There is no longer any git-tag
 # indirection — Context7 re-crawls the branch HEAD on refresh, so the
 # variant always reflects current branch content.
@@ -16,7 +17,7 @@ name: Context7 refresh
 # README, etc.) never trigger a refresh — Context7 only ingests `docs/**`
 # (per context7.json `folders`) plus the config file itself.
 #
-# NOTE: circinus/sagitta must be registered as BRANCH variants in the
+# NOTE: scutum/circinus/sagitta must be registered as BRANCH variants in the
 # Context7 dashboard (driven by the context7.json `previousVersions`
 # branch entries on the default branch). A refresh with `branch: "<name>"`
 # returns 404 until Context7 has crawled the config and registered the
@@ -26,6 +27,7 @@ on:
   push:
     branches:
       - rolling
+      - scutum
       - circinus
       - sagitta
     paths:
@@ -34,9 +36,9 @@ on:
   workflow_dispatch:
     inputs:
       variant:
-        description: "Context7 variant to refresh (rolling = default; circinus = 1.5; sagitta = 1.4)"
+        description: "Context7 variant to refresh (rolling = default; scutum = 1.6; circinus = 1.5; sagitta = 1.4)"
         type: choice
-        options: [rolling, circinus, sagitta]
+        options: [rolling, scutum, circinus, sagitta]
         default: rolling
 
 permissions: {}
@@ -75,11 +77,11 @@ jobs:
           # Defense-in-depth: the type:choice UI constraint is bypassable when
           # workflow_dispatch is invoked via API (`gh workflow run -f variant=…`).
           case "$VARIANT" in
-            rolling|circinus|sagitta) ;;
-            *) echo "Invalid variant: '${VARIANT}'. Expected one of: rolling, circinus, sagitta." >&2; exit 1 ;;
+            rolling|scutum|circinus|sagitta) ;;
+            *) echo "Invalid variant: '${VARIANT}'. Expected one of: rolling, scutum, circinus, sagitta." >&2; exit 1 ;;
           esac
           echo "Refreshing Context7 variant: $VARIANT"
-          # rolling = default variant (no field). circinus/sagitta = branch-backed.
+          # rolling = default variant (no field). scutum/circinus/sagitta = branch-backed.
           if [[ "$VARIANT" == "rolling" ]]; then
             PAYLOAD="$(jq -nc --arg lib "/$REPO" \
               '{libraryName: $lib}')"


### PR DESCRIPTION
## What

Companion to [vyos-documentation#2199](https://github.com/vyos/vyos-documentation/pull/2199) (base `rolling`). Carries the same Context7 branch enumeration onto the `scutum` branch itself, so the refresh workflow actually fires on `scutum` pushes.

| File | Change |
|------|--------|
| `.github/workflows/context7-refresh.yml` | `scutum` added to the `push:` branch list, the `workflow_dispatch` choice options + description, and the defence-in-depth variant allow-list (`case`). Header comments updated to match. |

## Why

GitHub Actions runs a `push`-triggered workflow from the copy of the file **on the pushed branch**. `scutum` was cut from `circinus` on 2026-08-13, so its copy still enumerates `rolling`/`circinus`/`sagitta` only — a docs push on `scutum` would match no trigger and refresh nothing. This adds the missing entry.

The file is maintained byte-identically across `rolling`, `circinus`, `sagitta` and `scutum` (verified: the pre-change blob is the same on all four). This change keeps that property — the resulting file is identical to the one in #2199.

**Ordering:** #2199 must land first. Context7 registers branch variants from `context7.json` `previousVersions` **on the default branch**, and a refresh call with `branch: "scutum"` returns 404 until Context7 has crawled that registration. Until then this workflow will fire on `scutum` pushes and the refresh call will 404; it becomes effective once #2199 is merged and crawled.

## Scope notes

- **`context7.json` is deliberately not added here.** It exists only on `rolling` (absent on `circinus`, `sagitta` and `scutum`), and per the workflow's own note the `previousVersions` registration is only read from the default branch. Adding it to this branch would be new behaviour, not parity.
- **No per-train action refs needed repinning.** Every `uses:` on this branch already targets `@production` or a pinned upstream SHA/tag — there are no `@circinus`/`@sagitta` references to retarget to `@scutum`.
- **`.readthedocs.yml` needs no change** — it contains no branch or train references.
- **`.mergify.yml` untouched.**

## Observed but deliberately not fixed here

`scutum` inherited two `peter-evans/create-pull-request` head-branch names verbatim from `circinus`, and they now **collide** with circinus's own:

| Workflow | `rolling` | `circinus` | `sagitta` | `scutum` (inherited) |
|---|---|---|---|---|
| `update-translations.yml` | `update-translations-rolling` | `update-translations-current` | `update-translations-master` | `update-translations-current` |
| `submodules.yml` | `update-dependencies-rolling` | `update-dependencies-current` | — | `update-dependencies-current` |

The historical convention is one distinct head branch per docs branch (the names track each era's default-branch name: `master` → `current` → `rolling`), so `scutum` should eventually get its own. Both workflows are `schedule:` + `workflow_dispatch:`, and scheduled runs only ever execute from the default branch, so this is inert unless someone manually dispatches on `circinus` and `scutum` concurrently — in which case the second run would push onto the first run's open PR branch.

Left out of this PR deliberately: it is neither a trigger nor a per-train `uses:` ref, it is pre-existing staleness shared with `circinus`/`sagitta` rather than something the cut introduced, and `submodules.yml` on this branch is deferred wholesale (see #2199). Worth a follow-up under IS-654.

## Known cut-day gap

`ai-validation.yml` resolves the docs branch through `branches.json` in `VyOS-Networks/vyos-docs-opus-reviewer`, checked out at the pinned `REVIEWER_REF: reviewer-v1.0.3`, and hard-errors on an unknown docs branch. No `scutum` entry exists at that ref, so **AI Validation is expected to fail on this PR** until a new reviewer ref ships the mapping and `REVIEWER_REF` is bumped on `rolling`. The mapping value itself is still undecided: `vyos/vyos-1x` has no `scutum` branch. Tracked under IS-654.

## Review

Phase-0 CodeRabbit: clean (0 findings) against `origin/scutum`.

Advances: IS-654

T9208

🤖 Generated by [robots](https://vyos.io)
