### PR TITLE
docs: T9145: document WLB health script variables

### DIFF
--- a/docs/configuration/loadbalancing/wan.md
+++ b/docs/configuration/loadbalancing/wan.md
@@ -174,7 +174,9 @@ type         WLB test type
   address or hostname.
 - `test-script`: A user-defined script must return 0 to succeed and
   non-zero to fail. Scripts reside in `/config/scripts`. For other locations,
-  provide the full path.
+  provide the full path. When the script runs, VyOS sets
+  `WLB_INTERFACE_NAME` to the interface under test. The same value is available
+  as `WLB_SCRIPT_IFACE` for backward compatibility.
 - `ttl-limit`: For the UDP TTL limit test, specify the hop count limit.
   The limit must be shorter than the path length. The test succeeds when an
   ICMP time-expired message is returned. Default `1`.


### PR DESCRIPTION
## Change Summary

Document the environment variables available to user-defined WAN load-balancing health-check scripts.

## Related Task(s)

* https://vyos.dev/T9145

## Related PR(s)

* https://github.com/vyos/vyos-1x/pull/5399

## Backport

None.

## Validation

- Targeted `scripts/doc-linter.py` check passed.
- Sphinx HTML build passed.
- `git diff --check` passed.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/current/CONTRIBUTING.md) document
