### PR TITLE
docs: Update Conntrack page to VyOS 1.5 standards

### DIFF
--- a/docs/configuration/system/conntrack.md
+++ b/docs/configuration/system/conntrack.md
@@ -481,7 +481,7 @@ Example:
 set system conntrack log timestamp
 ```
 
-```{cfgcmd} set system conntrack log queue-size \<1-2147483647\>
+```{cfgcmd} set system conntrack log queue-size \<100-2147483647\>
 
 **Configure how many connection tracking events the router holds in
 memory before writing them to the log.**

--- a/docs/configuration/system/conntrack.md
+++ b/docs/configuration/system/conntrack.md
@@ -1,218 +1,514 @@
+---
+myst:
+  html_meta:
+    description: |
+      Connection tracking (conntrack) is a VyOS subsystem that records the
+      state of network connections passing through the router. It
+      activates for IPv4 or IPv6 once a dependent feature such as NAT or a
+      stateful firewall rule is configured. Table sizes, helper modules,
+      custom timeouts, ignore rules, and logging can all be tuned.
+    keywords: conntrack, connection tracking, helper modules, timeout, ignore
+---
+
+(conntrack)=
+
 # Conntrack
 
-VyOS can be configured to track connections using the connection
-tracking subsystem. Connection tracking becomes operational once either
-stateful firewall or NAT is configured.
+VyOS tracks connections with its connection tracking subsystem.
+Connection tracking becomes operational for one or both address families
+once a dependent feature is configured:
 
-## Configure
+- IPv4: NAT, WAN load balancing, or an IPv4 firewall rule that matches
+  connection state or connection status, or enables flow offload.
+- IPv6: NAT66, or an IPv6 firewall rule that matches connection state or
+  connection status, or enables flow offload.
+- Both IPv4 and IPv6: a global firewall `state-policy`.
+
+## Configuration
 
 ```{cfgcmd} set system conntrack table-size \<1-50000000\>
-:defaultvalue:
 
-The connection tracking table contains one entry for each connection being
-tracked by the system.
+**Configure the maximum number of entries in the connection tracking
+table.**
+
+The router creates one entry for each tracked connection.
+
+The default is 262144.
+```
+
+Example:
+
+```none
+set system conntrack table-size 524288
 ```
 
 ```{cfgcmd} set system conntrack expect-table-size \<1-50000000\>
-:defaultvalue:
 
-The connection tracking expect table contains one entry for each expected
-connection related to an existing connection. These are generally used by
-“connection tracking helper” modules such as FTP.
-The default size of the expect table is 2048 entries.
+**Configure the maximum number of entries in the connection tracking
+expect table.**
+
+The expect table holds one entry for each related connection that the
+router expects to see, but that has not started yet. A connection
+tracking helper module adds this entry when its protocol is about to open
+the related connection, such as an FTP data connection.
+
+The default is 2048.
 ```
 
-```{cfgcmd} set system conntrack hash-size \<1-50000000\>
-:defaultvalue:
+Example:
 
-Set the size of the hash table. The connection tracking hash table makes
-searching the connection tracking table faster. The hash table uses
-“buckets” to record entries in the connection tracking table.
+```none
+set system conntrack expect-table-size 4096
 ```
 
-```{eval-rst}
-.. cfgcmd:: set system conntrack modules ftp
-.. cfgcmd:: set system conntrack modules h323
-.. cfgcmd:: set system conntrack modules nfs
-.. cfgcmd:: set system conntrack modules pptp
-.. cfgcmd:: set system conntrack modules sip
-.. cfgcmd:: set system conntrack modules sqlnet
-.. cfgcmd:: set system conntrack modules tftp
+```{cfgcmd} set system conntrack hash-size \<1024-50000000\>
 
-    Configure the connection tracking protocol helper modules.
-    All modules are enabled by default.
+**Configure the size of the hash table that indexes the connection
+tracking table.**
 
-    | Use `delete system conntrack modules` to deactivate all modules.
-    | Or, for example ftp, `delete system conntrack modules ftp`.
+A larger hash table makes looking up entries in the connection tracking
+table faster.
+
+The default is 65536.
 ```
 
-```{cfgcmd} set system conntrack tcp half-open-connections \<1-21474836\>
-:defaultvalue:
+Example:
 
-Set the maximum number of TCP half-open connections.
+```none
+set system conntrack hash-size 131072
+```
+
+```{cfgcmd} set system conntrack modules \<ftp | h323 | nfs | pptp | rtsp | sip | sqlnet | tftp\>
+
+**Enable a connection tracking helper module.**
+
+Some protocols open a second, related connection for their data. The
+data connection uses a port that is not fixed but chosen for each session
+over the control connection. A helper reads the control connection to
+learn the port.
+
+Each helper monitors the control connection on the following ports:
+
+- `ftp`: FTP on TCP port 21.
+- `h323`: H.323 RAS on UDP port 1719 and Q.931 on TCP port 1720.
+- `nfs`: RPC on TCP and UDP port 111.
+- `pptp`: PPTP on TCP port 1723. IPv4 only.
+- `rtsp`: RTSP on TCP port 554. IPv4 only.
+- `sip`: SIP on TCP and UDP ports 5060 and 5061.
+- `sqlnet`: SQLnet (TNS) on TCP ports 1521, 1525, and 1536.
+- `tftp`: TFTP on UDP port 69.
+
+A helper applies only while the router is already tracking connections in the
+helper's address family. See the conditions at the top of this page.
+
+By default, all helper modules are disabled.
+
+Repeat the command to enable multiple modules.
+```
+
+Example:
+
+```none
+set system conntrack modules ftp
+```
+
+```{cfgcmd} set system conntrack tcp half-open-connections \<1-2147483647\>
+
+**Configure the maximum number of half-open TCP connections to the
+router.**
+
+A half-open connection has reached the SYN-RECEIVED state and has not
+received the final acknowledgment from the client. The limit counts only
+connections to the router itself, such as an SSH or management session.
+It does not count connections that the router forwards between other
+hosts.
+
+By default, the limit is 512.
+```
+
+Example:
+
+```none
+set system conntrack tcp half-open-connections 1024
 ```
 
 ```{cfgcmd} set system conntrack tcp loose \<enable | disable\>
-:defaultvalue:
 
-Policy to track previously established connections.
+**Configure whether the router tracks connections that were established
+before tracking started:**
+
+- `enable`: Tracks previously established connections.
+- `disable`: Does not track previously established connections.
+
+The default is `enable`.
 ```
 
-```{cfgcmd} set system conntrack tcp max-retrans \<1-2147483647\>
-:defaultvalue:
+Example:
 
-Set the number of TCP maximum retransmit attempts.
+```none
+set system conntrack tcp loose disable
 ```
 
-### Contrack Timeouts
+```{cfgcmd} set system conntrack tcp max-retrans \<1-255\>
 
-You can define custom timeout values to apply to a specific subset of
-connections, based on a packet and flow selector. To do this, you need to
-create a rule defining the packet and flow selector.
+**Configure the number of packets that the sending end of a TCP
+connection can retransmit without being acknowledged by the receiving
+end.**
 
-```{eval-rst}
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   description <test>
+When a tracked TCP connection passes this count, the router applies a
+shorter timeout than the connection's state would normally use.
 
-    Set a rule description.
+The default is 3.
+```
 
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   destination address <ip-address>
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   source address <ip-address>
+Example:
 
-    Set a destination and/or source address. Accepted input for ipv4:
+```none
+set system conntrack tcp max-retrans 5
+```
 
-    .. code-block:: none
+### Conntrack timeouts
 
-        set system conntrack timeout custom ipv4 rule <1-999999> [source | destination] address
-        Possible completions:
-           <x.x.x.x>            IPv4 address to match
-           <x.x.x.x/x>          IPv4 prefix to match
-           <x.x.x.x>-<x.x.x.x>  IPv4 address range to match
-           !<x.x.x.x>           Match everything except the specified address
-           !<x.x.x.x/x>         Match everything except the specified prefix
-           !<x.x.x.x>-<x.x.x.x> Match everything except the specified range
+Custom timeouts can be applied to a chosen subset of connections by
+creating a numbered rule under `timeout custom`. Each rule defines
+matching criteria, such as inbound interface, protocol, source or
+destination address, and port, to select which connections it applies
+to, along with timeout values. Matching connections use these values
+instead of defaults.
 
-        set system conntrack timeout custom ipv6 rule <1-999999> [source | destination] address
-        Possible completions:
-           <h:h:h:h:h:h:h:h>    IP address to match
-           <h:h:h:h:h:h:h:h/x>  Subnet to match
-           <h:h:h:h:h:h:h:h>-<h:h:h:h:h:h:h:h>
-                                IP range to match
-           !<h:h:h:h:h:h:h:h>   Match everything except the specified address
-           !<h:h:h:h:h:h:h:h/x> Match everything except the specified prefix
-           !<h:h:h:h:h:h:h:h>-<h:h:h:h:h:h:h:h>
-                                Match everything except the specified range
+A packet is checked against every rule. Rules are not mutually exclusive,
+so avoid overlapping match criteria that would set conflicting timeouts
+on the same connection.
 
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   destination port <value>
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   source port <value>
+```{cfgcmd} set system conntrack timeout custom \<ipv4 | ipv6\> rule \<1-999999\> description \<text\>
 
-    Set a destination and/or source port. Accepted input:
+**Configure a description for the rule.**
 
-    .. code-block:: none
+The text can be up to 255 characters.
+```
 
-        <port name>    Named port (any name in /etc/services, e.g., http)
-        <1-65535>      Numbered port
-        <start>-<end>  Numbered port range (e.g., 1001-1005)
-    
-    Multiple destination ports can be specified as a comma-separated list.
-    The whole list can also be "negated" using '!'. For example:
-    `!22,telnet,http,123,1001-1005``
+Example:
 
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   protocol tcp close <1-21474836>
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   protocol tcp close-wait <1-21474836>
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   protocol tcp established <1-21474836>
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   protocol tcp fin-wait <1-21474836>
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   protocol tcp last-ack <1-21474836>
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   protocol tcp syn-recv <1-21474836>
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   protocol tcp syn-sent <1-21474836>
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   protocol tcp time-wait <1-21474836>
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   protocol udp replied <1-21474836>
-.. cfgcmd:: set system conntrack timeout custom [ipv4 | ipv6] rule <1-999999>
-   protocol udp unreplied <1-21474836>
+```none
+set system conntrack timeout custom ipv4 rule 100 description 'Long-lived SSH'
+```
 
-    Set the timeout in seconds for a protocol or state in a custom rule.
+```{cfgcmd} set system conntrack timeout custom \<ipv4 | ipv6\> rule \<1-999999\> \<destination | source\> address \<address\>
+
+**Configure the source or destination address, prefix, or address range
+the rule matches on.**
+
+Accepted values for an IPv4 rule:
+
+- `<x.x.x.x>`: Matches the address.
+- `<x.x.x.x/x>`: Matches the prefix.
+- `<x.x.x.x>-<x.x.x.x>`: Matches the address range.
+- `!<x.x.x.x>`, `!<x.x.x.x/x>`, `!<x.x.x.x>-<x.x.x.x>`: Matches everything
+  except the given address, prefix, or range.
+
+Accepted values for an IPv6 rule:
+
+- `<h:h:h:h:h:h:h:h>`: Matches the address.
+- `<h:h:h:h:h:h:h:h/x>`: Matches the prefix.
+- `<h:h:h:h:h:h:h:h>-<h:h:h:h:h:h:h:h>`: Matches the address range.
+- `!<address>`, `!<prefix>`, `!<range>`: Matches everything except the
+  given address, prefix, or range.
+
+A rule can set both a source and a destination address. It then matches a
+connection only when both the source and the destination match.
+```
+
+Example:
+
+```none
+set system conntrack timeout custom ipv4 rule 100 source address 198.51.100.0/24
+```
+
+```{cfgcmd} set system conntrack timeout custom \<ipv4 | ipv6\> rule \<1-999999\> inbound-interface \<interface\>
+
+**Configure the interface the rule matches on.**
+
+The rule matches packets that enter the router through this interface.
+The value `any` matches every interface.
+```
+
+Example:
+
+```none
+set system conntrack timeout custom ipv4 rule 100 inbound-interface eth0
+```
+
+```{cfgcmd} set system conntrack timeout custom \<ipv4 | ipv6\> rule \<1-999999\> \<destination | source\> port \<port\>
+
+**Configure the destination or source port the rule matches on.**
+
+Accepted values:
+
+- `<port name>`: Matches a named port from `/etc/services`, for example
+  `http`.
+- `<1-65535>`: Matches a port number.
+- `<start>-<end>`: Matches a port range.
+- `<a,b,c>`: Matches a comma-separated list of ports and ranges.
+- `!<list>`: Matches every port except the ones in the given list, for
+  example `!22,telnet,http,123,1001-1005`.
+```
+
+Example:
+
+```none
+set system conntrack timeout custom ipv4 rule 100 destination port 22
+```
+
+```{cfgcmd} set system conntrack timeout custom \<ipv4 | ipv6\> rule \<1-999999\> protocol tcp \<close | close-wait | established | fin-wait | last-ack | syn-recv | syn-sent | time-wait\> \<1-21474836\>
+
+**Configure the timeout, in seconds, that the router applies to a
+matching TCP connection while it is in the given state.**
+
+Each rule must configure timeouts for exactly one protocol, either `tcp`
+or `udp`. Otherwise, the commit fails.
+
+Repeat the command with a different state to set several timeouts in one
+rule.
+```
+
+Example:
+
+```none
+set system conntrack timeout custom ipv4 rule 100 protocol tcp established 3600
+```
+
+```{cfgcmd} set system conntrack timeout custom \<ipv4 | ipv6\> rule \<1-999999\> protocol udp \<replied | unreplied\> \<1-21474836\>
+
+**Configure the timeout, in seconds, that the router applies to a
+matching UDP connection in the given state.**
+
+Each rule must configure timeouts for exactly one protocol, either `tcp`
+or `udp`. Otherwise, the commit fails.
+
+Repeat the command with a different state to set several timeouts in one
+rule.
+```
+
+Example:
+
+```none
+set system conntrack timeout custom ipv6 rule 200 protocol udp replied 30
 ```
 
 ### Conntrack ignore rules
 
-:::{note}
-**Important note about conntrack ignore rules:**
-Starting from vyos-1.5-rolling-202406120020, ignore rules can be defined in
-``set firewall [ipv4 | ipv6] prerouting raw ...``. It's expected that in
-the future the conntrack ignore rules will be removed.
+```{note}
+Beginning with `vyos-1.5-rolling-202406120020`, ignore rules can be
+defined under `set firewall <ipv4 | ipv6> prerouting raw`. The conntrack
+ignore rules are expected to be removed in a future release.
+```
 
-> Customized ignore rules, based on a packet and flow selector.
-:::
+A chosen subset of packets can be exempted from connection tracking by
+creating a numbered rule under `ignore`. Each rule defines matching
+criteria, such as inbound interface, protocol, source or destination
+address, port, and TCP flags, to select which packets it applies to. The
+router does not create a tracking entry for a packet that matches a rule.
 
-```{eval-rst}
-.. cfgcmd:: set system conntrack ignore [ipv4 | ipv6] rule <1-999999>
-   description <text>
-.. cfgcmd:: set system conntrack ignore [ipv4 | ipv6] rule <1-999999>
-   destination address <ip-address>
-.. cfgcmd:: set system conntrack ignore [ipv4 | ipv6] rule <1-999999>
-   destination port <port>
-.. cfgcmd:: set system conntrack ignore [ipv4 | ipv6] rule <1-999999>
-   inbound-interface <interface>
-.. cfgcmd:: set system conntrack ignore [ipv4 | ipv6] rule <1-999999>
-   protocol <protocol>
-.. cfgcmd:: set system conntrack ignore [ipv4 | ipv6] rule <1-999999>
-   source address <ip-address>
-.. cfgcmd:: set system conntrack ignore [ipv4 | ipv6] rule <1-999999>
-   source port <port>
-.. cfgcmd:: set system conntrack ignore [ipv4 | ipv6] rule <1-999999>
-   tcp flags [not] <text>
+```{cfgcmd} set system conntrack ignore \<ipv4 | ipv6\> rule \<1-999999\> description \<text\>
 
-   Allowed values for TCP flags: ``ack``, ``cwr``, ``ecn``, ``fin``, ``psh``,
-   ``rst``, ``syn`` and ``urg``. Multiple values are supported, and for
-   inverted selection use ``not``, as shown in the example.
+**Configure a description for the rule.**
+
+The text can be up to 255 characters.
+```
+
+Example:
+
+```none
+set system conntrack ignore ipv4 rule 10 description 'Do not track BGP'
+```
+
+```{cfgcmd} set system conntrack ignore \<ipv4 | ipv6\> rule \<1-999999\> \<destination | source\> address \<address\>
+
+**Configure the source or destination address, prefix, or address range
+the rule matches on.**
+
+Accepted values for an IPv4 rule:
+
+- `<x.x.x.x>`: Matches the address.
+- `<x.x.x.x/x>`: Matches the prefix.
+- `<x.x.x.x>-<x.x.x.x>`: Matches the address range.
+- `!<x.x.x.x>`, `!<x.x.x.x/x>`, `!<x.x.x.x>-<x.x.x.x>`: Matches everything
+  except the given address, prefix, or range.
+
+Accepted values for an IPv6 rule:
+
+- `<h:h:h:h:h:h:h:h>`: Matches the address.
+- `<h:h:h:h:h:h:h:h/x>`: Matches the prefix.
+- `<h:h:h:h:h:h:h:h>-<h:h:h:h:h:h:h:h>`: Matches the address range.
+- `!<address>`, `!<prefix>`, `!<range>`: Matches everything except the
+  given address, prefix, or range.
+
+A rule can set both a source and a destination address. It then matches a
+packet only when both the source and the destination match.
+```
+
+Example:
+
+```none
+set system conntrack ignore ipv4 rule 10 destination address 192.0.2.10
+```
+
+````{cfgcmd} set system conntrack ignore \<ipv4 | ipv6\> rule \<1-999999\> \<destination | source\> port \<port\>
+
+**Configure the destination or source port the rule matches on.** A rule that
+matches a port must also set `protocol tcp` or `protocol udp`. Otherwise, the
+commit fails.
+
+Accepted values:
+
+- `<port name>`: Matches a named port, for example `http`.
+- `<1-65535>`: Matches a port number.
+- `<start>-<end>`: Matches a port range.
+- `<a,b,c>`: Matches a comma-separated list of ports and ranges.
+- `!<list>`: Matches every port except the ones in the given list, for example
+  `!22,telnet,http,123,1001-1005`.
+
+Example:
+
+```none
+set system conntrack ignore ipv4 rule 10 destination port 179
+```
+````
+
+```{cfgcmd} set system conntrack ignore \<ipv4 | ipv6\> rule \<1-999999\> inbound-interface \<interface\>
+
+**Configure the interface the rule matches on.**
+
+The rule applies to packets that enter the router through this
+interface. The value `any` matches every interface.
+```
+
+Example:
+
+```none
+set system conntrack ignore ipv4 rule 10 inbound-interface eth0
+```
+
+```{cfgcmd} set system conntrack ignore \<ipv4 | ipv6\> rule \<1-999999\> protocol \<protocol\>
+
+**Configure the protocol the rule matches on.**
+
+The protocol can be specified as:
+
+- `<name>`: A protocol name, for example `tcp` or `udp`.
+- `<0-255>`: A protocol number.
+- `all`: Every protocol.
+- `tcp_udp`: TCP and UDP.
+- `!<name>`: Every protocol except the named one.
+```
+
+Example:
+
+```none
+set system conntrack ignore ipv4 rule 10 protocol tcp
+```
+
+```{cfgcmd} set system conntrack ignore \<ipv4 | ipv6\> rule \<1-999999\> tcp flags [not] \<ack | cwr | ecn | fin | psh | rst | syn | urg\>
+
+**Configure the TCP flag the rule matches on.**
+
+The optional `not` keyword inverts the match, so the rule matches only
+when the specified flag is absent. A packet matches the rule only when
+every flag listed without `not` is set and every flag listed with `not`
+is absent.
+
+The rule must also set `protocol tcp`, and cannot list the same flag both
+with and without `not`. Otherwise, the commit fails.
+
+Repeat the command to match on additional flags.
+```
+
+Example:
+
+```none
+set system conntrack ignore ipv4 rule 10 tcp flags syn
 ```
 
 ### Conntrack log
 
-```{eval-rst}
-.. cfgcmd:: set system conntrack log event destroy
-.. cfgcmd:: set system conntrack log event new
-.. cfgcmd:: set system conntrack log event update
+```{cfgcmd} set system conntrack log event \<destroy | new | update\>
 
-    Log the connection tracking events per type.
+**Log connection tracking events of the given type:**
 
-.. cfgcmd:: set system conntrack log event destroy icmp
-.. cfgcmd:: set system conntrack log event destroy other
-.. cfgcmd:: set system conntrack log event destroy tcp
-.. cfgcmd:: set system conntrack log event destroy udp
-.. cfgcmd:: set system conntrack log event new icmp
-.. cfgcmd:: set system conntrack log event new other
-.. cfgcmd:: set system conntrack log event new tcp
-.. cfgcmd:: set system conntrack log event new udp
-.. cfgcmd:: set system conntrack log event update icmp
-.. cfgcmd:: set system conntrack log event update other
-.. cfgcmd:: set system conntrack log event update tcp
-.. cfgcmd:: set system conntrack log event update udp
+- `new`: Logs the creation of an entry.
+- `update`: Logs changes to an entry.
+- `destroy`: Logs the deletion of an entry.
 
-    Log the connection tracking events per protocol.
+Repeat the command to log multiple event types.
 
-.. cfgcmd:: set system conntrack log timestamp
+By default, the router logs events of the configured type for every
+protocol. To log only some protocols, add a protocol to the event type.
+```
 
-    Turn on flow-based timestamp extension.
+Example:
 
-.. cfgcmd:: set system conntrack log queue-size <100-999999>
+```none
+set system conntrack log event new
+```
 
-    Manage internal queue size, default size is 4096 events.
+```{cfgcmd} set system conntrack log event \<destroy | new | update\> \<icmp | other | tcp | udp\>
 
-.. cfgcmd:: set system conntrack log log-level <info | debug>
+**Restrict logging of an event type to the given protocol.**
 
-    Manage log level
+The value `other` covers every protocol except TCP, UDP, and ICMP.
+ICMPv6 is included in `other`.
+
+Repeat the command to log on additional protocols.
+```
+
+Example:
+
+```none
+set system conntrack log event destroy tcp
+```
+
+```{cfgcmd} set system conntrack log timestamp
+
+**Record the start and stop time of every tracked connection.**
+
+The log line for a destroyed connection then reports when the connection
+started, when it stopped, and how long it lasted.
+```
+
+Example:
+
+```none
+set system conntrack log timestamp
+```
+
+```{cfgcmd} set system conntrack log queue-size \<1-2147483647\>
+
+**Configure how many connection tracking events the router holds in
+memory before writing them to the log.**
+
+Raise the value if events are lost under heavy load.
+```
+
+Example:
+
+```none
+set system conntrack log queue-size 65536
+```
+
+```{cfgcmd} set system conntrack log log-level \<info | debug\>
+
+**Configure how much detail the router writes for each connection
+tracking event.**
+
+With `info`, each log line reports the event itself. With `debug`, the
+line also carries the raw event data and is prefixed with its time and
+level.
+
+By default, the level is `info`.
+```
+
+Example:
+
+```none
+set system conntrack log log-level debug
 ```

--- a/docs/configuration/system/conntrack.md
+++ b/docs/configuration/system/conntrack.md
@@ -7,7 +7,7 @@ myst:
       activates for IPv4 or IPv6 once a dependent feature such as NAT or a
       stateful firewall rule is configured. Table sizes, helper modules,
       custom timeouts, ignore rules, and logging can all be tuned.
-    keywords: conntrack, connection tracking, helper modules, timeout, ignore
+    keywords: conntrack, connection tracking, helper modules, timeout
 ---
 
 (conntrack)=

--- a/docs/configuration/system/conntrack.md
+++ b/docs/configuration/system/conntrack.md
@@ -14,8 +14,8 @@ myst:
 
 # Conntrack
 
-Connection tracking becomes operational for one or both address families
-once a dependent feature is configured:
+Connection tracking is activated for one or both address families
+when any of the following features is configured:
 
 - IPv4: NAT, WAN load balancing, or an IPv4 firewall rule that matches
   connection state or connection status, or enables flow offload.

--- a/docs/configuration/system/conntrack.md
+++ b/docs/configuration/system/conntrack.md
@@ -62,8 +62,11 @@ set system conntrack expect-table-size 4096
 
 ```{cfgcmd} set system conntrack hash-size \<1024-50000000\>
 
-**Configure the size of the hash table that indexes the connection
+**Configure the number of buckets in the hash table that indexes the connection
 tracking table.**
+
+This value is not a limit on the number of hash entries and does not have to match
+or exceed `system conntrack table-size`.
 
 A larger hash table makes looking up entries in the connection tracking
 table faster.

--- a/docs/configuration/system/conntrack.md
+++ b/docs/configuration/system/conntrack.md
@@ -14,7 +14,6 @@ myst:
 
 # Conntrack
 
-VyOS tracks connections with its connection tracking subsystem.
 Connection tracking becomes operational for one or both address families
 once a dependent feature is configured:
 


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->
This PR refactors the Conntrack page to comply with the current VyOS documentation style guide.

Changes:

* AI & SEO Context: Added :description: and :keywords: metadata tags.
* Content: Proofread and improved. The intro was restructured to spell out the exact conditions that activate tracking per address family. 
* Technical accuracy: Verified commands against VyOS 1.5.
* Added examples for all commands.
* The style guide checklist was applied.

Added new conf-mode commands:
set system conntrack timeout custom <ipv4 | ipv6> rule <1-999999> inbound-interface <interface>

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
NOS-3211

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document