### PR TITLE
T9220: ci: upload JUnit test results to Codecov Test Analytics

### DIFF
--- a/.github/workflows/apex-deploy.yml
+++ b/.github/workflows/apex-deploy.yml
@@ -35,7 +35,7 @@ jobs:
         if: >-
           ${{ !cancelled() &&
               (github.event_name != 'pull_request' ||
-               github.event.pull_request.head.repo.fork == false) &&
+               github.event.pull_request.head.repo.full_name == github.repository) &&
               github.actor != 'dependabot[bot]' }}
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         timeout-minutes: 5

--- a/.github/workflows/apex-deploy.yml
+++ b/.github/workflows/apex-deploy.yml
@@ -27,7 +27,27 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: 22 }
-      - run: cd workers && npm ci && npx vitest run
+      - run: >-
+          cd workers && npm ci && npx vitest run
+          --reporter=default --reporter=junit
+          --outputFile=test-results/junit-apex-deploy-test-vitest-s0.xml
+      - name: Upload test results to Codecov
+        if: >-
+          ${{ !cancelled() &&
+              (github.event_name != 'pull_request' ||
+               github.event.pull_request.head.repo.fork == false) &&
+              github.actor != 'dependabot[bot]' }}
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          report_type: test_results
+          files: workers/test-results/junit-apex-deploy-test-vitest-s0.xml
+          disable_search: true
+          fail_ci_if_error: false
+          flags: unit-vitest-s0
+          name: unit-vitest-s0
+          version: v11.3.1
 
   deploy-canary:
     needs: test

--- a/workers/.gitignore
+++ b/workers/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .wrangler/
 dist/
+test-results/


### PR DESCRIPTION
## Summary

Codecov Test Analytics fleet rollout (T9220) — T1 batch. Pattern proven end-to-end on the [vyos.vyos probe](https://github.com/vyos/vyos.vyos/pull/497):

- `vitest` emits JUnit XML (`--outputFile=workers/test-results/…`); **console reporter preserved** via `--reporter=default --reporter=junit` — the `test` job's deploy-gating semantics are unchanged (deliberately minimal diff; this workflow belongs to the baking docs-migration pipeline)
- Pinned `codecov/codecov-action@v5.5.5` (commit SHA) test-results upload: `report_type: test_results`, explicit `files:`, `disable_search: true`, `fail_ci_if_error: false`, `continue-on-error: true`, CLI pinned `v11.3.1`, tokenless (public repo)
- Runs on test failure (`!cancelled()`); fork-PR + Dependabot contexts guarded until those modes are empirically proven

Informational only — no gating.

Advances: IS-658

🤖 Generated by [robots](https://vyos.io)