### PR TITLE
Option "data-ciphers-fallback" must required for s2s

### DIFF
--- a/docs/configuration/interfaces/openvpn-examples.md
+++ b/docs/configuration/interfaces/openvpn-examples.md
@@ -82,6 +82,7 @@ Local configuration:
 ``` none
 Configure the tunnel:
 
+set interfaces openvpn vtun1 encryption data-ciphers-fallback aes256
 set interfaces openvpn vtun1 mode site-to-site
 set interfaces openvpn vtun1 protocol udp
 set interfaces openvpn vtun1 persistent-tunnel
@@ -98,6 +99,7 @@ set interfaces openvpn vtun1 tls role active
 Remote configuration:
 
 ``` none
+set interfaces openvpn vtun1 encryption data-ciphers-fallback aes256
 set interfaces openvpn vtun1 mode site-to-site
 set interfaces openvpn vtun1 protocol udp
 set interfaces openvpn vtun1 persistent-tunnel


### PR DESCRIPTION
<!-- All PRs should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Option data-ciphers-fallback must required to configure the site-to-site openvpn configuration
## Related Task(s)
<!-- optional: Link related Tasks on Phabricator. -->
* https://vyos.dev/Txxxx

## Related PR(s)
<!-- optional: Link here any PRs in other repositories that are related to this PR -->

## Backport
<!-- optional: the PR should backport to this documentation branch -->

Yes, to 1.5

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-documentation/blob/rolling/CONTRIBUTING.md) document