### PR TITLE
docs: T9212: document radius source-address6 for IPv6

### DIFF
--- a/docs/configuration/system/login.md
+++ b/docs/configuration/system/login.md
@@ -367,7 +367,7 @@ connect to another configured server or falls back to local authentication.
 
 ```{cfgcmd} set system login radius source-address \<address\>
 
-**Configure the source IP address the router uses for** {abbr}`RADIUS (Remote
+**Configure the source IPv4 address the router uses for** {abbr}`RADIUS (Remote
 Authentication Dial-In User Service)` **authentication requests.**
 
 A consistent source IP address is recommended as RADIUS servers typically
@@ -376,6 +376,23 @@ accept requests only from known, trusted IP addresses.
 If not explicitly defined, the router uses the current egress interface
 address, which may change (e.g., due to a link outage), causing authentication
 failures.
+
+:::{note}
+This command accepts an IPv4 address only. Use `source-address6` for IPv6.
+Configurations created before the two commands were separated are migrated
+automatically.
+:::
+```
+
+```{cfgcmd} set system login radius source-address6 \<address\>
+
+**Configure the source IPv6 address the router uses for** {abbr}`RADIUS (Remote
+Authentication Dial-In User Service)` **authentication requests.**
+
+Each address family has its own command, so an IPv4 and an IPv6 source address
+can be configured at the same time. Requests sent to an IPv4 server are sourced
+from the address set with `source-address`, and requests sent to an IPv6 server
+from the address set with `source-address6`.
 ```
 
 ```{cfgcmd} set system login radius vrf \<name\>
@@ -507,9 +524,10 @@ authentication.
 ## Login banners
 
 VyOS allows you to configure **pre-login** and **post-login** banners.
-Pre-login banners are typically used for system identification, legal disclaimers, or security warnings
-displayed before authentication, while post-login banners provide system
-information or operational notices to users after login.
+Pre-login banners are typically used for system identification, legal
+disclaimers, or security warnings displayed before authentication, while
+post-login banners provide system information or operational notices to users
+after login.
 
 ```{cfgcmd} set system login banner pre-login \<message\>
 
@@ -566,8 +584,8 @@ set system login user vyos authentication otp key OHZ3OJ7U2N25BK4G7SOFFJTZDTCFUU
 set system login user vyos authentication plaintext-password vyos
 ```
 
-Example 2: Containerized {abbr}`TACACS+ (Terminal Access Controller Access Control System)`
-deployment with redundancy.
+Example 2: Containerized {abbr}`TACACS+ (Terminal Access Controller Access
+Control System)` deployment with redundancy.
 
 In this configuration, the VyOS router hosts its own authentication
 infrastructure using two containerized {abbr}`TACACS+ (Terminal Access


### PR DESCRIPTION
## Change Summary

Documents the split of `system login radius source-address` into one command per address family.

`source-address` was a multi-value node, so a second `set` appended rather than replaced and the commit then failed with `Only one IPv4 source-address can be set!`. It is now IPv4-only, with the IPv6 source address moving to a new `source-address6` command. Both replace on set, and a dual-stack deployment can still pin a source address for each family — which is the capability the multi-value node existed to provide.

Changes to `docs/configuration/system/login.md`:

* scope the existing `source-address` description to IPv4, with a note pointing at `source-address6` and confirming that existing configurations are migrated automatically
* add a `{cfgcmd}` block for `set system login radius source-address6 <address>`, explaining that requests to an IPv4 server are sourced from `source-address` and those to an IPv6 server from `source-address6`

### Unrelated hunk, deliberately included

The diff also rewraps two pre-existing over-length lines (in the "Login banners" section and a TACACS+ example caption). `scripts/doc-linter.py` returns a failure for warning-severity findings as well as errors, and `lint-doc.yml` runs it over every changed file — so those two lines would turn the lint job red on any PR touching this page, including this one. Verified: the linter reports them on an unmodified `origin/rolling` copy of the file too. Happy to split them out if you would rather keep the diff pure.

## Related Task(s)

* https://vyos.dev/T9212

## Related PR(s)

* https://github.com/vyos/vyos-1x/pull/5404 — the implementation. **This docs PR should not merge before that one**, since `source-address6` does not exist until it lands.

## Backport

None. The new command only exists in rolling.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document
