### PR TITLE
ipoe-server: T9289: document DHCP lease-time options

### DIFF
--- a/docs/configuration/service/ipoe-server.md
+++ b/docs/configuration/service/ipoe-server.md
@@ -908,7 +908,9 @@ set service ipoe-server lease-time 3600
 if a client does not renew its DHCP lease in time.**
 
 This value is internal to the server; it is not sent to the client
-and does not limit the lease time the client can request.
+and does not limit the lease time the client can request. The
+effective timer is the larger of this value and `lease-time`, so a
+value smaller than `lease-time` has no effect.
 
 The default is `lease-time` plus 10%.
 ```
@@ -925,7 +927,8 @@ set service ipoe-server max-lease-time 4000
 client attempts to renew its lease with the server that issued it.**
 
 If unset, or greater than `lease-time`, the server derives the value
-from `lease-time`.
+from `lease-time`. If it is also greater than `rebind-time`, the
+server instead recalculates it as `rebind-time` multiplied by 4/7.
 ```
 
 Example:

--- a/docs/configuration/service/ipoe-server.md
+++ b/docs/configuration/service/ipoe-server.md
@@ -888,7 +888,7 @@ set service ipoe-server name-server 2001:db8::53
 
 ### DHCP lease
 
-```{cfgcmd} set service ipoe-server lease-time \<1-4294967295\>
+```{cfgcmd} set service ipoe-server lease-time \<1-2147483647\>
 
 **Configure the DHCP lease time, in seconds, offered to IPoE
 clients.**
@@ -902,7 +902,7 @@ Example:
 set service ipoe-server lease-time 3600
 ```
 
-```{cfgcmd} set service ipoe-server max-lease-time \<1-4294967295\>
+```{cfgcmd} set service ipoe-server max-lease-time \<1-2147483647\>
 
 **Configure the maximum DHCP lease time, in seconds, that can be
 requested by an IPoE client.**
@@ -916,7 +916,7 @@ Example:
 set service ipoe-server max-lease-time 4000
 ```
 
-```{cfgcmd} set service ipoe-server renew-time \<1-4294967295\>
+```{cfgcmd} set service ipoe-server renew-time \<1-2147483647\>
 
 **Configure the DHCP renewal (T1) time, in seconds, after which the
 client attempts to renew its lease with the server that issued it.**
@@ -928,10 +928,11 @@ from `lease-time`.
 Example:
 
 ```none
+set service ipoe-server lease-time 3600
 set service ipoe-server renew-time 1800
 ```
 
-```{cfgcmd} set service ipoe-server rebind-time \<1-4294967295\>
+```{cfgcmd} set service ipoe-server rebind-time \<1-2147483647\>
 
 **Configure the DHCP rebinding (T2) time, in seconds, after which the
 client attempts to rebind its lease with any available server.**
@@ -943,6 +944,7 @@ from `lease-time`.
 Example:
 
 ```none
+set service ipoe-server lease-time 3600
 set service ipoe-server rebind-time 3150
 ```
 

--- a/docs/configuration/service/ipoe-server.md
+++ b/docs/configuration/service/ipoe-server.md
@@ -904,8 +904,11 @@ set service ipoe-server lease-time 3600
 
 ```{cfgcmd} set service ipoe-server max-lease-time \<1-2147483647\>
 
-**Configure the maximum DHCP lease time, in seconds, that can be
-requested by an IPoE client.**
+**Configure the server-side session expiry timer, in seconds, applied
+if a client does not renew its DHCP lease in time.**
+
+This value is internal to the server; it is not sent to the client
+and does not limit the lease time the client can request.
 
 The default is `lease-time` plus 10%.
 ```

--- a/docs/configuration/service/ipoe-server.md
+++ b/docs/configuration/service/ipoe-server.md
@@ -886,6 +886,66 @@ set service ipoe-server name-server 192.0.2.53
 set service ipoe-server name-server 2001:db8::53
 ```
 
+### DHCP lease
+
+```{cfgcmd} set service ipoe-server lease-time \<1-4294967295\>
+
+**Configure the DHCP lease time, in seconds, offered to IPoE
+clients.**
+
+The default is 600.
+```
+
+Example:
+
+```none
+set service ipoe-server lease-time 3600
+```
+
+```{cfgcmd} set service ipoe-server max-lease-time \<1-4294967295\>
+
+**Configure the maximum DHCP lease time, in seconds, that can be
+requested by an IPoE client.**
+
+The default is `lease-time` plus 10%.
+```
+
+Example:
+
+```none
+set service ipoe-server max-lease-time 4000
+```
+
+```{cfgcmd} set service ipoe-server renew-time \<1-4294967295\>
+
+**Configure the DHCP renewal (T1) time, in seconds, after which the
+client attempts to renew its lease with the server that issued it.**
+
+If unset, or greater than `lease-time`, the server derives the value
+from `lease-time`.
+```
+
+Example:
+
+```none
+set service ipoe-server renew-time 1800
+```
+
+```{cfgcmd} set service ipoe-server rebind-time \<1-4294967295\>
+
+**Configure the DHCP rebinding (T2) time, in seconds, after which the
+client attempts to rebind its lease with any available server.**
+
+If unset, or greater than `lease-time`, the server derives the value
+from `lease-time`.
+```
+
+Example:
+
+```none
+set service ipoe-server rebind-time 3150
+```
+
 ### Session and connection limits
 
 ```{cfgcmd} set service ipoe-server idle-timeout \<0-86400\>


### PR DESCRIPTION
## Summary
- Document the new `lease-time`, `max-lease-time`, `renew-time` and `rebind-time` options for `service ipoe-server`, added in vyos/vyos-1x#5459.
- Adds a new "DHCP lease" subsection under Configuration, between "Name servers" and "Session and connection limits".

Related: https://vyos.dev/T9289
Depends on: vyos/vyos-1x#5459

## Test plan
- [ ] `python3 scripts/doc-linter.py docs/configuration/service/ipoe-server.md` reports no issues for the changed file
- [ ] Sphinx build (Read the Docs preview) renders the new section correctly