### PR TITLE
ci: T9208: bump AI-validation reviewer pin to v1.0.4 for scutum branch map

### DIFF
--- a/.github/workflows/ai-validation.yml
+++ b/.github/workflows/ai-validation.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REVIEWER_REF: reviewer-v1.0.3
+  REVIEWER_REF: reviewer-v1.0.4
   # Force JavaScript actions to run on Node 24. Some pinned action SHAs
   # we rely on still ship with Node 20 ABI; this env var opts the whole
   # workflow into Node 24 without per-action version churn.


### PR DESCRIPTION
## What

Bump `REVIEWER_REF` in the AI Validation workflow from `reviewer-v1.0.3` to `reviewer-v1.0.4`. One line; no other change.

## Why

The reviewer's branch map (`branches.json`, sparse-checked-out at `REVIEWER_REF`) gains a `scutum` entry in `reviewer-v1.0.4`. Without the bump, PRs targeting the new `scutum` docs branch (VyOS 1.6 LTS, cut from `circinus` on 2026-08-13, T9208) hard-fail at the "Resolve docs-branch to vyos-1x branch" step. The `rolling` / `circinus` / `sagitta` bumps are drift avoidance — same rationale as the `reviewer-v1.0.3` bump: keep every docs branch on one reviewer tag so the next bump has no divergence to reconcile.

## :warning: Do not merge yet — sequencing

The tag `reviewer-v1.0.4` **does not exist yet**. It is cut after `VyOS-Networks/vyos-docs-opus-reviewer` PR #26 merges, followed by a full-matrix `rebuild-reference.yml` dispatch that produces the `reference-db-scutum.tar.gz` release asset.

**Do not merge until tag `reviewer-v1.0.4` exists and the latest reference-DB release in the reviewer repo contains `reference-db-scutum.tar.gz` — merging early makes AI Validation fail on checkout of the nonexistent tag.**

This PR stays a draft until both conditions hold.

## Verification note

This PR changes no `docs/**/*.md`, so the `validate` job (gated on `has_md_changes == 'true'`) skips and the bumped pin is not exercised here. Verify after merge on the next docs-touching PR against this branch.

## Phase 0 (local CodeRabbit)

`coderabbit review --committed --base sagitta` — **no findings**.

:robot: Generated by [robots](https://vyos.io)
